### PR TITLE
Changes in confd and haproxy roles.

### DIFF
--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -16,9 +16,9 @@
 - name: Set maintenance variable
   hosts: all
   tasks:
-    - name: set variable
+    - name: Set variable
       set_fact:
-        postgresql_cluster_maintenance: false
+        postgresql_cluster_maintenance: true
   tags: always
 
 - name: Gathering facts from all servers

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -106,6 +106,8 @@
     - role: ssh-keys
 
 - import_playbook: balancers.yml
+  vars:
+    postgresql_cluster_maintenance: true
   when: with_haproxy_load_balancing|bool
   tags: config_balancers,load_balancing, haproxy
 

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -13,6 +13,14 @@
         msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
       when: ansible_version.full is version(minimal_ansible_version, '<')
 
+- name: Set maintenance variable
+  hosts: all
+  tasks:
+    - name: set variable
+      set_fact:
+        postgresql_cluster_maintenance: false
+  tags: always
+
 - name: Gathering facts from all servers
   hosts: all
   gather_facts: true
@@ -106,8 +114,6 @@
     - role: ssh-keys
 
 - import_playbook: balancers.yml
-  vars:
-    postgresql_cluster_maintenance: true
   when: with_haproxy_load_balancing|bool
   tags: config_balancers,load_balancing, haproxy
 

--- a/roles/confd/templates/confd.toml.j2
+++ b/roles/confd/templates/confd.toml.j2
@@ -9,7 +9,7 @@ nodes = [
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
   {% for etcd_hosts in patroni_etcd_hosts %}
-  {{etcd_hosts.host}}:{{etcd_hosts.port}},
+  "http://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
   {% endfor %}
 {% endif %}
 ]

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -354,7 +354,7 @@
     owner: haproxy
     group: haproxy
   notify: "restart haproxy"
-  when: add_balancer is not defined or not add_balancer|bool
+  when: (add_balancer is not defined or not add_balancer|bool) and (postgresql_cluster_maintenance is not defined or not postgresql_cluster_maintenance|bool)
   tags: haproxy, haproxy_conf, load_balancing
 
 - name: Generate systemd service file "/etc/systemd/system/haproxy.service"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -354,7 +354,8 @@
     owner: haproxy
     group: haproxy
   notify: "restart haproxy"
-  when: (add_balancer is not defined or not add_balancer|bool) and (postgresql_cluster_maintenance is not defined or not postgresql_cluster_maintenance|bool)
+  when: (add_balancer is not defined or not add_balancer|bool) and
+        (postgresql_cluster_maintenance is not defined or not postgresql_cluster_maintenance|bool)
   tags: haproxy, haproxy_conf, load_balancing
 
 - name: Generate systemd service file "/etc/systemd/system/haproxy.service"


### PR DESCRIPTION
1. If generate confd.toml nodes without "http://", then service dont start with error:
FATAL Near line 4 (last key parsed 'nodes'): Invalid float value: "10.128.64.140"

2. A variable "postgresql_cluster_maintenance" has been added to config_cluster.yml to not generate the haproxy.cfg file from being generated by the haproxy task when confd is used. (deploy_pgcluster.yml - no changes)