### PR TITLE
Pgbackrest srv

### DIFF
--- a/roles/patroni/templates/pg_hba.conf.j2
+++ b/roles/patroni/templates/pg_hba.conf.j2
@@ -96,3 +96,9 @@
 {% for host in groups['postgres_cluster'] %}
   host      replication              {{ patroni_replication_username }}               {{ hostvars[host]['inventory_hostname'] }}/32         {{ postgresql_password_encryption_algorithm }}
 {% endfor %}
+# For pgBackRest from external server
+{% if pgbackrest_srv_install -%}
+{% for pgbackrestsrv in groups['pgbackrest'] %}
+  host      all              postgres               {{ hostvars[pgbackrestsrv]['inventory_hostname'] }}/32                md5
+{% endfor %}
+{% endif %}

--- a/roles/pgbackrest_srv/tasks/main.yml
+++ b/roles/pgbackrest_srv/tasks/main.yml
@@ -1,0 +1,115 @@
+---
+# yamllint disable rule:line-length
+
+- block:  # Debian pgdg repo
+    - name: Make sure the gnupg and apt-transport-https packages are present
+      apt:
+        pkg:
+          - gnupg
+          - apt-transport-https
+        state: present
+
+    - name: Make sure pgdg apt key is installed
+      apt_key:
+        id: ACCC4CF8
+        url: https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc
+
+    - name: Make sure pgdg repository is installed
+      apt_repository:
+        repo: "deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+
+    - name: Update apt cache
+      apt:
+        update_cache: true
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - ansible_os_family == "Debian"
+    - pgbackrest_install_from_pgdg_repo|bool
+  tags: pgbackrest, pgbackrest_repo, pgbackrest_install, pgbackrest_srv_install
+
+- block:  # RedHat pgdg repo
+    - name: Get pgdg-redhat-repo-latest.noarch.rpm
+      get_url:
+        url: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"  # noqa 204
+        dest: /tmp/
+        timeout: 30
+        validate_certs: false
+
+    - name: Make sure pgdg repository is installed
+      package:
+        name: /tmp/pgdg-redhat-repo-latest.noarch.rpm
+        state: present
+
+    - name: Clean yum cache
+      command: yum clean all
+      args:
+        warn: false
+      when: ansible_distribution_major_version == '7'
+
+    - name: Clean dnf cache
+      command: dnf clean all
+      args:
+        warn: false
+      when: ansible_distribution_major_version is version('8', '>=')
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - ansible_os_family == "RedHat"
+    - pgbackrest_install_from_pgdg_repo|bool
+  tags: pgbackrest, pgbackrest_repo, pgbackrest_install
+
+# (workaround for CentOS 8.0/8.1)
+# install libzstd RPM from an archived EPEL 8.1 release
+# The problem will be solved when CentOS 8.2 will be released.
+- block:
+    - name: Get libzstd rpm package from archived EPEL
+      get_url:
+        url: https://dl.fedoraproject.org/pub/archive/epel/8.1/Everything/x86_64/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm
+        dest: /tmp/
+        timeout: 120
+        validate_certs: false
+      register: get_libzstd_result
+
+    - name: Install libzstd
+      package:
+        name: /tmp/libzstd-1.4.4-1.el8.x86_64.rpm
+        state: present
+      when: get_libzstd_result is changed
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == '8'
+    - ansible_distribution_version is version('8.1', '<=')
+  tags: pgbackrest, pgbackrest_install
+
+- name: Install pgbackrest
+  package:
+    name: pgbackrest
+    state: latest
+  environment: "{{ proxy_env | default({}) }}"
+  tags: pgbackrest, pgbackrest_install
+
+- block:
+    - name: Ensure config directory exispgbackrest_srvt
+      file:
+        path: "{{ pgbackrest_conf_file | dirname }}"
+        state: directory
+
+    - name: "Generate conf file {{ pgbackrest_conf_file }}"
+      template:
+        src: pgbackrest.conf.j2
+        dest: "{{ pgbackrest_conf_file }}"
+        owner: postgres
+        group: postgres
+        mode: 0644
+  when: "'pgbackrest' in group_names"
+  tags: pgbackrest, pgbackrest_conf, pgbackrest_srv
+
+# if pgbackrest_repo_type: "posix" and pgbackrest_repo_host is set
+- import_tasks: ssh_keys.yml
+  when:
+    - pgbackrest_repo_type|lower != "s3"
+    - pgbackrest_repo_host is defined
+    - pgbackrest_repo_host | length > 0
+  tags: pgbackrest, pgbackrest_ssh_keys

--- a/roles/pgbackrest_srv/tasks/ssh_keys.yml
+++ b/roles/pgbackrest_srv/tasks/ssh_keys.yml
@@ -1,0 +1,80 @@
+---
+# yamllint disable rule:line-length
+
+- name: ssh_keys | Ensure ssh key are created for "{{ pgbackrest_repo_user }}" user on pgbackrest server
+  user:
+    name: "{{ pgbackrest_repo_user }}"
+    generate_ssh_key: true
+    ssh_key_bits: 2048
+    ssh_key_file: .ssh/id_rsa
+  when: "'pgbackrest' in group_names"
+
+- name: ssh_keys | Ensure ssh key are created for "postgres" user on database servers
+  #become: true
+  #become_user: postgres
+  user:
+    name: "postgres"
+    generate_ssh_key: true
+    ssh_key_bits: 2048
+    ssh_key_file: .ssh/id_rsa
+  when: "'postgres_cluster' in group_names"
+
+- name: ssh_keys | Get public ssh key from pgbackrest server
+  slurp:
+    src: "~{{ pgbackrest_repo_user }}/.ssh/id_rsa.pub"
+  register: pgbackrest_sshkey
+  changed_when: false
+  when: "'pgbackrest' in group_names"
+
+- name: ssh_keys | Get public ssh key from database servers
+  slurp:
+    src: "~postgres/.ssh/id_rsa.pub"
+  register: postgres_cluster_sshkey
+  changed_when: false
+  when: "'postgres_cluster' in group_names"
+
+- name: ssh_keys | Add pgbackrest ssh key in "~postgres/.ssh/authorized_keys" on database servers
+  authorized_key:
+    user: postgres
+    state: present
+    key: "{{ hostvars[item].pgbackrest_sshkey['content'] | b64decode }}"
+  loop: "{{ groups['pgbackrest'] }}"
+  when: "'postgres_cluster' in group_names"
+
+- name: ssh_keys | Add database ssh keys in "~{{ pgbackrest_repo_user }}/.ssh/authorized_keys" on pgbackrest server
+  authorized_key:
+    user: "{{ pgbackrest_repo_user }}"
+    state: present
+    key: "{{ hostvars[item].postgres_cluster_sshkey['content'] | b64decode }}"
+  loop: "{{ groups['postgres_cluster'] }}"
+  when: "'pgbackrest' in group_names"
+
+- name: known_hosts | Get public ssh keys of hosts (ssh-keyscan)
+  command: "ssh-keyscan -trsa -p {{ ansible_ssh_port | default(22) }} {{ item }}"
+  loop: "{{ groups['all'] }}"
+  register: ssh_known_host_keyscan
+  changed_when: false
+
+- name: known_hosts | add ssh public keys in "~postgres/.ssh/known_hosts" on database servers
+  become: true
+  become_user: postgres
+  known_hosts:
+    host: "{{ item.item }}"
+    key: "{{ item.stdout }}"
+    path: "~postgres/.ssh/known_hosts"
+  no_log: true
+  loop: "{{ ssh_known_host_keyscan.results }}"
+  when: "'postgres_cluster' in group_names"
+
+- name: known_hosts | add ssh public keys in "~{{ pgbackrest_repo_user }}/.ssh/known_hosts" on pgbackrest server
+  become: true
+  become_user: "{{ pgbackrest_repo_user }}"
+  known_hosts:
+    host: "{{ item.item }}"
+    key: "{{ item.stdout }}"
+    path: "~{{ pgbackrest_repo_user }}/.ssh/known_hosts"
+  no_log: false
+  loop: "{{ ssh_known_host_keyscan.results }}"
+  when: "'pgbackrest' in group_names"
+
+...

--- a/roles/pgbackrest_srv/tasks/system.yml
+++ b/roles/pgbackrest_srv/tasks/system.yml
@@ -1,0 +1,159 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+
+# DNS servers (/etc/resolv.conf)
+nameservers: []
+#  - "8.8.8.8"  # example (Google Public DNS)
+#  - "9.9.9.9"  # (Quad9 Public DNS)
+
+# /etc/hosts (optional)
+etc_hosts: []
+#  - "10.128.64.143 pgbackrest.minio.local minio.local s3.eu-west-3.amazonaws.com"  # example (MinIO)
+#  - ""
+
+ntp_enabled: false  # or 'true' if you want to install and configure the ntp service
+ntp_servers: []
+#  - "10.128.64.44"
+#  - "10.128.64.45"
+
+timezone: ""
+# timezone: "Europe/Berlin"
+
+# Generate locale
+# (except RHEL>=8,use glibc-langpack)
+locale_gen:
+  - {language_country: "en_US", encoding: "UTF-8"}
+  - {language_country: "de_DE", encoding: "UTF-8"}
+
+# Set system locale (LANG,LC_ALL)
+locale: "en_US.utf-8"
+
+
+# Kernel parameters
+sysctl_set: true  # or 'false'
+# these parameters for example! Specify kernel options for your system
+sysctl_conf:
+  etcd_cluster: []
+  master: []
+  replica: []
+  postgres_cluster:
+    - {name: "vm.swappiness", value: "1"}
+    - {name: "vm.min_free_kbytes", value: "102400"}
+    - {name: "vm.dirty_expire_centisecs", value: "1000"}
+    - {name: "vm.dirty_background_bytes", value: "67108864"}
+    - {name: "vm.dirty_bytes", value: "536870912"}
+#    - {name: "vm.nr_hugepages", value: "9510"}  # example "9510"=18GB
+    - {name: "vm.zone_reclaim_mode", value: "0"}
+    - {name: "kernel.numa_balancing", value: "0"}
+    - {name: "kernel.sched_migration_cost_ns", value: "5000000"}
+    - {name: "kernel.sched_autogroup_enabled", value: "0"}
+    - {name: "net.ipv4.ip_nonlocal_bind", value: "1"}
+    - {name: "net.ipv4.ip_forward", value: "1"}
+    - {name: "net.ipv4.ip_local_port_range", value: "10000 65535"}
+    - {name: "net.netfilter.nf_conntrack_max", value: "1048576"}
+    - {name: "net.core.netdev_max_backlog", value: "10000"}
+    - {name: "net.ipv4.tcp_max_syn_backlog", value: "8192"}
+    - {name: "net.core.somaxconn", value: "65535"}
+    - {name: "net.ipv4.tcp_tw_reuse", value: "1"}
+#    - {name: "", value: ""}
+  balancers:
+    - {name: "net.ipv4.ip_nonlocal_bind", value: "1"}
+    - {name: "net.ipv4.ip_forward", value: "1"}
+    - {name: "net.ipv4.ip_local_port_range", value: "10000 65535"}
+    - {name: "net.netfilter.nf_conntrack_max", value: "1048576"}
+    - {name: "net.core.netdev_max_backlog", value: "10000"}
+    - {name: "net.ipv4.tcp_max_syn_backlog", value: "8192"}
+    - {name: "net.core.somaxconn", value: "65535"}
+    - {name: "net.ipv4.tcp_tw_reuse", value: "1"}
+#    - {name: "", value: ""}
+
+
+# Transparent Huge Pages
+disable_thp: true  # or 'false'
+
+
+# Max open file limit
+set_limits: true  # or 'false'
+limits_user: "postgres"
+soft_nofile: 65536
+hard_nofile: 200000
+
+
+# I/O Scheduler (optional)
+set_scheduler: false  # or 'true'
+scheduler:
+  - {sched: "deadline", nr_requests: "1024", device: "sda"}
+#  - {sched: "noop" , nr_requests: "1024", device: "sdb"}
+#  - {sched: "" , nr_requests: "1024", device: ""}
+
+# Non-multiqueue I/O schedulers:
+# cfq         - for desktop systems and slow SATA drives
+# deadline    - for SAS drives (recommended for databases)
+# noop        - for SSD drives
+# Multiqueue I/O schedulers (blk-mq):
+# mq-deadline - (recommended for databases)
+# none        - (ideal for fast random I/O devices such as NVMe)
+# bfq         - (avoid for databases)
+# kyber
+
+
+# SSH Keys (optional)
+enable_ssh_key_based_authentication: false  # or 'true' for configure SSH Key-Based Authentication
+ssh_key_user: "postgres"
+ssh_key_state: "present"
+ssh_known_hosts: "{{ groups['postgres_cluster'] }}"
+
+
+# sudo
+sudo_users:
+  - name: "postgres"
+    nopasswd: "yes"  # or "no" to require a password
+    commands: "ALL"
+#  - name: "joe" # other user (example)
+#    nopasswd: "no"
+#    commands: "/usr/bin/find, /usr/bin/less, /usr/bin/tail, /bin/kill"
+
+
+# Firewall (ansible-role-firewall)
+firewall_enabled_at_boot: false
+
+firewall_allowed_tcp_ports_for:
+  master: []
+  replica: []
+  postgres_cluster:
+    - "{{ ansible_ssh_port | default(22) }}"
+    - "{{ postgresql_port }}"
+    - "{{ pgbouncer_listen_port }}"
+    - "8008"  # Patroni REST API port
+    - "19999"  # Netdata
+#    - "10050"  # Zabbix agent
+#    - ""
+  etcd_cluster:
+    - "{{ ansible_ssh_port | default(22) }}"
+    - "2379"  # ETCD port
+    - "2380"  # ETCD port
+#    - ""
+  balancers:
+    - "{{ ansible_ssh_port | default(22) }}"
+    - "{{ haproxy_listen_port.master }}"  # HAProxy (read/write) master
+    - "{{ haproxy_listen_port.replicas }}"  # HAProxy (read only) all replicas
+    - "{{ haproxy_listen_port.replicas_sync }}"  # HAProxy (read only) synchronous replica only
+    - "{{ haproxy_listen_port.replicas_async }}"  # HAProxy (read only) asynchronous replicas only
+    - "{{ haproxy_listen_port.stats }}"  # HAProxy stats
+#    - ""
+
+firewall_additional_rules_for:
+  master: []
+  replica: []
+  postgres_cluster: []
+  etcd_cluster: []
+  balancers:
+    - "iptables -p vrrp -A INPUT -j ACCEPT"  # Keepalived (vrrp)
+    - "iptables -p vrrp -A OUTPUT -j ACCEPT"  # Keepalived (vrrp)
+
+# disable firewalld (installed by default on RHEL/CentOS) or ufw (installed by default on Ubuntu)
+firewall_disable_firewalld: true
+firewall_disable_ufw: true
+
+...

--- a/roles/pgbackrest_srv/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest_srv/templates/pgbackrest.conf.j2
@@ -1,0 +1,13 @@
+[global]
+{% for global in pgbackrest_srv_conf.global %}
+{{ global.option }}={{ global.value }}
+{% endfor %}
+
+[{{ pgbackrest_stanza }}]
+{% for patroni in groups['postgres_cluster'] %}
+pg{{ loop.index }}-host={{ hostvars[patroni]['inventory_hostname'] }}
+pg{{ loop.index }}-path={{ postgresql_data_dir }}
+{% endfor %}
+{% for stanza in pgbackrest_srv_conf.stanza %}
+{{ stanza.option }}={{ stanza.value }}
+{% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -319,6 +319,7 @@ wal_g_patroni_cluster_bootstrap_command: "wal-g backup-fetch {{ postgresql_data_
 
 # pgBackRest
 pgbackrest_install: false  # or 'true'
+pgbackrest_srv_install: false  # or 'true'
 pgbackrest_install_from_pgdg_repo: true  # or 'false'
 pgbackrest_stanza: "stanza_name"  # specify your --stanza
 pgbackrest_repo_type: "posix"  # or "s3"
@@ -331,6 +332,7 @@ pgbackrest_conf:
     - {option: "log-level-file", value: "detail"}
     - {option: "log-path", value: "/var/log/pgbackrest"}
     - {option: "repo1-type", value: "{{ pgbackrest_repo_type |lower }}"}
+    # - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
     - {option: "repo1-host", value: "{{ pgbackrest_repo_host }}"}
     - {option: "repo1-host-user", value: "{{ pgbackrest_repo_user }}"}
 #    - {option: "", value: ""}
@@ -339,6 +341,20 @@ pgbackrest_conf:
     - {option: "process-max", value: "2"}
     - {option: "recovery-option", value: "recovery_target_action=promote"}
 #    - {option: "", value: ""}
+
+pgbackrest_srv_conf:
+  global:  # [global] section
+    - {option: "log-level-file", value: "detail"}
+    - {option: "log-path", value: "/var/log/pgbackrest"}
+    - {option: "repo1-type", value: "{{ pgbackrest_repo_type |lower }}"}
+    # - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
+    - {option: "repo1-path", value: "/var/lib/pgbackrest"}
+    - {option: "repo1-host-user", value: "{{ pgbackrest_repo_user }}"}
+  stanza:
+    - {option: "process-max", value: "2"}
+    - {option: "recovery-option", value: "recovery_target_action=promote"}
+    - {option: "backup-standby", value: "y"} # Don't take backups from a primary, move the work to a secondary, especially because of compression
+
 pgbackrest_patroni_cluster_restore_command:
   '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore'  # restore from latest backup
 #  '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --type=time "--target=2020-06-01 11:00:00+03" --delta restore'  # Point-in-Time Recovery (example)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -332,7 +332,7 @@ pgbackrest_conf:
     - {option: "log-level-file", value: "detail"}
     - {option: "log-path", value: "/var/log/pgbackrest"}
     - {option: "repo1-type", value: "{{ pgbackrest_repo_type |lower }}"}
-    # - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
+#    - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
     - {option: "repo1-host", value: "{{ pgbackrest_repo_host }}"}
     - {option: "repo1-host-user", value: "{{ pgbackrest_repo_user }}"}
 #    - {option: "", value: ""}
@@ -347,13 +347,13 @@ pgbackrest_srv_conf:
     - {option: "log-level-file", value: "detail"}
     - {option: "log-path", value: "/var/log/pgbackrest"}
     - {option: "repo1-type", value: "{{ pgbackrest_repo_type |lower }}"}
-    # - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
+#   - {option: "repo1-retention-full", value: 5} #  Take care, not to fill up your disks with backups
     - {option: "repo1-path", value: "/var/lib/pgbackrest"}
     - {option: "repo1-host-user", value: "{{ pgbackrest_repo_user }}"}
   stanza:
     - {option: "process-max", value: "2"}
     - {option: "recovery-option", value: "recovery_target_action=promote"}
-    - {option: "backup-standby", value: "y"} # Don't take backups from a primary, move the work to a secondary, especially because of compression
+    - {option: "backup-standby", value: "y"}  # Don't take backups from a primary, move the work to a secondary, especially because of compression
 
 pgbackrest_patroni_cluster_restore_command:
   '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore'  # restore from latest backup


### PR DESCRIPTION
I have added the possibility to have pgBackRest running on a dedicated server. This has two advantages, one can take backups from one of the followers instead of taking backups from the leader, and it moves the compression of the backup away from the database server.
The usage is optional configured in pgbackrest_srv_install. But it does require pgbackrest_install, too.