### PR TITLE
Disable vip-manager if run keepalived

### DIFF
--- a/balancers.yml
+++ b/balancers.yml
@@ -10,6 +10,8 @@
     - vars/main.yml
     - vars/system.yml
     - "vars/{{ ansible_os_family }}.yml"
+  vars:
+    vip_manager_disable: false  # or 'true' for disable vip-manager service (if installed)
 
   pre_tasks:
     - name: Checking Linux distribution
@@ -69,6 +71,7 @@
       when: dcs_type == "etcd"
 
     - role: vip-manager-disable
+      when: vip_manager_disable|bool
 
     - role: keepalived
       when: cluster_vip is defined and cluster_vip | length > 0

--- a/balancers.yml
+++ b/balancers.yml
@@ -68,6 +68,8 @@
     - role: confd
       when: dcs_type == "etcd"
 
+    - role: vip-manager-disable
+
     - role: keepalived
       when: cluster_vip is defined and cluster_vip | length > 0
 

--- a/roles/vip-manager-disable/tasks/main.yml
+++ b/roles/vip-manager-disable/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Disabe vip-manager service
+  systemd:
+    daemon_reload: true
+    name: vip-manager
+    state: stopped
+    enabled: false

--- a/roles/vip-manager/templates/vip-manager.service.j2
+++ b/roles/vip-manager/templates/vip-manager.service.j2
@@ -7,6 +7,9 @@ Type=simple
 
 ExecStart=/usr/bin/vip-manager -config={{ vip_manager_conf }}
 
+# VIP not released when service stopped https://github.com/cybertec-postgresql/vip-manager/issues/19
+ExecStopPost=/sbin/ip addr del {{ vip_manager_ip }}/{{ vip_manager_mask }} dev {{ vip_manager_iface }}
+
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
If I switch Type B to Type A, I must turn off the vip-manager.
Also, when you stop the vip-manager, it seems like it would be nice to remove the VIP from the interface. Or make it optional?
(Если есть вопросы, лучше по русски ) )