### PR TITLE
haproxy (enhancement)

### DIFF
--- a/tags.md
+++ b/tags.md
@@ -45,6 +45,7 @@
 - - haproxy
 - - - haproxy_requirements
 - - - haproxy_conf
+- - - haproxy_selinux
 - - confd
 - - - get_confd
 - - - confd_conf

--- a/tags.md
+++ b/tags.md
@@ -57,6 +57,7 @@
 - - keepalived
 - - - keepalived_install
 - - - keepalived_conf
+- - - keepalived_selinux
 - - - keepalived_restart
 - vip_manager
 - - vip_manager_install

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -33,6 +33,19 @@
         state: present
       when: ansible_distribution_major_version == '7'
 
+    - name: haproxy | create a symlink "/usr/sbin/haproxy"
+      file:
+        src: /opt/rh/rh-haproxy18/root/usr/sbin/haproxy
+        dest: /usr/sbin/haproxy
+        owner: root
+        group: root
+        state: link
+      when: ansible_distribution_major_version == '7'
+  environment: '{{ proxy_env | default({}) }}'
+  when: ansible_os_family == "RedHat" and installation_method == "repo" and haproxy_installation_method == "rpm"
+  tags: haproxy
+
+- block:
     # RedHat os family version 8 (and higher)
     - name: haproxy | install HAProxy 1.8 package
       package:

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -1,5 +1,127 @@
 ---
 
+# Install HAProxy from rpm/deb packages
+# from repo
+- block:
+    # RedHat/CentOS/OracleLinux 7 (SCL repo https://www.softwarecollections.org/en/scls/rhscl/rh-haproxy18/)
+    - name: haproxy | install Software Collections (SCL) repository for CentOS 7
+      package:
+        name: centos-release-scl-rh
+        state: present
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7')
+      tags: haproxy_scl_repo
+
+    - name: haproxy | install Software Collections (SCL) repository for OracleLinux 7
+      yum_repository:
+        name: ol7_software_collections
+        description: Software Collection Library packages for Oracle Linux 7 (x86_64)
+        baseurl: https://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/x86_64/
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+        gpgcheck: yes
+        enabled: yes
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7')
+      tags: haproxy_scl_repo
+
+    - name: haproxy | enable Software Collections (SCL) repository for RedHat 7
+      command: 'sudo yum-config-manager --enable rhel-server-rhscl-7-rpms'
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'Red Hat Enterprise Linux' and ansible_distribution_major_version == '7')
+      tags: haproxy_scl_repo
+
+    - name: haproxy | install HAProxy 1.8 (rh-haproxy18 package)
+      package:
+        name: rh-haproxy18
+        state: present
+      when: ansible_distribution_major_version == '7'
+
+    # RedHat os family version 8 (and higher)
+    - name: haproxy | install HAProxy 1.8 package
+      package:
+        name: "haproxy=1.8.*"
+        state: haproxy
+      when: ansible_distribution_major_version is version('8', '>=')
+  environment: '{{ proxy_env | default({}) }}'
+  when: ansible_os_family == "RedHat" and installation_method == "repo" and haproxy_installation_method == "rpm"
+  tags: haproxy
+
+- block:
+    # Debian
+    - name: haproxy | add haproxy.debian.net repository apt-key
+      apt_key:
+        url: https://haproxy.debian.net/bernat.debian.org.gpg
+        state: present
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'Debian' and ansible_distribution_major_version is version('10', '<='))
+
+    - name: haproxy | add haproxy.debian.net repository
+      apt_repository:
+        repo: "deb http://haproxy.debian.net {{ ansible_distribution_release }}-backports-1.8 main"
+        state: present
+        update_cache: yes
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'Debian' and ansible_distribution_major_version is version('10', '<='))
+
+    # Ubuntu
+    - name: haproxy | add ppa:vbernat/haproxy-1.8 repository apt-key
+      apt_key: # https://github.com/ansible/ansible/issues/31691
+      #  keyserver: keyserver.ubuntu.com
+      #  id: CFFB779AADC995E4F350A060505D97A41C61B9CD
+        data: |
+          -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+          xo0EUa70wAEEAMtI29s01PCX0JleVmh1QQr3rfPkfGo/GFKfcXRGE40nQHq+rWUh
+          9slUN+kXBckSE0DDrnQH08Uvf12TJiHHFlbXnH5Ep+hgYPZGlVSpvBGO+c/CopU7
+          RHMx9bl+pVOhrVeDWqLl2KqJI2wjJBLXA0dbRbCzmXPvrg3mBQ0hZ533ABEBAAHN
+          IExhdW5jaHBhZCBQUEEgZm9yIFZpbmNlbnQgQmVybmF0wrgEEwECACIFAlGu9MAC
+          GwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFBdl6QcYbnN8aMD/RM3InMu
+          bxTF9hzToCPF2EP37Q9WUQNF15f90jTOl8VqqpnUfGd2qlxUW31soCpDVxqX6lXf
+          qB0bI9EDz2r7w+goxBH+cRArJ2APdC7wE/U9eIxY49mzNsqjsl7zY+eoX4v4fjqk
+          33hFyMMJDUtPxSRHWFqP5QNwCN+fbPh5GiyL
+          =ZiOf
+          -----END PGP PUBLIC KEY BLOCK-----
+        state: present
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '<='))
+
+    - name: haproxy | add ppa:vbernat/haproxy-1.8 repository
+      apt_repository:
+        repo: "deb http://ppa.launchpad.net/vbernat/haproxy-1.8/ubuntu {{ ansible_distribution_release }} main"
+        state: present
+        update_cache: yes
+      when: haproxy_install_repo == "true" and (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '<='))
+
+    - name: haproxy | install HAProxy 1.8 package
+      apt:
+        force_apt_get: yes
+        name: "haproxy=1.8.*"
+        state: present
+  environment: '{{ proxy_env | default({}) }}'
+  when: ansible_os_family == "Debian" and installation_method == "repo" and haproxy_installation_method == "deb"
+  tags: haproxy
+
+# from file (rpm/deb packages)
+- block:
+    - name: haproxy | copy packages into /tmp
+      copy:
+        src: '{{ item }}'
+        dest: /tmp/
+      loop: "{{ haproxy_package_file }}"
+      register: copy_packages_result
+
+    - name: haproxy | install packages
+      apt:
+        force_apt_get: yes
+        deb: '/tmp/{{ item }}'
+        state: present
+      loop: "{{ haproxy_package_file | map('basename') | list }}"
+      when: ansible_os_family == "Debian" and copy_packages_result.changed
+
+    - name: haproxy | install packages
+      package:
+        name: '/tmp/{{ item }}'
+        state: present
+      loop: "{{ haproxy_package_file | map('basename') | list }}"
+      when: ansible_os_family == "RedHat" and copy_packages_result.changed
+  when: haproxy_package_file is defined and haproxy_package_file | length > 0
+  tags: haproxy
+
+# Build and install HAproxy from source
 # from repo
 - block:
     - name: "haproxy | download HAProxy and lua source files"
@@ -27,7 +149,7 @@
         remote_src: yes
       when: lua_src_repo | length > 0
       tags: lua
-  when: installation_method == "repo"
+  when: installation_method == "repo" and haproxy_installation_method == "src"
   tags: haproxy
 
 # from file
@@ -44,7 +166,7 @@
         dest: /tmp/
       when: lua_src_file | length > 0
       tags: lua
-  when: installation_method == "file"
+  when: installation_method == "file" and haproxy_installation_method == "src"
   tags: haproxy
 
 - name: haproxy | install the prerequisites packages to compile HAProxy
@@ -52,35 +174,9 @@
     name: "{{ haproxy_compile_requirements }}"
     state: present
   environment: '{{ proxy_env | default({}) }}'
+  when: haproxy_installation_method == "src"
   tags: [ haproxy, haproxy_requirements ]
 
-- name: haproxy | add haproxy group
-  group:
-    name: haproxy
-    state: present
-  tags: haproxy
-
-- name: haproxy | add haproxy user
-  user:
-    name: haproxy
-    comment: "HAProxy user"
-    group: haproxy
-    shell: /usr/sbin/nologin
-  tags: haproxy
-
-- name: haproxy | create directories
-  file:
-    dest: "{{ item }}"
-    state: directory
-    owner: haproxy
-    group: haproxy
-  loop:
-    - /etc/haproxy
-    - /var/run/haproxy
-    - /var/lib/haproxy/dev
-  tags: haproxy
-
-# Build and install HAproxy from source
 - block:
     - name: haproxy | build and install lua (required for haproxy)
       become: yes
@@ -116,7 +212,7 @@
       make:
         chdir: "/tmp/{{ haproxy_src_repo.split('.tar.gz')[0] | basename }}"
         target: install
-  when: installation_method == "repo"
+  when: installation_method == "repo" and haproxy_installation_method == "src"
   tags: haproxy
 
 # installation_method: "file"
@@ -155,10 +251,37 @@
       make:
         chdir: "/tmp/{{ haproxy_src_file.split('.tar.gz')[0] | basename }}"
         target: install
-  when: installation_method == "file"
+  when: installation_method == "file" and haproxy_installation_method == "src"
   tags: haproxy
 
-- name: haproxy | create systemd service file
+# Configure
+- name: haproxy | add haproxy group
+  group:
+    name: haproxy
+    state: present
+  tags: haproxy
+
+- name: haproxy | add haproxy user
+  user:
+    name: haproxy
+    comment: "HAProxy user"
+    group: haproxy
+    shell: /usr/sbin/nologin
+  tags: haproxy
+
+- name: haproxy | create directories
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: haproxy
+    group: haproxy
+  loop:
+    - /etc/haproxy
+    - /var/run/haproxy
+    - /var/lib/haproxy/dev
+  tags: haproxy
+
+- name: haproxy | generate systemd service file "/etc/systemd/system/haproxy.service"
   template:
     src: templates/haproxy.service.j2
     dest: /etc/systemd/system/haproxy.service
@@ -173,7 +296,7 @@
   register: haproxy_conf_result
   tags: [ haproxy, haproxy_conf ]
 
-- name: haproxy | restart systemd service
+- name: haproxy | restart haproxy.service
   systemd:
     daemon_reload: yes
     name: haproxy

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -302,6 +302,15 @@
   register: haproxy_conf_result
   tags: [ haproxy, haproxy_conf ]
 
+- name: haproxy | selinux | set haproxy_connect_any flag to enable tcp connections
+  seboolean:
+    name: haproxy_connect_any
+    state: yes
+    persistent: yes
+  when: ansible_os_family == "RedHat"
+  ignore_errors: yes
+  tags: [ haproxy, haproxy_selinux ]
+
 - name: haproxy | restart haproxy.service
   systemd:
     daemon_reload: yes

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -320,7 +320,7 @@
     name: haproxy_connect_any
     state: yes
     persistent: yes
-  when: ansible_os_family == "RedHat"
+  when: ansible_selinux.status is defined and ansible_selinux.status == 'enabled'
   ignore_errors: yes
   tags: [ haproxy, haproxy_selinux ]
 

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -122,6 +122,12 @@
   tags: haproxy
 
 # Build and install HAproxy from source
+- name: haproxy | setting facts
+  set_fact:
+    target_linux: "{% if haproxy_major is version('2.0', '>=') %}linux-glibc{% else %}linux2628{% endif %}"
+  when: haproxy_installation_method == "src"
+  tags: haproxy
+
 # from repo
 - block:
     - name: "haproxy | download HAProxy and lua source files"
@@ -192,7 +198,7 @@
       make:
         chdir: "/tmp/{{ haproxy_src_repo.split('.tar.gz')[0] | basename }}"
         params:
-          TARGET: linux2628
+          TARGET: "{{ target_linux }}"
           USE_GETADDRINFO: 1
           USE_ZLIB: 1
           USE_REGPARM: 1
@@ -231,7 +237,7 @@
       make:
         chdir: "/tmp/{{ haproxy_src_file.split('.tar.gz')[0] | basename }}"
         params:
-          TARGET: linux2628
+          TARGET: "{{ target_linux }}"
           USE_GETADDRINFO: 1
           USE_ZLIB: 1
           USE_REGPARM: 1

--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -24,6 +24,14 @@
     dest: /etc/keepalived/keepalived.conf
   tags: [ keepalived_conf, keepalived ]
 
+- name: keepalived | selinux | change the keepalived_t domain to permissive
+  selinux_permissive:
+    name: keepalived_t
+    permissive: true
+  when: ansible_os_family == "RedHat"
+  ignore_errors: yes
+  tags: [ keepalived, keepalived_selinux ]
+
 - name: keepalived | restart systemd service
   systemd:
     daemon_reload: yes

--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -28,7 +28,7 @@
   selinux_permissive:
     name: keepalived_t
     permissive: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_selinux.status is defined and ansible_selinux.status == 'enabled'
   ignore_errors: yes
   tags: [ keepalived, keepalived_selinux ]
 

--- a/templates/haproxy.service.j2
+++ b/templates/haproxy.service.j2
@@ -9,10 +9,6 @@ ExecStartPre=/bin/mkdir -p /var/run/haproxy
 ExecStartPre=/usr/local/sbin/haproxy -f $CONFIG -c -q
 ExecStart=/usr/local/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
 ExecReload=/usr/local/sbin/haproxy -f $CONFIG -c -q
-{% elif haproxy_installation_method == "rpm" and (ansible_os_family == "RedHat" and ansible_distribution_major_version == '7') %}
-ExecStartPre=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -f $CONFIG -c -q
-ExecStart=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
-ExecReload=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -f $CONFIG -c -q
 {% else %}
 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE

--- a/templates/haproxy.service.j2
+++ b/templates/haproxy.service.j2
@@ -5,9 +5,19 @@ After=network.target
 [Service]
 Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/var/run/haproxy/haproxy.pid"
 ExecStartPre=/bin/mkdir -p /var/run/haproxy
+{% if haproxy_installation_method == "src" %}
 ExecStartPre=/usr/local/sbin/haproxy -f $CONFIG -c -q
 ExecStart=/usr/local/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
 ExecReload=/usr/local/sbin/haproxy -f $CONFIG -c -q
+{% elif haproxy_installation_method == "rpm" and (ansible_os_family == "RedHat" and ansible_distribution_major_version == '7') %}
+ExecStartPre=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -f $CONFIG -c -q
+ExecStart=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
+ExecReload=/opt/rh/rh-haproxy18/root/usr/sbin/haproxy -f $CONFIG -c -q
+{% else %}
+ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q
+ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE
+ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q
+{% endif %}
 ExecReload=/bin/kill -USR2 $MAINPID
 KillMode=mixed
 Restart=always

--- a/templates/haproxy.toml.j2
+++ b/templates/haproxy.toml.j2
@@ -2,10 +2,13 @@
 prefix = "/service/{{ patroni_cluster_name }}"
 src = "haproxy.tmpl"
 dest = "/etc/haproxy/haproxy.cfg"
- 
+{% if haproxy_installation_method == "src" %}
 check_cmd = "/usr/local/sbin/haproxy -c -f {% raw %}{{ .src }}{% endraw %}"
+{% else %}
+check_cmd = "/usr/sbin/haproxy -c -f {% raw %}{{ .src }}{% endraw %}"
+{% endif %}
 reload_cmd = "/bin/systemctl reload haproxy"
- 
+
 keys = [
     "/members/",
 ]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -37,8 +37,6 @@ system_packages:
   - sudo
   - vim
   - gcc
-  - unzip
-  - gzip
   - jq
   - iptables
   - acl
@@ -62,11 +60,15 @@ haproxy_install_repo: 'true' # or 'false'
 confd_package_repo: "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64"
 
 ## (optional) if haproxy_installation_method: 'src'
+haproxy_major: "1.8"
+haproxy_version: "1.8.22"  # version to build from source
 lua_src_repo: "https://www.lua.org/ftp/lua-5.3.5.tar.gz" # required for build haproxy
-haproxy_src_repo: "http://www.haproxy.org/download/1.8/src/haproxy-1.8.21.tar.gz"
+haproxy_src_repo: "http://www.haproxy.org/download/{{ haproxy_major }}/src/haproxy-{{ haproxy_version }}.tar.gz"
 haproxy_compile_requirements:
   - unzip
   - gzip
+  - make
+  - gcc
   - build-essential
   - libc6-dev
   - libpcre3-dev

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -54,9 +54,16 @@ postgresql_packages:
 etcd_package_repo: "https://github.com/etcd-io/etcd/releases/download/{{ etcd_ver }}/etcd-{{ etcd_ver }}-linux-amd64.tar.gz"
 vip_manager_package_repo: "https://github.com/cybertec-postgresql/vip-manager/releases/download/v{{ vip_manager_version }}/vip-manager_{{ vip_manager_version }}-1_amd64.deb"
 ## (if with_haproxy_load_balancing: 'true')
+haproxy_installation_method: "deb" #(default)"deb" or "src"
+haproxy_install_repo: 'true' # or 'false'
+## for Debian 8/9/10 the haproxy version 1.8 (LTS) will be installed from the haproxy.debian.net repository.
+## for Ubuntu <=18.04 the haproxy version 1.8 (LTS) will be installed from the ppa:vbernat/haproxy-1.8 repository.
+## you can preload the haproxy deb packages to your APT repository (in this case specify "haproxy_install_repo: 'false'").
 confd_package_repo: "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64"
+
+## (optional) if haproxy_installation_method: 'src'
 lua_src_repo: "https://www.lua.org/ftp/lua-5.3.5.tar.gz" # required for build haproxy
-haproxy_src_repo: "http://www.haproxy.org/download/{{ haproxy_major }}/src/haproxy-{{ haproxy_version }}.tar.gz"
+haproxy_src_repo: "http://www.haproxy.org/download/1.8/src/haproxy-1.8.21.tar.gz"
 haproxy_compile_requirements:
   - unzip
   - gzip
@@ -115,7 +122,6 @@ patroni_deb_package_repo: []
 # (optional) if installation_method: "file"
 # You can also download the necessary packages into postgresql_cluster/files/ directory.
 # Packages from this directory will be used for installation.
-
 pip_package_file: "pip-19.2.3.tar.gz" # https://pypi.org/project/pip/#files
 patroni_pip_requirements_file:
   - "setuptools-41.2.0.zip"        # https://pypi.org/project/setuptools/#files
@@ -149,9 +155,12 @@ patroni_deb_package_file: "patroni_1.6.0-2.pgdg90+1_all.deb" # (package for Debi
 etcd_package_file: "etcd-v3.3.15-linux-amd64.tar.gz" # https://github.com/etcd-io/etcd/releases
 vip_manager_package_file: "vip-manager_0.6-1_amd64.deb" # https://github.com/cybertec-postgresql/vip-manager/releases
 ## (if with_haproxy_load_balancing: 'true')
-haproxy_src_file: "haproxy-1.8.20.tar.gz" # http://www.haproxy.org/download/1.8/src/
-lua_src_file: "lua-5.3.5.tar.gz" # https://www.lua.org/ftp/lua-5.3.5.tar.gz (required for build haproxy)
+haproxy_package_file: []
+#  - "haproxy_1.8.21-1~bpo9+1_amd64.deb"
 confd_package_file: "confd-0.16.0-linux-amd64" # https://github.com/kelseyhightower/confd/releases
+# (optional) if haproxy_installation_method: 'src'
+lua_src_file: "lua-5.3.5.tar.gz" # https://www.lua.org/ftp/lua-5.3.5.tar.gz (required for build haproxy)
+haproxy_src_file: "haproxy-1.8.20.tar.gz" # http://www.haproxy.org/download/1.8/src/
 
 # ------------------------------------------------------------------------------------------------- #
 # (optional) Specify additional deb packages if required (for any installation_method)
@@ -161,3 +170,7 @@ packages_from_file: []
 #  - "my-package-name_2_amd64.deb"
 #  - ""
 
+# ----------------------------------------------------------------------------------------------------------------------------------
+# Attention! If you want to use the installation method "file".
+# You need to independently determine all the necessary the dependencies of deb packages for your version of the Linux distribution.
+# ----------------------------------------------------------------------------------------------------------------------------------

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -55,10 +55,16 @@ postgresql_packages:
 # Extra packages
 etcd_package_repo: "https://github.com/etcd-io/etcd/releases/download/{{ etcd_ver }}/etcd-{{ etcd_ver }}-linux-amd64.tar.gz"
 vip_manager_package_repo: "https://github.com/cybertec-postgresql/vip-manager/releases/download/v{{ vip_manager_version }}/vip-manager_{{ vip_manager_version }}-1_amd64.rpm"
-## (if with_haproxy_load_balancing: 'true')
+# (if with_haproxy_load_balancing: 'true')
+haproxy_installation_method: "rpm" #(default)"rpm" or "src"
+haproxy_install_repo: 'true' # or 'false' # only for RedHat/CentOS version 7.
+## for RedHat/CentOS/OracleLinux 7 the haproxy version 1.8 (LTS) will be installed from the "rh-haproxy18" package from the Software Collections (SCL) repository.
+## you can preload the haproxy rpm packages to your YUM repository (in this case specify "haproxy_install_repo: 'false'").
 confd_package_repo: "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64"
+
+# (optional) if haproxy_installation_method: 'src'
 lua_src_repo: "https://www.lua.org/ftp/lua-5.3.5.tar.gz" # required for build haproxy
-haproxy_src_repo: "http://www.haproxy.org/download/{{ haproxy_major }}/src/haproxy-{{ haproxy_version }}.tar.gz"
+haproxy_src_repo: "http://www.haproxy.org/download/1.8/src/haproxy-1.8.21.tar.gz"
 haproxy_compile_requirements:
   - unzip
   - gzip
@@ -149,9 +155,13 @@ patroni_rpm_package_file: "patroni-1.6.0-1.rhel7.x86_64.rpm" # (package for RHEL
 etcd_package_file: "etcd-v3.3.15-linux-amd64.tar.gz" # https://github.com/etcd-io/etcd/releases
 vip_manager_package_file: "vip-manager_0.6-1_amd64.rpm" # https://github.com/cybertec-postgresql/vip-manager/releases
 ## (if with_haproxy_load_balancing: 'true')
-haproxy_src_file: "haproxy-1.8.21.tar.gz" # http://www.haproxy.org/download/1.8/src/
-lua_src_file: "lua-5.3.5.tar.gz" # https://www.lua.org/ftp/lua-5.3.5.tar.gz (required for build haproxy)
+haproxy_package_file: []
+#  - "rh-haproxy18-runtime-3.1-2.el7.x86_64.rpm"
+#  - "rh-haproxy18-haproxy-1.8.17-1.el7.x86_64.rpm"
 confd_package_file: "confd-0.16.0-linux-amd64" # https://github.com/kelseyhightower/confd/releases
+# (optional) if haproxy_installation_method: 'src'
+lua_src_file: "lua-5.3.5.tar.gz" # https://www.lua.org/ftp/lua-5.3.5.tar.gz (required for build haproxy)
+haproxy_src_file: "haproxy-1.8.21.tar.gz" # http://www.haproxy.org/download/1.8/src/
 
 # ------------------------------------------------------------------------------------------------- #
 # (optional) Specify additional rpm packages if required (for any installation_method)
@@ -163,3 +173,7 @@ packages_from_file: []
 #  - "other-package-name_1_amd64.rpm"
 #  - ""
 
+# ----------------------------------------------------------------------------------------------------------------------------------
+# Attention! If you want to use the installation method "file".
+# You need to independently determine all the necessary the dependencies of rpm packages for your version of the Linux distribution.
+# ----------------------------------------------------------------------------------------------------------------------------------

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -29,6 +29,8 @@ system_packages:
   - python-devel
   - python-psycopg2
   - python-setuptools
+  - libselinux-python
+  - libsemanage-python
   - python36
   - python36-devel
   - python36-psycopg2

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -31,6 +31,7 @@ system_packages:
   - python-setuptools
   - libselinux-python
   - libsemanage-python
+  - policycoreutils-python
   - python36
   - python36-devel
   - python36-psycopg2

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -39,8 +39,6 @@ system_packages:
   - sudo
   - vim
   - gcc
-  - unzip
-  - gzip
   - jq
   - iptables
   - acl
@@ -63,12 +61,16 @@ haproxy_install_repo: 'true' # or 'false' # only for RedHat/CentOS version 7.
 confd_package_repo: "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64"
 
 # (optional) if haproxy_installation_method: 'src'
+haproxy_major: "1.8"
+haproxy_version: "1.8.22"  # version to build from source
 lua_src_repo: "https://www.lua.org/ftp/lua-5.3.5.tar.gz" # required for build haproxy
-haproxy_src_repo: "http://www.haproxy.org/download/1.8/src/haproxy-1.8.21.tar.gz"
+haproxy_src_repo: "http://www.haproxy.org/download/{{ haproxy_major }}/src/haproxy-{{ haproxy_version }}.tar.gz"
 haproxy_compile_requirements:
   - unzip
   - gzip
-  - "@Development tools"
+  - make
+  - gcc
+  - gcc-c++
   - pcre-devel
   - zlib-devel
   - readline-devel

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,8 +23,7 @@ patroni_install_version: "latest"  # or specific version (example 1.5.6)
 
 # Load Balancing
 with_haproxy_load_balancing: 'false' # or 'true' if you want to install and configure the load-balancing (based on haproxy+confd+keepalived)
-haproxy_major: "1.8"  # if variable "with_haproxy_load_balancing=true"
-haproxy_version: "1.8.20"  # version to build from source
+## if variable "with_haproxy_load_balancing: 'true'"
 keepalived_virtual_router_id: "133"  # specify a unique virtual_router_id
 
 # vip-manager  (if with_haproxy_load_balancing: 'false')


### PR DESCRIPTION
* Install rpm/deb HAProxy 1.8 packages by default, instead of building from source #14

* Support for build and install HAProxy version 2.0 from source https://github.com/vitabaks/postgresql_cluster/pull/15/commits/b690e46549ac67c0ef84072f79a1618871462ea6 

* Configure SELinux for haproxy https://github.com/vitabaks/postgresql_cluster/pull/15/commits/2b252c69d4f377e2b1c389b33576fca5f59220cb and keepalived  https://github.com/vitabaks/postgresql_cluster/pull/15/commits/daa6f70037d54f1edd05663f71ba13044ed13a22 