### PR TITLE
Add a check for the total pgbouncer pool_size less than the PostgreSQL max_connections (#236)

### DIFF
--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -8,14 +8,6 @@
     mode: 0750
   tags: pgbouncer, pgbouncer_conf
 
-- name: Get count postgres databases
-  become: true
-  become_user: postgres
-  command: >
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -Atq -c "select count(*) from pg_database where not datistemplate;"
-  register: postgres_database_count
-  tags: pgbouncer_conf, pgbouncer
-
 - name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
     defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
@@ -24,7 +16,7 @@
 
 - name: Calculate totla_pool_size
   set_fact:
-    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgres_database_count.stdout|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
+    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgresql_databases|length|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Check max_connections

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -8,6 +8,25 @@
     mode: 0750
   tags: pgbouncer, pgbouncer_conf
 
+- name: Calculate pgbouncer total pool size
+  set_fact:
+    total_pool_size: "{{ total_pool_size|default(0)|int + item.pool_parameters | regex_replace ('[^0-9]') | int }}"
+  loop: "{{ pgbouncer_pools }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Get postgresql max_connections parameter
+  set_fact:
+    max_connections: "{{ item.value }}"
+  when: item.option == "max_connections"
+  loop: "{{ postgresql_parameters }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Failed when total_pool_size > max_connections
+  fail:
+    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
+  when: total_pool_size > max_connections
+  tags: pgbouncer_conf, pgbouncer
+
 - name: Update pgbouncer.ini
   template:
     src: ../templates/pgbouncer.ini.j2

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -8,13 +8,26 @@
     mode: 0750
   tags: pgbouncer, pgbouncer_conf
 
-- name: Calculate pgbouncer total pool size
+- name: Get count postgres databases
+  become: true
+  become_user: postgres
+  command: >
+    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -Atq -c "select count(*) from pg_database where not datistemplate;"
+  register: postgres_database_count
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
-    total_pool_size: "{{ total_pool_size|default(0)|int + item.pool_parameters | regex_replace ('[^0-9]') | int }}"
+    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
   loop: "{{ pgbouncer_pools }}"
   tags: pgbouncer_conf, pgbouncer
 
-- name: Get postgresql max_connections parameter
+- name: Calculate totla_pool_size
+  set_fact:
+    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgres_database_count.stdout|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Check max_connections
   set_fact:
     max_connections: "{{ item.value }}"
   when: item.option == "max_connections"
@@ -24,7 +37,7 @@
 - name: Failed when total_pool_size > max_connections
   fail:
     msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size > max_connections
+  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size | int > max_connections | int
   tags: pgbouncer_conf, pgbouncer
 
 - name: Update pgbouncer.ini

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -21,9 +21,7 @@
 
 - name: Check max_connections
   set_fact:
-    max_connections: "{{ item.value }}"
-  when: item.option == "max_connections"
-  loop: "{{ postgresql_parameters }}"
+    max_connections: "{{ postgresql_parameters|json_query(\"[? option == 'max_connections'].value\")|first|default(100, true) }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Failed when total_pool_size > max_connections

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
-    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
+    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_search('pool_size=(\\d+)')|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size, true)|int }}"
   loop: "{{ pgbouncer_pools }}"
   tags: pgbouncer_conf, pgbouncer
 

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -20,9 +20,16 @@
     total_pool_size: "{{ defined_pool_size|default(0)|int + (postgresql_databases|length|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
   tags: pgbouncer_conf, pgbouncer
 
-- name: Check max_connections
+- name: Set default value to max_connections
   set_fact:
-    max_connections: "{{ postgresql_parameters|json_query(\"[? option == 'max_connections'].value\")|first|default(100, true) }}"
+    max_connections: 100
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Set max_connections from vars if it defined
+  set_fact:
+    max_connections: "{{ item.value|default(100, true) }}"
+  when: item.option == "max_connections"
+  loop: "{{ postgresql_parameters }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Failed when total_pool_size > max_connections

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Failed when total_pool_size > max_connections
   fail:
     msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: total_pool_size > max_connections
+  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size > max_connections
   tags: pgbouncer_conf, pgbouncer
 
 - name: Update pgbouncer.ini

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -80,13 +80,26 @@
     dest: /etc/logrotate.d/pgbouncer
   tags: pgbouncer_logrotate, pgbouncer
 
-- name: Calculate pgbouncer total pool size
+- name: Get count postgres databases
+  become: true
+  become_user: postgres
+  command: >
+    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -Atq -c "select count(*) from pg_database where not datistemplate;"
+  register: postgres_database_count
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
-    total_pool_size: "{{ total_pool_size|default(0)|int + item.pool_parameters | regex_replace ('[^0-9]') | int }}"
+    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
   loop: "{{ pgbouncer_pools }}"
   tags: pgbouncer_conf, pgbouncer
 
-- name: Get postgresql max_connections parameter
+- name: Calculate totla_pool_size
+  set_fact:
+    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgres_database_count.stdout|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Check max_connections
   set_fact:
     max_connections: "{{ item.value }}"
   when: item.option == "max_connections"
@@ -96,7 +109,18 @@
 - name: Failed when total_pool_size > max_connections
   fail:
     msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size > max_connections
+  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size | int > max_connections | int
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Update pgbouncer.ini
+  template:
+    src: ../templates/pgbouncer.ini.j2
+    dest: "{{ pgbouncer_conf_dir }}/pgbouncer.ini"
+    owner: postgres
+    group: postgres
+    mode: 0640
+  notify: "restart pgbouncer"
+  when: existing_pgcluster is not defined or not existing_pgcluster|bool
   tags: pgbouncer_conf, pgbouncer
 
 - name: Configure pgbouncer.ini

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -80,6 +80,25 @@
     dest: /etc/logrotate.d/pgbouncer
   tags: pgbouncer_logrotate, pgbouncer
 
+- name: Calculate pgbouncer total pool size
+  set_fact:
+    total_pool_size: "{{ total_pool_size|default(0)|int + item.pool_parameters | regex_replace ('[^0-9]') | int }}"
+  loop: "{{ pgbouncer_pools }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Get postgresql max_connections parameter
+  set_fact:
+    max_connections: "{{ item.value }}"
+  when: item.option == "max_connections"
+  loop: "{{ postgresql_parameters }}"
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Failed when total_pool_size > max_connections
+  fail:
+    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
+  when: total_pool_size > max_connections
+  tags: pgbouncer_conf, pgbouncer
+
 - name: Configure pgbouncer.ini
   template:
     src: templates/pgbouncer.ini.j2

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -82,7 +82,7 @@
 
 - name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
-    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
+    defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_search('pool_size=(\\d+)')|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size, true)|int }}"
   loop: "{{ pgbouncer_pools }}"
   tags: pgbouncer_conf, pgbouncer
 

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Failed when total_pool_size > max_connections
   fail:
     msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: total_pool_size > max_connections
+  when: pgbouncer_pools is defined and pgbouncer_pools | length > 0 and total_pool_size > max_connections
   tags: pgbouncer_conf, pgbouncer
 
 - name: Configure pgbouncer.ini

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -92,9 +92,16 @@
     total_pool_size: "{{ defined_pool_size|default(0)|int + (postgresql_databases|length|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
   tags: pgbouncer_conf, pgbouncer
 
-- name: Check max_connections
+- name: Set default value to max_connections
   set_fact:
-    max_connections: "{{ postgresql_parameters|json_query(\"[? option == 'max_connections'].value\")|first|default(100, true) }}"
+    max_connections: 100
+  tags: pgbouncer_conf, pgbouncer
+
+- name: Set max_connections from vars if it defined
+  set_fact:
+    max_connections: "{{ item.value|default(100, true) }}"
+  when: item.option == "max_connections"
+  loop: "{{ postgresql_parameters }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Failed when total_pool_size > max_connections

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -93,9 +93,7 @@
 
 - name: Check max_connections
   set_fact:
-    max_connections: "{{ item.value }}"
-  when: item.option == "max_connections"
-  loop: "{{ postgresql_parameters }}"
+    max_connections: "{{ postgresql_parameters|json_query(\"[? option == 'max_connections'].value\")|first|default(100, true) }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Failed when total_pool_size > max_connections

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -80,14 +80,6 @@
     dest: /etc/logrotate.d/pgbouncer
   tags: pgbouncer_logrotate, pgbouncer
 
-- name: Get count postgres databases
-  become: true
-  become_user: postgres
-  command: >
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -Atq -c "select count(*) from pg_database where not datistemplate;"
-  register: postgres_database_count
-  tags: pgbouncer_conf, pgbouncer
-
 - name: Calculate pool_size for defined pgbouncer_pools (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
   set_fact:
     defined_pool_size: "{{ defined_pool_size|default(0)|int + item.pool_parameters|regex_replace ('[^0-9]')|default(pgbouncer_default_pool_size, true)|int }}"
@@ -96,7 +88,7 @@
 
 - name: Calculate totla_pool_size
   set_fact:
-    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgres_database_count.stdout|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
+    total_pool_size: "{{ defined_pool_size|default(0)|int + (postgresql_databases|length|int - pgbouncer_pools|length|int) * pgbouncer_default_pool_size|int }}"
   tags: pgbouncer_conf, pgbouncer
 
 - name: Check max_connections


### PR DESCRIPTION
MR for issue #236
add 3 tasks:
- calculate pgbouncer total pool_size (if not defined pool_size, then calculate as pgbouncer_default_pool_size)
- get number of max connections from "postgresql_parameters" variable
- if total_pool_size > max_connections and pgbouncer_pools not empty, task will be failed and send special message