### PR TITLE
Address upstream Issue #211

### DIFF
--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -6,7 +6,7 @@
 - block:
     - name: Build a sysctl_conf dynamic variable
       set_fact:
-        sysctl_conf_dynamic_var: "{{ sysctl_conf_dynamic_var |default([]) }} + {{ sysctl_conf[item] | flatten(1) }}"  # yamllint disable rule:line-length
+        sysctl_conf_dynamic_var: "{{ sysctl_conf_dynamic_var | default([]) + (sysctl_conf[item] | flatten(1)) }}"  # yamllint disable rule:line-length
       loop: "{{ hostvars[inventory_hostname].group_names }}"
 
     - name: Setting kernel parameters
@@ -16,7 +16,7 @@
         sysctl_set: true
         state: present
         reload: true
-      loop: "{{ sysctl_conf_dynamic_var|list | unique }}"
+      loop: "{{ sysctl_conf_dynamic_var | unique }}"
       when: sysctl_conf_dynamic_var | length > 0
   ignore_errors: true
   when: sysctl_set|bool


### PR DESCRIPTION
Investigated the issue because it happened to me also on newer ansible version.

I printed debug output and found it was treating the concatenated lists as a string and then forcing it to a list was flattening it to a list of characters but you can build the list this way instead and then you don't need to force it to a list in the second step either... left the `unique` there because that is still desired