### PR TITLE
Add Patroni raft

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,48 +22,37 @@ In addition to deploying new clusters, this playbook also support the deployment
 
 
 ## Index
-- [PostgreSQL High-Availability Cluster :elephant: :sparkling\_heart:](#postgresql-high-availability-cluster-elephant-sparkling_heart)
-    - [Deploy a Production Ready PostgreSQL High-Availability Cluster (based on "Patroni" and DCS "etcd" or "consul"). Automating with Ansible.](#deploy-a-production-ready-postgresql-high-availability-cluster-based-on-patroni-and-dcs-etcd-or-consul-automating-with-ansible)
-  - [Index](#index)
-  - [Cluster types](#cluster-types)
-    - [\[Type A\] PostgreSQL High-Availability with HAProxy Load Balancing](#type-a-postgresql-high-availability-with-haproxy-load-balancing)
-          - [if variable "synchronous\_mode" is 'true' (vars/main.yml):](#if-variable-synchronous_mode-is-true-varsmainyml)
-        - [Components of high availability:](#components-of-high-availability)
-        - [Components of load balancing:](#components-of-load-balancing)
-    - [\[Type B\] PostgreSQL High-Availability only](#type-b-postgresql-high-availability-only)
-    - [\[Type C\] PostgreSQL High-Availability with Consul Service Discovery (DNS)](#type-c-postgresql-high-availability-with-consul-service-discovery-dns)
-    - [\[Type D\] PostgreSQL High-Availability with HAProxy Load Balancing and Patroni raft](#type-d-postgresql-high-availability-with-haproxy-load-balancing-and-patroni-raft)
-          - [if variable "synchronous\_mode" is 'true' (vars/main.yml):](#if-variable-synchronous_mode-is-true-varsmainyml-1)
-        - [Components of high availability:](#components-of-high-availability-1)
-        - [Components of load balancing:](#components-of-load-balancing-1)
-  - [Compatibility](#compatibility)
-          - [Supported Linux Distributions:](#supported-linux-distributions)
-          - [PostgreSQL versions:](#postgresql-versions)
-          - [Ansible version](#ansible-version)
-  - [Requirements](#requirements)
-  - [Port requirements](#port-requirements)
-  - [Recommenations](#recommenations)
-  - [Deployment: quick start](#deployment-quick-start)
-          - [Specify (non-public) IP addresses and connection settings (`ansible_user`, `ansible_ssh_pass` or `ansible_ssh_private_key_file` for your environment](#specify-non-public-ip-addresses-and-connection-settings-ansible_user-ansible_ssh_pass-or-ansible_ssh_private_key_file-for-your-environment)
-          - [Minimum set of variables:](#minimum-set-of-variables)
-  - [Variables](#variables)
-  - [Cluster Scaling](#cluster-scaling)
-          - [Preparation:](#preparation)
-          - [Steps to add a new node:](#steps-to-add-a-new-node)
-          - [Steps to add a new banlancer node:](#steps-to-add-a-new-banlancer-node)
-  - [Restore and Cloning](#restore-and-cloning)
-        - [Create cluster with pgBackRest:](#create-cluster-with-pgbackrest)
-        - [Create cluster with WAL-G:](#create-cluster-with-wal-g)
-        - [Point-In-Time-Recovery:](#point-in-time-recovery)
-  - [Maintenance](#maintenance)
-  - [Disaster Recovery](#disaster-recovery)
-        - [etcd](#etcd)
-        - [PostgreSQL (databases)](#postgresql-databases)
-  - [How to start from scratch](#how-to-start-from-scratch)
-  - [License](#license)
-  - [Author](#author)
-  - [Sponsor this project](#sponsor-this-project)
-  - [Feedback, bug-reports, requests, ...](#feedback-bug-reports-requests-)
+- [Cluster types](#cluster-types)
+    - [[Type A] PostgreSQL High-Availability with HAProxy Load Balancing](#type-a-postgresql-high-availability-with-haproxy-load-balancing)
+    - [[Type B] PostgreSQL High-Availability only](#type-b-postgresql-high-availability-only)
+    - [[Type C] PostgreSQL High-Availability with Consul Service Discovery (DNS)](#type-c-postgresql-high-availability-with-consul-service-discovery-dns)
+    - [[Type D] PostgreSQL High-Availability with HAProxy Load Balancing and Patroni raft](#type-d-postgresql-high-availability-with-haproxy-load-balancing-and-patroni-raft)
+- [Compatibility](#compatibility)
+    - [Supported Linux Distributions:](#supported-linux-distributions)
+    - [PostgreSQL versions:](#postgresql-versions)
+    - [Ansible version](#ansible-version)
+- [Requirements](#requirements)
+- [Port requirements](#port-requirements)
+- [Recommendations](#recommenations)
+- [Deployment: quick start](#deployment-quick-start)
+- [Variables](#variables)
+- [Cluster Scaling](#cluster-scaling)
+    - [Preparation:](#preparation)
+    - [Steps to add a new node:](#steps-to-add-a-new-node)
+    - [Steps to add a new banlancer node:](#steps-to-add-a-new-banlancer-node)
+- [Restore and Cloning](#restore-and-cloning)
+    - [Create cluster with pgBackRest:](#create-cluster-with-pgbackrest)
+    - [Create cluster with WAL-G:](#create-cluster-with-wal-g)
+    - [Point-In-Time-Recovery:](#point-in-time-recovery)
+- [Maintenance](#maintenance)
+- [Disaster Recovery](#disaster-recovery)
+    - [etcd](#etcd)
+    - [PostgreSQL (databases)](#postgresql-databases)
+- [How to start from scratch](#how-to-start-from-scratch)
+- [License](#license)
+- [Author](#author)
+- [Sponsor this project](#sponsor-this-project)
+- [Feedback, bug-reports, requests, ...](#feedback-bug-reports-requests-)
 
 ## Cluster types
 
@@ -135,7 +124,8 @@ It requires the installation of a consul in client mode on each application serv
 
 
 ### [Type D] PostgreSQL High-Availability with HAProxy Load Balancing and Patroni raft
-![TypeA](images/TypeA.png)
+
+Image to be added!
 
 > To use this scheme, specify `with_haproxy_load_balancing: true` in variable file vars/main.yml and `dcs_type: patroni_raft` in variable file vars/main.yml
 
@@ -153,9 +143,7 @@ This scheme provides the ability to distribute the load on reading. This also al
 ##### Components of high availability:
 [**Patroni**](https://github.com/zalando/patroni) is a template for you to create your own customized, high-availability solution using Python and - for maximum accessibility - a distributed configuration store like ZooKeeper, etcd, Consul or Kubernetes. Used for automate the management of PostgreSQL instances and auto failover.
 
-[**Patroni_raft**](TBD) .
-
-[What is Distributed Consensus?](http://thesecretlivesofdata.com/raft/)
+[**Patroni_raft**](https://github.com/zalando/patroni) is a native consensus raft present on patroni starting from v2. You can deploy also a node with patroni and raft without deploy Postgres.
 
 ##### Components of load balancing:
 [**HAProxy**](http://www.haproxy.org/) is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. 

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -69,6 +69,8 @@
     - name: Make sure the gnupg and apt-transport-https packages are present
       apt:
         pkg:
+          - curl
+          - ca-certificates
           - gnupg
           - apt-transport-https
         state: present

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -27,10 +27,8 @@
   tags: keepalived_conf, keepalived
 
 - name: Create vrrp_script "/usr/libexec/keepalived/haproxy_check.sh"
-  copy:
-    content: |
-      #!/bin/bash
-      /bin/kill -0 `cat /var/run/haproxy/haproxy.pid`
+  template:
+    src: templates/haproxy_check.sh.j2
     dest: /usr/libexec/keepalived/haproxy_check.sh
     owner: root
     group: root

--- a/roles/keepalived/templates/haproxy_check.sh.j2
+++ b/roles/keepalived/templates/haproxy_check.sh.j2
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CURRRENT_ROLE=$(curl http://{{ hostvars[host]['inventory_hostname'] }}:8008/master --silent | jq ' .role' | sed 's/"//g')
+
+if [ $CURRRENT_ROLE == 'master' ] 
+then
+  exit 0
+fi
+
+exit 1

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -817,7 +817,7 @@
       retries: 10
       delay: 2
       when: patroni_standby_cluster.host is not defined or patroni_standby_cluster.host | length < 1
-  when: is_master == "true"
+  when: is_master == "true" and dcs_type != "patroni_raft"
   tags: patroni, patroni_start_master, point_in_time_recovery
 
 - block:  # pg_hba (using a templates/pg_hba.conf.j2)
@@ -939,7 +939,7 @@
       until: replica_result.status == 200
       retries: 1200  # timeout 10 hours
       delay: 30
-  when: is_master != "true"
+  when: is_master != "true" or dcs_type == "patroni_raft"
   tags: patroni, patroni_start_replica, point_in_time_recovery
 
 # create symlink pg_xlog/pg_wal to custom WAL dir

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -263,6 +263,16 @@
     mode: 0750
   when: patroni_log_destination == 'logfile'
   tags: patroni, patroni_conf
+  
+- name: Create patroni raft directory
+  file:
+    path: "{{ patroni_raft_data_dir }}"
+    owner: postgres
+    group: postgres
+    state: directory
+    mode: 0750
+  when: dcs_type == 'patroni_raft'
+  tags: patroni, patroni_conf
 
 - block:  # for add_pgnode.yml
     - name: Fetch patroni.yml conf file from master

--- a/roles/patroni/templates/patroni.service.j2
+++ b/roles/patroni/templates/patroni.service.j2
@@ -20,8 +20,13 @@ EnvironmentFile=-/etc/patroni_env.conf
 
 # Pre-commands to start watchdog device
 # Uncomment if watchdog is part of your patroni setup
+{% if patroni_watchdog in ['automatic', 'required']  %}
+ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
+ExecStartPre=-/usr/bin/sudo /bin/chown postgres {{ patroni_watchdog_device }} 
+{% else %}
 #ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
-#ExecStartPre=-/usr/bin/sudo /bin/chown postgres /dev/watchdog
+#ExecStartPre=-/usr/bin/sudo /bin/chown postgres {{ patroni_watchdog_device }} 
+{% endif %}
 
 # Start the patroni process
 {% if patroni_installation_method == 'pip' %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -48,8 +48,8 @@ consul:
 raft:
   data_dir: "{{ patroni_raft_data_dir }}"
   self_addr: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}:5010"
-  partner_addrs: [{% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}'{{ hostvars[host]['inventory_hostname'] }}:5010'{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
-{% endif %}]
+  partner_addrs: [{% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}'{{ hostvars[host]['inventory_hostname'] }}:5010'{% if not loop.last %},{% endif %}{% endif %}{% endfor %}]
+{% endif %}
 
 bootstrap:
   method: {{ patroni_cluster_bootstrap_method }}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -48,7 +48,7 @@ consul:
 raft:
   data_dir: "{{ patroni_raft_data_dir }}"
   self_addr: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}:5010"
-  partner_addrs: [{% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}{{ hostvars[host]['inventory_hostname'] }}:5010{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
+  partner_addrs: [{% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}'{{ hostvars[host]['inventory_hostname'] }}:5010'{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
 {% endif %}]
 
 bootstrap:

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -44,6 +44,13 @@ consul:
   checks: []
 {% endif %}
 
+{% if dcs_type == 'patroni_raft' %}
+raft:
+  data_dir: "{{ patroni_raft_data_dir }}"
+  self_addr: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}:5010"
+  partner_addrs: {% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}{{ hostvars[host]['inventory_hostname'] }}:5010{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
+{% endif %}
+
 bootstrap:
   method: {{ patroni_cluster_bootstrap_method }}
 {% if patroni_cluster_bootstrap_method == 'wal-g' %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -48,8 +48,8 @@ consul:
 raft:
   data_dir: "{{ patroni_raft_data_dir }}"
   self_addr: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}:5010"
-  partner_addrs: {% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}{{ hostvars[host]['inventory_hostname'] }}:5010{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
-{% endif %}
+  partner_addrs: [{% for host in groups['postgres_cluster'] %}{% if hostvars[host]['inventory_hostname'] != hostvars[inventory_hostname]['inventory_hostname']%}{{ hostvars[host]['inventory_hostname'] }}:5010{% if not loop.last %},{% endif %}{% endif %}{% endfor %}
+{% endif %}]
 
 bootstrap:
   method: {{ patroni_cluster_bootstrap_method }}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -208,8 +208,8 @@ postgresql:
 {% endif %}
 
 watchdog:
-  mode: off  # Allowed values: off, automatic, required
-  device: /dev/watchdog
+  mode: {{ patroni_watchdog if patroni_watchdog in ['off', 'automatic', 'required'] else 'off'}}  # Allowed values: off, automatic, required
+  device: {{ patroni_watchdog_device }}  # Path to the watchdog device
   safety_margin: 5
 
 tags:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -296,6 +296,9 @@ patroni_retry_timeout: 10
 patroni_maximum_lag_on_failover: 1048576
 patroni_master_start_timeout: 300
 
+patroni_watchdog: "off"  # or 'automatic' or 'required' if you want to use the watchdog
+patroni_watchdog_device: "/dev/watchdog"
+
 # https://patroni.readthedocs.io/en/latest/replica_bootstrap.html#standby-cluster
 patroni_standby_cluster:
   host: ""  # an address of remote master

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -49,7 +49,7 @@ vip_manager_mask: "24"  # netmask for the virtual ip
 
 # DCS (Distributed Consensus Store)
 dcs_exists: false  # or 'true' if you don't want to deploy a new etcd cluster
-dcs_type: "etcd"  # or 'consul'
+dcs_type: "patroni_raft"  # or 'consul' or 'etcd'
 
 # if dcs_type: "etcd" and dcs_exists: false
 etcd_ver: "v3.3.27"  # version for deploy etcd cluster
@@ -128,6 +128,7 @@ consul_services:
 #      - { http: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:8008/async", interval: "2s" }
 #      - { args: ["systemctl", "status", "pgbouncer"], interval: "5s" }
 
+patroni_raft_data_dir: "/var/lib/raft"
 
 # PostgreSQL variables
 postgresql_version: "14"


### PR DESCRIPTION
Hi @vitabaks,

I added support to Patrini raft (present here from patroni v2). This allow us to avoid the usage of etcd and consul.

Moreover  I added:

- a script for HA in keepalived to discover the master and assign correctly keepalived
- patroni_watchdog configuration (and respective patroni_watchdog_device)
- added doc side for raft

I only missed the architettural image for patroni raft, because i don't find the original code of image (i think draw.io).

Let me know if I need to change something.
Thanks for your work!