### PR TITLE
Fix typo in confd role

### DIFF
--- a/roles/confd/tasks/main.yml
+++ b/roles/confd/tasks/main.yml
@@ -75,7 +75,7 @@
         src: "files/{{ item.conf }}"
         dest: "{{ item.dest }}"
       loop:
-        - { onf: 'confd.toml', dest: '/etc/confd/confd.toml' }
+        - { conf: 'confd.toml', dest: '/etc/confd/confd.toml' }
         - { conf: 'haproxy.toml', dest: '/etc/confd/conf.d/haproxy.toml' }
         - { conf: 'haproxy.tmpl', dest: '/etc/confd/templates/haproxy.tmpl' }
       loop_control:


### PR DESCRIPTION
I guess there is a typo and it should "conf", not "onf".