### PR TITLE
Restrict standard local port range

### DIFF
--- a/vars/system.yml
+++ b/vars/system.yml
@@ -51,7 +51,7 @@ sysctl_conf:
     - {name: "kernel.sched_autogroup_enabled", value: "0"}
     - {name: "net.ipv4.ip_nonlocal_bind", value: "1"}
     - {name: "net.ipv4.ip_forward", value: "1"}
-    - {name: "net.ipv4.ip_local_port_range", value: "1024 65535"}
+    - {name: "net.ipv4.ip_local_port_range", value: "10000 65535"}
     - {name: "net.netfilter.nf_conntrack_max", value: "1048576"}
     - {name: "net.core.netdev_max_backlog", value: "10000"}
     - {name: "net.ipv4.tcp_max_syn_backlog", value: "8192"}
@@ -60,7 +60,7 @@ sysctl_conf:
   balancers:
     - {name: "net.ipv4.ip_nonlocal_bind", value: "1"}
     - {name: "net.ipv4.ip_forward", value: "1"}
-    - {name: "net.ipv4.ip_local_port_range", value: "1024 65535"}
+    - {name: "net.ipv4.ip_local_port_range", value: "10000 65535"}
     - {name: "net.netfilter.nf_conntrack_max", value: "1048576"}
     - {name: "net.core.netdev_max_backlog", value: "10000"}
     - {name: "net.ipv4.tcp_max_syn_backlog", value: "8192"}


### PR DESCRIPTION
Using a local port range of 1024-65535 is risky because etcd listens on port 2379 and 2380, pgbouncer on port 6432, PostgreSQL on port 5432 and Patroni on 8008. This can lead to collision.

In my case, etcd established a connection to another cluster member on port 8008, which meant that Patroni wasn't able to start because port 8008 was already in use.

10000 stays clear of all predefined ports.