### PR TITLE
pgbouncer: ignore_startup_parameters variable

### DIFF
--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -18,7 +18,7 @@ unix_socket_dir = /var/run/postgresql
 auth_type = {{ pgbouncer_auth_type }}
 auth_file = /etc/pgbouncer/userlist.txt
 admin_users = postgres
-ignore_startup_parameters = extra_float_digits,geqo
+ignore_startup_parameters = {{ pgbouncer_ignore_startup_parameters }}
 
 pool_mode = {{ pgbouncer_default_pool_mode }}
 server_reset_query = DISCARD ALL

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -213,6 +213,7 @@ pgbouncer_default_pool_size: 20
 pgbouncer_default_pool_mode: "session"
 pgbouncer_generate_userlist: true  # generate the authentication file (userlist.txt) from the pg_shadow system table
 pgbouncer_auth_type: "{{ postgresql_password_encryption_algorithm }}"
+pgbouncer_ignore_startup_parameters: "extra_float_digits,geqo"
 
 pgbouncer_pools:
   - {name: "postgres", dbname: "postgres", pool_parameters: ""}


### PR DESCRIPTION
Promote pgouncer `ignore_startup_parameters` to a variable - mostly to cover things like https://github.com/pgbouncer/pgbouncer/issues/89 