### PR TITLE
Make Patroni REST API port configurable

### DIFF
--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -38,12 +38,12 @@ listen master
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 
@@ -61,12 +61,12 @@ listen replicas
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 
@@ -84,12 +84,12 @@ listen replicas_sync
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
  
@@ -107,12 +107,12 @@ listen replicas_async
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
   {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port 8008
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
 

--- a/roles/patroni/tasks/custom_wal_dir.yml
+++ b/roles/patroni/tasks/custom_wal_dir.yml
@@ -61,9 +61,9 @@
         name: patroni
         state: started
 
-    - name: Wait for port 8008 to become open on the host
+    - name: Wait for port {{ patroni_restapi_port }} to become open on the host
       wait_for:
-        port: 8008
+        port: {{ patroni_restapi_port }}
         host: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}"
         state: started
         timeout: 120
@@ -72,7 +72,7 @@
 
     - name: Check that the patroni is healthy
       uri:
-        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008/health"
+        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/health"
         status_code: 200
       register: replica_result
       until: replica_result.status == 200

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -276,10 +276,10 @@
         backrefs: true
       loop:
         - {regexp: '^name:', line: 'name: {{ ansible_hostname }}'}
-        - {regexp: '^  listen: .*:8008$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }}:8008'}
-        - {regexp: '^  connect_address: .*:8008$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:8008'}
-        - {regexp: '^  listen: ((?!8008).)*$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }},127.0.0.1:{{ postgresql_port }}'}
-        - {regexp: '^  connect_address: ((?!8008).)*$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ postgresql_port }}'}
+        - {regexp: '^  listen: .*:{{ patroni_restapi_port }}$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ patroni_restapi_port }}'}
+        - {regexp: '^  connect_address: .*:{{ patroni_restapi_port }}$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ patroni_restapi_port }}'}
+        - {regexp: '^  listen: ((?!{{ patroni_restapi_port }}).)*$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }},127.0.0.1:{{ postgresql_port }}'}
+        - {regexp: '^  connect_address: ((?!{{ patroni_restapi_port }}).)*$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ postgresql_port }}'}
       loop_control:
         label: "{{ item.line }}"
       when: with_haproxy_load_balancing|bool or pgbouncer_install|bool or (cluster_vip is not defined or cluster_vip | length < 1)
@@ -292,10 +292,10 @@
         backrefs: true
       loop:
         - {regexp: '^name:', line: 'name: {{ ansible_hostname }}'}
-        - {regexp: '^  listen: .*:8008$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }}:8008'}
-        - {regexp: '^  connect_address: .*:8008$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:8008'}
-        - {regexp: '^  listen: ((?!8008).)*$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }},{{ cluster_vip }},127.0.0.1:{{ postgresql_port }}'}  # noqa 204
-        - {regexp: '^  connect_address: ((?!8008).)*$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ postgresql_port }}'}
+        - {regexp: '^  listen: .*:{{ patroni_restapi_port }}$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ patroni_restapi_port }}'}
+        - {regexp: '^  connect_address: .*:{{ patroni_restapi_port }}$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ patroni_restapi_port }}'}
+        - {regexp: '^  listen: ((?!{{ patroni_restapi_port }}).)*$', line: '  listen: {{ hostvars[inventory_hostname].inventory_hostname }},{{ cluster_vip }},127.0.0.1:{{ postgresql_port }}'}  # noqa 204
+        - {regexp: '^  connect_address: ((?!{{ patroni_restapi_port }}).)*$', line: '  connect_address: {{ hostvars[inventory_hostname].inventory_hostname }}:{{ postgresql_port }}'}
       loop_control:
         label: "{{ item.line }}"
       when: not with_haproxy_load_balancing|bool and not pgbouncer_install|bool and (cluster_vip is defined and cluster_vip | length > 0)
@@ -752,9 +752,9 @@
         state: restarted
         enabled: true
 
-    - name: Wait for port 8008 to become open on the host
+    - name: Wait for port {{ patroni_restapi_port }} to become open on the host
       wait_for:
-        port: 8008
+        port: {{ patroni_restapi_port }}
         host: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}"
         state: started
         timeout: 120
@@ -773,7 +773,7 @@
 
     - name: Wait for the cluster to initialize (master is the leader with the lock)
       uri:
-        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008/leader"
+        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/leader"
         status_code: 200
       register: result
       until: result.status == 200
@@ -890,9 +890,9 @@
         state: restarted
         enabled: true
 
-    - name: Wait for port 8008 to become open on the host
+    - name: Wait for port {{ patroni_restapi_port }} to become open on the host
       wait_for:
-        port: 8008
+        port: {{ patroni_restapi_port }}
         host: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}"
         state: started
         timeout: 120
@@ -901,7 +901,7 @@
 
     - name: Check that the patroni is healthy on the replica server
       uri:
-        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008/health"
+        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/health"
         status_code: 200
       register: replica_result
       until: replica_result.status == 200

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -6,8 +6,8 @@ name: {{ ansible_hostname }}
 namespace: /service/
 
 restapi:
-  listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008
-  connect_address: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008
+  listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}
+  connect_address: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}
 #  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
 #  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
 #  authentication:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,7 +15,7 @@ vip_interface: "{{ ansible_default_ipv4.interface }}"  # interface name (ex. "en
 
 patroni_cluster_name: "postgres-cluster"  # specify the cluster name
 patroni_install_version: "latest"  # or specific version (example 1.5.6)
-
+patroni_restapi_port: "8008"  # specify a port for the Patroni REST API
 patroni_superuser_username: "postgres"
 patroni_superuser_password: "postgres-pass"  # please change password
 patroni_replication_username: "replicator"

--- a/vars/system.yml
+++ b/vars/system.yml
@@ -124,7 +124,7 @@ firewall_allowed_tcp_ports_for:
     - "{{ ansible_ssh_port | default(22) }}"
     - "{{ postgresql_port }}"
     - "{{ pgbouncer_listen_port }}"
-    - "8008"  # Patroni REST API port
+    - "{{ patroni_restapi_port }}"
 #    - "10050"  # Zabbix agent
 #    - ""
   etcd_cluster:


### PR DESCRIPTION
In our setup, we would like to be able to configure the port that the Patroni API is listening on.

I did a find/replace on the codebase and replaced it with a new custom variable, ` patroni_restapi_port`, which is defined in `vars/main.yml`

Thanks again for this awesome role, I really like it!