### PR TITLE
Fix /etc/environment error

### DIFF
--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -980,8 +980,8 @@
   lineinfile:
     dest: "/etc/environment"
     state: present
-    regexp: "^export PATRONICTL_CONFIG_FILE"
-    line: "export PATRONICTL_CONFIG_FILE=/etc/patroni/patroni.yml"
+    regexp: "^PATRONICTL_CONFIG_FILE"
+    line: "PATRONICTL_CONFIG_FILE=/etc/patroni/patroni.yml"
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
I've noticed the following error in system log:

`systemd[3456620]: /usr/lib/environment.d/99-environment.conf:2: invalid variable name "export PATRONICTL_CONFIG_FILE", ignoring.`

/usr/lib/environment.d/99-environment.conf is a symlink to /etc/environment.

Documentation says that the /etc/environment file must consist of simple NAME=VALUE pairs on separate lines.

According to this we should probably remove "export" before the variable name.