### PR TITLE
add role "copy"

### DIFF
--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -87,6 +87,7 @@
     - role: timezone
     - role: ntp
     - role: ssh-keys
+    - role: copy
 
 - hosts: pgbackrest:postgres_cluster
   become: true

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -105,6 +105,7 @@
     - role: timezone
     - role: ntp
     - role: ssh-keys
+    - role: copy
 
 - import_playbook: balancers.yml
   when: with_haproxy_load_balancing|bool

--- a/roles/copy/tasks/main.yml
+++ b/roles/copy/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Fetch files from the master
+  run_once: true
+  fetch:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    flat: true
+    validate_checksum: true
+  loop: "{{ fetch_files_from_master }}"
+  delegate_to: "{{ groups.master[0] }}"
+  when:
+    - fetch_files_from_master is defined
+    - fetch_files_from_master | length > 0
+  tags: fetch_files
+
+- name: Copy files to all servers
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop: "{{ copy_files_to_all_server }}"
+  when:
+    - copy_files_to_all_server is defined
+    - copy_files_to_all_server | length > 0
+  tags: copy_files
+
+...

--- a/tags.md
+++ b/tags.md
@@ -23,6 +23,8 @@
 - - ntp_install
 - - ntp_conf
 - ssh_keys
+- fetch_files
+- copy_files
 - etcd
 - - etcd_install
 - - etcd_conf

--- a/vars/system.yml
+++ b/vars/system.yml
@@ -157,4 +157,17 @@ firewall_additional_rules_for:
 firewall_disable_firewalld: true
 firewall_disable_ufw: true
 
+
+# (optional) - Fetch files from the server in the "master" group. These files can later be copied to all servers.
+fetch_files_from_master: []
+#  - {src: "/etc/ssl/certs/ssl-cert-snakeoil.pem", dest: "files/ssl-cert-snakeoil.pem"}
+#  - {src: "/etc/ssl/private/ssl-cert-snakeoil.key", dest: "files/ssl-cert-snakeoil.key"}
+#  - {src: "/path/to/myfile", dest: "files/myfile"}
+
+# (optional) - Copy this files to all servers in the cluster ("master" and "replica" groups)
+copy_files_to_all_server: []
+#  - {src: "files/ssl-cert-snakeoil.pem", dest: "/etc/ssl/certs/ssl-cert-snakeoil.pem", owner: "root", group: "root", mode: "0644"}
+#  - {src: "files/ssl-cert-snakeoil.key", dest: "/etc/ssl/private/ssl-cert-snakeoil.key", owner: "root", group: "root", mode: "0640"}
+#  - {src: "files/myfile", dest: "/path/to/myfile", owner: "postgres", group: "postgres", mode: "0640"}
+
 ...


### PR DESCRIPTION
1. Fetch files from the server in the "master" group. These files can later be copied to all servers.
2. Copy this files to all servers in the cluster ("master" and "replica" groups)

variables: `fetch_files_from_master`, `copy_files_to_all_server`

by default, do nothing