### PR TITLE
small fix "postgresql_parameters" variable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -174,7 +174,7 @@ postgresql_parameters:
   - { option: "log_rotation_age", value: "1d" }
   - { option: "log_rotation_size", value: "0" }
   - { option: "log_line_prefix", value: "'%t [%p-%l] %r %q%u@%d '" }
-  - { option: "log_filename", value: "'postgresql-%a.log'" }
+  - { option: "log_filename", value: "postgresql-%a.log" }
   - { option: "log_directory", value: "{{ postgresql_log_dir }}" }
   - { option: "hot_standby_feedback", value: "on" }  # allows feedback from a hot standby to the primary that will avoid query conflicts
   - { option: "max_standby_streaming_delay", value: "30s" }


### PR DESCRIPTION
The config_cluster.yml playbook creates a patroni.yml file and sets the values of postgresql parameters in dcs etcd.
Prior to this change, the log_filename parameter was set in etcd as 'postgresql-%a.log'. Because of this, we received incorrect log files of approximately the following type:
/var/log/postgresql/'postgresql-Mon.log'

Now the log_filename parameter was set in the etcd sun as postgresql-%a.log (without quotes) and the log files are written correctly:
/var/log/postgresql/postgresql-Mon.log
Writing to patroni.yml without quotes is not a problem in this case, the parameter is read correctly

In this case, we leave the log_line_prefix parameter with two pairs of buckets. Because the entry %t [%p-%l] %r %q%u@%d in the file patroni.html it is not considered correct because of the special character "%" at the beginning of the line.
This solution is also to add quotes inside the log file.