### PR TITLE
Add playbook: update_pgcluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ In addition to deploying new clusters, this playbook also support the deployment
     - [Create cluster with WAL-G:](#create-cluster-with-wal-g)
     - [Point-In-Time-Recovery:](#point-in-time-recovery)
 - [Maintenance](#maintenance)
+    - [Update the PostgreSQL HA Cluster](#update-the-postgresql-ha-cluster)
+    - [Using Git for cluster configuration management](#using-git-for-cluster-configuration-management-iacgitops)
 - [Disaster Recovery](#disaster-recovery)
     - [etcd](#etcd)
     - [PostgreSQL (databases)](#postgresql-databases)
@@ -460,7 +462,27 @@ I recommend that you study the following materials for further maintenance of th
 - [Patroni documentation](https://patroni.readthedocs.io/en/latest/)
 - [etcd operations guide](https://etcd.io/docs/v3.3.12/op-guide/)
 
-## Using Git for cluster configuration management (IaC/GitOps)
+#### Update the PostgreSQL HA Cluster
+
+`update_pgcluster.yml` playbook is designed to update the PostgreSQL HA Cluster, to a new minor version (for example 15.1->15.2, and etc).
+
+Usage:
+
+- Update PostgreSQL:
+
+    `ansible-playbook update_pgcluster.yml`
+
+- Update Patroni:
+
+    `ansible-playbook update_pgcluster.yml -e target=patroni`
+
+- Update all system:
+
+    `ansible-playbook update_pgcluster.yml -e target=system`
+
+More details [here](roles/update)
+
+#### Using Git for cluster configuration management (IaC/GitOps)
 
 Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes. \
 GitOps automates infrastructure updates using a Git workflow with continuous integration (CI) and continuous delivery (CI/CD). When new code is merged, the CI/CD pipeline enacts the change in the environment. Any configuration drift, such as manual changes or errors, is overwritten by GitOps automation so the environment converges on the desired state defined in Git. 

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -43,7 +43,7 @@ Update all system packages:
 
 Note: About the expected downtime of the database during the update:
 
-When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~2-5 seconds.
+When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~5-10 seconds.
 
 #### 1. PRE-UPDATE: Perform Pre-Checks
 - Test PostgreSQL DB Access

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -43,7 +43,7 @@ Update all system packages:
 
 Note: About the expected downtime of the database during the update:
 
-When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~5 seconds.
+When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~2-5 seconds.
 
 #### 1. PRE-UPDATE: Perform Pre-Checks
 - Test PostgreSQL DB Access

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -1,0 +1,122 @@
+
+`update_pgcluster.yml` playbook is designed to update the PostgreSQL HA Cluster, to a new minor version (for example 15.1->15.2, and etc).
+
+By default, only PostgreSQL packages defined in the postgresql_packages variable are updated (vars/Debian.yml or vars/RedHat.yml). In addition, you can update Patroni or the entire system. 
+
+#### Usage
+
+Update PostgreSQL:
+
+`ansible-playbook update_pgcluster.yml`
+
+Update Patroni:
+
+`ansible-playbook update_pgcluster.yml -e target=patroni`
+
+Update all system packages:
+
+`ansible-playbook update_pgcluster.yml -e target=system`
+
+
+#### Variables
+
+- `target` 
+  - Defines the target for the update.
+  - Available values: 'postgres', 'patroni', 'system'
+  - Default value: postgres
+- `max_replication_lag_bytes`
+  - Determines the size of the replication lag above which the update will not be performed.
+  - If the lag is high, you will be prompted to try again later.
+  - Default value: 10485760 (10 MiB)
+- `max_transaction_sec`
+  - Determines the maximum transaction time, in the presence of which the update will not be performed.
+  - If long-running transactions are present, you will be prompted to try again later. 
+  - Default value: 15 (seconds)
+- `update_extensions`
+  - If 'true', an attempt will be made to automatically update all extensions for all databases.
+  - Specify 'false', to avoid updating extensions.
+  - Default value: true
+---
+
+## Plan:
+
+#### 1. PRE-UPDATE: Perform Pre-Checks
+- Test PostgreSQL DB Access
+- Make sure that physical replication is active
+  - Stop, if there are no active replicas
+- Make sure there is no high replication lag
+  - Note: no more than `max_replication_lag_bytes`
+  - Stop, if replication lag is high
+- Make sure there are no long-running transactions
+  - no more than `max_transaction_sec`
+  - Stop, if long-running transactions detected
+#### 2. UPDATE: Secondary (one by one)
+- Stop read-only traffic
+  - Enable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml
+  - Reload patroni service
+  - Make sure replica endpoint is unavailable
+  - Wait for active transactions to complete
+- Stop Services
+  - Execute CHECKPOINT before stopping PostgreSQL
+  - Stop Patroni service on the Cluster Replica
+- Update PostgreSQL
+  - if `target` variable is not defined or `target=postgres`
+  - Install the latest version of PostgreSQL packages
+- Update Patroni
+  - if `target=patroni` (or `system`)
+  - Install the latest version of Patroni package
+- Update all system packages (includes PostgreSQL and Patroni)
+  - if `target=system`
+  - Update all system packages
+- Start Services
+  - Start Patroni service
+  - Wait for Patroni port to become open on the host
+  - Check that the Patroni is healthy
+  - Check PostgreSQL is started and accepting connections
+- Start read-only traffic
+  - Disable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml
+  - Reload patroni service
+  - Make sure replica endpoint is available
+- Perform the same steps for the next replica server.
+#### 3. UPDATE: Primary
+- Switchover Patroni leader role
+  - Perform switchover of the leader for the Patroni cluster
+  -  Make sure that the Patroni is healthy and is a replica
+     - Note: At this stage, the leader becomes a replica
+- Stop read-only traffic
+  - Enable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml
+  - Reload patroni service
+  - Make sure replica endpoint is unavailable
+  - Wait for active transactions to complete
+- Stop Services
+  - Execute CHECKPOINT before stopping PostgreSQL
+  - Stop Patroni service on the old Cluster Leader
+- Update PostgreSQL
+  - if `target` variable is not defined or `target=postgres`
+  - Install the latest version of PostgreSQL packages
+- Update Patroni
+  - if `target=patroni` (or `system`)
+  - Install the latest version of Patroni package
+- Update all system packages (includes PostgreSQL and Patroni)
+  - if `target=system`
+  - Update all system packages
+- Start Services
+  - Start Patroni service
+  - Wait for Patroni port to become open on the host
+  - Check that the Patroni is healthy
+  - Check PostgreSQL is started and accepting connections
+- Start read-only traffic
+  - Disable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml
+  - Reload patroni service
+  - Make sure replica endpoint is available
+#### 4. POST-UPDATE: Update extensions
+- Update extensions
+  - Get the current Patroni Cluster Leader Node
+  - Get a list of databases
+  - Update extensions in each database
+    - Get a list of old PostgreSQL extensions
+    - Update old PostgreSQL extensions (if an update is required)
+- Check the Patroni cluster state
+- Check the current PostgreSQL version
+- List the Patroni cluster members
+- Update completed.

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -41,6 +41,10 @@ Update all system packages:
 
 ## Plan:
 
+Note: About the expected downtime of the database during the update:
+
+When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~5 seconds.
+
 #### 1. PRE-UPDATE: Perform Pre-Checks
 - Test PostgreSQL DB Access
 - Make sure that physical replication is active
@@ -83,7 +87,9 @@ Update all system packages:
 - Switchover Patroni leader role
   - Perform switchover of the leader for the Patroni cluster
   -  Make sure that the Patroni is healthy and is a replica
-     - Note: At this stage, the leader becomes a replica
+     - Notes:
+       - At this stage, the leader becomes a replica
+       - the database downtime is ~5 seconds (write traffic)
 - Stop read-only traffic
   - Enable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml
   - Reload patroni service

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -1,5 +1,6 @@
+## Update the PostgreSQL HA Cluster
 
-`update_pgcluster.yml` playbook is designed to update the PostgreSQL HA Cluster, to a new minor version (for example 15.1->15.2, and etc).
+This role is designed to update the PostgreSQL HA cluster to a new minor version (for example, 15.1->15.2, and etc).
 
 By default, only PostgreSQL packages defined in the postgresql_packages variable are updated (vars/Debian.yml or vars/RedHat.yml). In addition, you can update Patroni or the entire system. 
 

--- a/roles/update/tasks/extensions.yml
+++ b/roles/update/tasks/extensions.yml
@@ -1,0 +1,66 @@
+---
+- name: 'Get the current Patroni Cluster Leader Node'
+  uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/leader
+    status_code: 200
+  register: patroni_leader_result
+  changed_when: false
+  failed_when: false
+
+- name: Get a list of old PostgreSQL extensions
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "select
+    extname from pg_extension e
+    join pg_available_extensions ae on extname = ae.name
+    where installed_version <> default_version"
+  register: pg_old_extensions
+  changed_when: false
+  when:
+    - patroni_leader_result.status == 200
+
+# excluding: 'pg_repack' (is exists), as it requires re-creation to update
+- name: Update old PostgreSQL extensions
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
+  ignore_errors: true
+  loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^pg_repack$') | list }}"
+  register: pg_old_extensions_update_result
+  when:
+    - patroni_leader_result.status == 200
+    - (pg_old_extensions.stdout_lines | length > 0
+       and not 'pg_stat_kcache' in pg_old_extensions.stdout_lines)
+
+# if pg_stat_kcache is exists
+- block:
+    # excluding: 'pg_stat_statements', because extension pg_stat_kcache depends on it (will be re-created)
+    - name: Update old PostgreSQL extensions
+      command: >-
+        psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
+      ignore_errors: true
+      loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^(pg_repack|pg_stat_statements|pg_stat_kcache)$') | list }}"
+      register: pg_old_extensions_update_result
+
+    # re-create 'pg_stat_statements' and 'pg_stat_kcache' if an update is required
+    - name: Recreate old pg_stat_statements and pg_stat_kcache extensions to update
+      command: >-
+        psql -d {{ pg_target_dbname }} -tAXc "
+        DROP EXTENSION pg_stat_statements CASCADE;
+        CREATE EXTENSION pg_stat_statements;
+        CREATE EXTENSION pg_stat_kcache"
+  when:
+    - patroni_leader_result.status == 200
+    - pg_old_extensions.stdout_lines | length > 0
+    - ('pg_stat_statements' in pg_old_extensions.stdout_lines or
+       'pg_stat_kcache' in pg_old_extensions.stdout_lines)
+
+# re-create the 'pg_repack' if it exists and an update is required
+- name: Recreate old pg_repack extension to update
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "
+    DROP EXTENSION pg_repack;
+    CREATE EXTENSION pg_repack;"
+  when:
+    - patroni_leader_result.status == 200
+    - (pg_old_extensions.stdout_lines | length > 0
+       and 'pg_repack' in pg_old_extensions.stdout_lines)
+...

--- a/roles/update/tasks/extensions.yml
+++ b/roles/update/tasks/extensions.yml
@@ -19,4 +19,5 @@
   loop: "{{ databases_list.stdout_lines }}"
   loop_control:
     loop_var: pg_target_dbname
+  when: databases_list.stdout_lines is defined
 ...

--- a/roles/update/tasks/extensions.yml
+++ b/roles/update/tasks/extensions.yml
@@ -7,60 +7,16 @@
   changed_when: false
   failed_when: false
 
-- name: Get a list of old PostgreSQL extensions
-  command: >-
-    psql -d {{ pg_target_dbname }} -tAXc "select
-    extname from pg_extension e
-    join pg_available_extensions ae on extname = ae.name
-    where installed_version <> default_version"
-  register: pg_old_extensions
+- name: Get a list of databases
+  command: psql -tAXc "select datname from pg_catalog.pg_database where not datistemplate"
+  register: databases_list
   changed_when: false
   when:
     - patroni_leader_result.status == 200
 
-# excluding: 'pg_repack' (is exists), as it requires re-creation to update
-- name: Update old PostgreSQL extensions
-  command: >-
-    psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
-  ignore_errors: true
-  loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^pg_repack$') | list }}"
-  register: pg_old_extensions_update_result
-  when:
-    - patroni_leader_result.status == 200
-    - (pg_old_extensions.stdout_lines | length > 0
-       and not 'pg_stat_kcache' in pg_old_extensions.stdout_lines)
-
-# if pg_stat_kcache is exists
-- block:
-    # excluding: 'pg_stat_statements', because extension pg_stat_kcache depends on it (will be re-created)
-    - name: Update old PostgreSQL extensions
-      command: >-
-        psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
-      ignore_errors: true
-      loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^(pg_repack|pg_stat_statements|pg_stat_kcache)$') | list }}"
-      register: pg_old_extensions_update_result
-
-    # re-create 'pg_stat_statements' and 'pg_stat_kcache' if an update is required
-    - name: Recreate old pg_stat_statements and pg_stat_kcache extensions to update
-      command: >-
-        psql -d {{ pg_target_dbname }} -tAXc "
-        DROP EXTENSION pg_stat_statements CASCADE;
-        CREATE EXTENSION pg_stat_statements;
-        CREATE EXTENSION pg_stat_kcache"
-  when:
-    - patroni_leader_result.status == 200
-    - pg_old_extensions.stdout_lines | length > 0
-    - ('pg_stat_statements' in pg_old_extensions.stdout_lines or
-       'pg_stat_kcache' in pg_old_extensions.stdout_lines)
-
-# re-create the 'pg_repack' if it exists and an update is required
-- name: Recreate old pg_repack extension to update
-  command: >-
-    psql -d {{ pg_target_dbname }} -tAXc "
-    DROP EXTENSION pg_repack;
-    CREATE EXTENSION pg_repack;"
-  when:
-    - patroni_leader_result.status == 200
-    - (pg_old_extensions.stdout_lines | length > 0
-       and 'pg_repack' in pg_old_extensions.stdout_lines)
+- name: Update extensions in each database
+  include_tasks: update_extensions.yml
+  loop: "{{ databases_list.stdout_lines }}"
+  loop_control:
+    loop_var: pg_target_dbname
 ...

--- a/roles/update/tasks/patroni.yml
+++ b/roles/update/tasks/patroni.yml
@@ -1,16 +1,6 @@
 ---
 # patroni_installation_method: "pip"
 - block:
-    - name: Install the latest version of setuptools
-      pip:
-        name: setuptools<66.0.0  # https://github.com/pypa/setuptools/issues/3772
-        state: latest
-        executable: pip3
-        extra_args: "--trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"
-        umask: "0022"
-      environment:
-        PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
-
     - name: Install the latest version of Patroni
       pip:
         name: patroni

--- a/roles/update/tasks/patroni.yml
+++ b/roles/update/tasks/patroni.yml
@@ -1,0 +1,83 @@
+---
+# patroni_installation_method: "pip"
+- block:
+    - name: Install the latest version of setuptools
+      pip:
+        name: setuptools<66.0.0  # https://github.com/pypa/setuptools/issues/3772
+        state: latest
+        executable: pip3
+        extra_args: "--trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"
+        umask: "0022"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+
+    - name: Install the latest version of Patroni
+      pip:
+        name: patroni
+        state: latest
+        executable: pip3
+        extra_args: "--trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"
+        umask: "0022"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+  when: installation_method == "repo" and patroni_installation_method == "pip"
+  environment: "{{ proxy_env | default({}) }}"
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+
+# patroni_installation_method: "rpm/deb"
+- block:
+    # Debian
+    - name: Install the latest version of Patroni packages
+      package:
+        name: "{{ patroni_packages| default('patroni')}}"
+        state: latest
+      when: ansible_os_family == "Debian" and patroni_deb_package_repo | length < 1
+
+    # RedHat
+    - name: Install the latest version of Patroni packages
+      package:
+        name: "{{ patroni_packages| default('patroni')}}"
+        state: latest
+      when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length < 1
+
+    # when patroni_deb_package_repo or patroni_rpm_package_repo URL is defined
+    # Debian
+    - name: Download Patroni deb package
+      get_url:
+        url: "{{ item }}"
+        dest: /tmp/
+        timeout: 60
+        validate_certs: false
+      loop: "{{ patroni_deb_package_repo | list }}"
+      when: ansible_os_family == "Debian" and patroni_deb_package_repo | length > 0
+
+    - name: Install Patroni from deb package
+      apt:
+        force_apt_get: true
+        deb: "/tmp/{{ item }}"
+        state: present
+      loop: "{{ patroni_deb_package_repo | map('basename') | list }}"
+      when: ansible_os_family == "Debian" and patroni_deb_package_repo | length > 0
+
+    # RedHat
+    - name: Download Patroni rpm package
+      get_url:
+        url: "{{ item }}"
+        dest: /tmp/
+        timeout: 60
+        validate_certs: false
+      loop: "{{ patroni_rpm_package_repo | list }}"
+      when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
+
+    - name: Install Patroni from rpm package
+      package:
+        name: "/tmp/{{ item }}"
+        state: present
+      loop: "{{ patroni_rpm_package_repo | map('basename') | list }}"
+      when: ansible_os_family == "RedHat" and patroni_rpm_package_repo | length > 0
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - (patroni_installation_method == "rpm" or patroni_installation_method == "deb")
+...

--- a/roles/update/tasks/postgres.yml
+++ b/roles/update/tasks/postgres.yml
@@ -1,0 +1,12 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install the latest version of PostgreSQL packages
+  package:
+    name: "{{ item }}"
+    state: latest
+  loop: "{{ postgresql_packages }}"
+...

--- a/roles/update/tasks/postgres.yml
+++ b/roles/update/tasks/postgres.yml
@@ -1,8 +1,21 @@
 ---
+- name: Clean yum cache
+  command: yum clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == '7'
+
+- name: Clean dnf cache
+  command: dnf clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version is version('8', '>=')
+
 - name: Update apt cache
   apt:
     update_cache: true
     cache_valid_time: 3600
+  when: ansible_os_family == "Debian"
 
 - name: Install the latest version of PostgreSQL packages
   package:

--- a/roles/update/tasks/pre_checks.yml
+++ b/roles/update/tasks/pre_checks.yml
@@ -20,7 +20,7 @@
     - inventory_hostname in groups['primary']
     - pg_replication_state.stdout | int == 0
 
-- name: '[Pre-Check] Make sure there is no high physical replication lag (more than {{ max_replication_lag_bytes | human_readable }})'
+- name: '[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | human_readable }})'
   command: >-
     psql -tAXc "select pg_wal_lsn_diff(pg_current_wal_lsn(),
     replay_lsn) pg_lag_bytes from pg_stat_replication
@@ -34,7 +34,7 @@
   when:
     - inventory_hostname in groups['primary']
 
-# Stop, if physical replication lag is high
+# Stop, if replication lag is high
 - block:
     - name: "Print replication lag"
       debug:
@@ -68,7 +68,7 @@
 
 # Stop, if long-running transactions detected
 - block:
-    - name: "(SOURCE) Print long-running (>{{ max_transaction_sec }}s) transactions"
+    - name: "Print long-running (>{{ max_transaction_sec }}s) transactions"
       debug:
         msg: "{{ pg_long_transactions.stdout_lines }}"
 

--- a/roles/update/tasks/pre_checks.yml
+++ b/roles/update/tasks/pre_checks.yml
@@ -1,0 +1,81 @@
+---
+- name: '[Pre-Check] (ALL) Test PostgreSQL DB Access'
+  command: psql -tAXc 'select 1'
+  changed_when: false
+
+- name: '[Pre-Check] Make sure that physical replication is active'
+  command: >-
+    psql -tAXc "select count(*) from pg_stat_replication
+    where application_name != 'pg_basebackup'"
+  register: pg_replication_state
+  changed_when: false
+  when:
+    - inventory_hostname in groups['primary']
+
+# Stop, if there are no active replicas
+- name: "Pre-Check error. Print physical replication state"
+  fail:
+    msg: "There are no active replica servers (pg_stat_replication returned 0 entries)."
+  when:
+    - inventory_hostname in groups['primary']
+    - pg_replication_state.stdout | int == 0
+
+- name: '[Pre-Check] Make sure there is no high physical replication lag (more than {{ max_replication_lag_bytes | human_readable }})'
+  command: >-
+    psql -tAXc "select pg_wal_lsn_diff(pg_current_wal_lsn(),
+    replay_lsn) pg_lag_bytes from pg_stat_replication
+    order by pg_lag_bytes desc limit 1"
+  register: pg_lag_bytes
+  changed_when: false
+  failed_when: false
+  until: pg_lag_bytes.stdout|int < max_replication_lag_bytes|int
+  retries: 30
+  delay: 5
+  when:
+    - inventory_hostname in groups['primary']
+
+# Stop, if physical replication lag is high
+- block:
+    - name: "Print replication lag"
+      debug:
+        msg: "Current replication lag:
+          {{ pg_lag_bytes.stdout | int | human_readable }}"
+
+    - name: "Pre-Check error. Please try again later"
+      fail:
+        msg: High replication lag on the Patroni Cluster, please try again later.
+  when:
+    - pg_lag_bytes.stdout is defined
+    - pg_lag_bytes.stdout|int >= max_replication_lag_bytes|int
+
+- name: '[Pre-Check] Make sure there are no long-running transactions (more than {{ max_transaction_sec }} seconds)'
+  command: >-
+    psql -tAXc "select pid, usename, client_addr, clock_timestamp() - xact_start as xact_age,
+      state, wait_event_type ||':'|| wait_event as wait_events,
+      left(regexp_replace(query, E'[ \\t\\n\\r]+', ' ', 'g'),100) as query
+      from pg_stat_activity
+      where clock_timestamp() - xact_start > '{{ max_transaction_sec }} seconds'::interval
+      and backend_type = 'client backend' and pid <> pg_backend_pid()
+      order by xact_age desc limit 10"
+  register: pg_long_transactions
+  changed_when: false
+  failed_when: false
+  until: pg_long_transactions.stdout | length < 1
+  retries: 30
+  delay: 2
+  when:
+    - inventory_hostname in groups['primary']
+
+# Stop, if long-running transactions detected
+- block:
+    - name: "(SOURCE) Print long-running (>{{ max_transaction_sec }}s) transactions"
+      debug:
+        msg: "{{ pg_long_transactions.stdout_lines }}"
+
+    - name: "Pre-Check error. Please try again later"
+      fail:
+        msg: long-running transactions detected (more than {{ max_transaction_sec }} seconds), please try again later.
+  when:
+    - pg_long_transactions.stdout is defined
+    - pg_long_transactions.stdout | length > 0
+...

--- a/roles/update/tasks/start_services.yml
+++ b/roles/update/tasks/start_services.yml
@@ -22,4 +22,14 @@
   until: patroni_replica_result.status == 200
   retries: 300
   delay: 2
+
+- name: Check PostgreSQL is started and accepting connections
+  become: true
+  become_user: postgres
+  command: "{{ postgresql_bin_dir }}/pg_isready -p {{ postgresql_port }}"
+  register: pg_isready_result
+  until: pg_isready_result.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
 ...

--- a/roles/update/tasks/start_services.yml
+++ b/roles/update/tasks/start_services.yml
@@ -1,0 +1,25 @@
+---
+- name: Start Patroni service
+  become: true
+  become_user: root
+  service:
+    name: patroni
+    state: started
+
+- name: "Wait for port {{ patroni_restapi_port }} to become open on the host"
+  wait_for:
+    port: '{{ patroni_restapi_port }}'
+    host: '{{ hostvars[inventory_hostname][''inventory_hostname''] }}'
+    state: started
+    timeout: 60
+    delay: 10
+
+- name: Check that the Patroni is healthy
+  uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/health
+    status_code: 200
+  register: patroni_replica_result
+  until: patroni_replica_result.status == 200
+  retries: 300
+  delay: 2
+...

--- a/roles/update/tasks/start_traffic.yml
+++ b/roles/update/tasks/start_traffic.yml
@@ -18,7 +18,7 @@
     enabled: true
     state: reloaded
 
-- name: Make sure that the Patroni is healthy and is a replica
+- name: Make sure replica endpoint is available
   uri:
     url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/replica
     status_code: 200

--- a/roles/update/tasks/start_traffic.yml
+++ b/roles/update/tasks/start_traffic.yml
@@ -1,0 +1,29 @@
+---
+- name: "Edit patroni.yml | disable noloadbalance, nosync, nofailover"
+  replace:
+    path: /etc/patroni/patroni.yml
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  loop:
+    - { regexp: 'noloadbalance: true', replace: 'noloadbalance: false' }
+    - { regexp: 'nosync: true', replace: 'nosync: false' }
+    - { regexp: 'nofailover: true', replace: 'nofailover: false' }
+  loop_control:
+    label: '{{ item.replace }}'
+
+- name: Reload patroni service
+  systemd:
+    daemon_reload: true
+    name: patroni
+    enabled: true
+    state: reloaded
+
+- name: Make sure that the Patroni is healthy and is a replica
+  uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/replica
+    status_code: 200
+  register: patroni_replica_result
+  until: patroni_replica_result.status == 200
+  retries: 30
+  delay: 2
+...

--- a/roles/update/tasks/stop_services.yml
+++ b/roles/update/tasks/stop_services.yml
@@ -1,0 +1,42 @@
+---
+# pre-check
+- name: Check PostgreSQL is started and accepting connections
+  become: true
+  become_user: postgres
+  command: "{{ postgresql_bin_dir }}/pg_isready -p {{ postgresql_port }}"
+  register: pg_isready_result
+  until: pg_isready_result.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
+
+# Stop the secondary
+- block:
+    - name: Execute CHECKPOINT before stopping PostgreSQL
+      become: true
+      become_user: postgres
+      command: psql -tAXc "CHECKPOINT"
+
+    - name: "Stop Patroni service on the Cluster Replica ({{ ansible_hostname }})"
+      become: true
+      become_user: root
+      service:
+        name: patroni
+        state: stopped
+  when: inventory_hostname in groups['secondary']
+
+# Stop the old primary (now secondary, after switchover)
+- block:
+    - name: Execute CHECKPOINT before stopping PostgreSQL
+      become: true
+      become_user: postgres
+      command: psql -tAXc "CHECKPOINT"
+
+    - name: "Stop Patroni service on the old Cluster Leader ({{ ansible_hostname }})"
+      become: true
+      become_user: root
+      service:
+        name: patroni
+        state: stopped
+  when: inventory_hostname in groups['primary']
+...

--- a/roles/update/tasks/stop_traffic.yml
+++ b/roles/update/tasks/stop_traffic.yml
@@ -26,4 +26,19 @@
   until: patroni_replica_result.status == 503
   retries: 30
   delay: 2
+
+- name: Wait for active transactions to complete
+  become: true
+  become_user: postgres
+  command: >-
+    psql -tAXc "select
+    count(*) from pg_stat_activity
+    where pid <> pg_backend_pid()
+    and backend_type = 'client backend'
+    and state = 'active'"
+  register: pg_active_count
+  until: pg_active_count.stdout|int == 0
+  retries: 300
+  delay: 2
+  changed_when: false
 ...

--- a/roles/update/tasks/stop_traffic.yml
+++ b/roles/update/tasks/stop_traffic.yml
@@ -1,0 +1,29 @@
+---
+- name: "Edit patroni.yml | enable noloadbalance, nosync, nofailover"
+  replace:
+    path: /etc/patroni/patroni.yml
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  loop:
+    - { regexp: 'noloadbalance: false', replace: 'noloadbalance: true' }
+    - { regexp: 'nosync: false', replace: 'nosync: true' }
+    - { regexp: 'nofailover: false', replace: 'nofailover: true' }
+  loop_control:
+    label: '{{ item.replace }}'
+
+- name: Reload patroni service
+  systemd:
+    daemon_reload: true
+    name: patroni
+    enabled: true
+    state: reloaded
+
+- name: Make sure replica endpoint is unavailable
+  uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/replica
+    status_code: 503
+  register: patroni_replica_result
+  until: patroni_replica_result.status == 503
+  retries: 30
+  delay: 2
+...

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -1,0 +1,26 @@
+---
+- name: Perform switchover of the leader for the Patroni cluster "{{ patroni_cluster_name }}"
+  become: true
+  become_user: postgres
+  expect:
+    command: "patronictl -c /etc/patroni/patroni.yml switchover {{ patroni_cluster_name }}"
+    responses:
+      (.*)Primary(.*): "{{ hostvars[groups['primary'][0]]['ansible_hostname'] }}"
+      (.*)Candidate(.*): "{{ hostvars[groups['secondary'][0]]['ansible_hostname'] }}"
+      (.*)When should the switchover take place(.*): "now"
+      (.*)Are you sure you want to switchover cluster(.*): "y"
+  register: patronictl_switchover_result
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+
+- name: Make sure that the Patroni is healthy and is a replica
+  uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/replica
+    status_code: 200
+  register: patroni_replica_result
+  until: patroni_replica_result.status == 200
+  retries: 300
+  delay: 2
+...

--- a/roles/update/tasks/system.yml
+++ b/roles/update/tasks/system.yml
@@ -1,0 +1,25 @@
+---
+- name: Clean yum cache
+  command: yum clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == '7'
+
+- name: Clean dnf cache
+  command: dnf clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version is version('8', '>=')
+
+- name: Update apt cache
+  apt:
+    update_cache: true
+    cache_valid_time: 3600
+  when: ansible_os_family == "Debian"
+
+- name: Update all system packages
+  package:
+    name: '*'
+    state: latest
+  ignore_errors: true
+...

--- a/roles/update/tasks/update_extensions.yml
+++ b/roles/update/tasks/update_extensions.yml
@@ -13,7 +13,9 @@
 # if there are no old extensions
 - name: The extensions are up-to-date
   debug:
-    msg: "The extension versions are up-to-date. No update is required."
+    msg:
+      - "The extension versions are up-to-date for the database {{ pg_target_dbname }}"
+      - "No update is required."
   when: pg_old_extensions.stdout_lines | length < 1
 
 # excluding: 'pg_repack' (is exists), as it requires re-creation to update

--- a/roles/update/tasks/update_extensions.yml
+++ b/roles/update/tasks/update_extensions.yml
@@ -1,0 +1,58 @@
+---
+- name: Get a list of old PostgreSQL extensions
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "select
+    extname from pg_extension e
+    join pg_available_extensions ae on extname = ae.name
+    where installed_version <> default_version"
+  register: pg_old_extensions
+  changed_when: false
+  when:
+    - patroni_leader_result.status == 200
+
+# excluding: 'pg_repack' (is exists), as it requires re-creation to update
+- name: Update old PostgreSQL extensions
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
+  ignore_errors: true
+  loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^pg_repack$') | list }}"
+  register: pg_old_extensions_update_result
+  when:
+    - patroni_leader_result.status == 200
+    - (pg_old_extensions.stdout_lines | length > 0
+       and not 'pg_stat_kcache' in pg_old_extensions.stdout_lines)
+
+# if pg_stat_kcache is exists
+- block:
+    # excluding: 'pg_stat_statements', because extension pg_stat_kcache depends on it (will be re-created)
+    - name: Update old PostgreSQL extensions
+      command: >-
+        psql -d {{ pg_target_dbname }} -tAXc "ALTER EXTENSION {{ item }} UPDATE"
+      ignore_errors: true
+      loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^(pg_repack|pg_stat_statements|pg_stat_kcache)$') | list }}"
+      register: pg_old_extensions_update_result
+
+    # re-create 'pg_stat_statements' and 'pg_stat_kcache' if an update is required
+    - name: Recreate old pg_stat_statements and pg_stat_kcache extensions to update
+      command: >-
+        psql -d {{ pg_target_dbname }} -tAXc "
+        DROP EXTENSION pg_stat_statements CASCADE;
+        CREATE EXTENSION pg_stat_statements;
+        CREATE EXTENSION pg_stat_kcache"
+  when:
+    - patroni_leader_result.status == 200
+    - pg_old_extensions.stdout_lines | length > 0
+    - ('pg_stat_statements' in pg_old_extensions.stdout_lines or
+       'pg_stat_kcache' in pg_old_extensions.stdout_lines)
+
+# re-create the 'pg_repack' if it exists and an update is required
+- name: Recreate old pg_repack extension to update
+  command: >-
+    psql -d {{ pg_target_dbname }} -tAXc "
+    DROP EXTENSION pg_repack;
+    CREATE EXTENSION pg_repack;"
+  when:
+    - patroni_leader_result.status == 200
+    - (pg_old_extensions.stdout_lines | length > 0
+       and 'pg_repack' in pg_old_extensions.stdout_lines)
+...

--- a/roles/update/tasks/update_extensions.yml
+++ b/roles/update/tasks/update_extensions.yml
@@ -10,6 +10,12 @@
   when:
     - patroni_leader_result.status == 200
 
+# if there are no old extensions
+- name: List the Patroni cluster members
+  debug:
+    msg: "The extension versions are up-to-date. No update is required."
+  when: pg_old_extensions.stdout_lines | length < 1
+
 # excluding: 'pg_repack' (is exists), as it requires re-creation to update
 - name: Update old PostgreSQL extensions
   command: >-

--- a/roles/update/tasks/update_extensions.yml
+++ b/roles/update/tasks/update_extensions.yml
@@ -11,7 +11,7 @@
     - patroni_leader_result.status == 200
 
 # if there are no old extensions
-- name: List the Patroni cluster members
+- name: The extensions are up-to-date
   debug:
     msg: "The extension versions are up-to-date. No update is required."
   when: pg_old_extensions.stdout_lines | length < 1

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -194,6 +194,23 @@
       include_role:
         name: update
         tasks_from: start_traffic
+
+    - name: Check the Patroni cluster state
+      become: true
+      become_user: postgres
+      command: patronictl -c /etc/patroni/patroni.yml list
+      register: patronictl_result
+      changed_when: false
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
+
+    - name: List the Patroni cluster members
+      debug:
+        msg: "{{ patronictl_result.stdout_lines }}"
+
+    - name: Update completed
+      debug:
+        msg: "PostgreSQL HA cluster update completed."
   tags:
     - update
     - update-primary

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -67,7 +67,7 @@
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
       tags: always
   tasks:
-    - name: Stop read-only trafic
+    - name: Stop read-only traffic
       include_role:
         name: update
         tasks_from: stop_traffic
@@ -101,7 +101,7 @@
         name: update
         tasks_from: start_services
 
-    - name: Start read-only trafic
+    - name: Start read-only traffic
       include_role:
         name: update
         tasks_from: start_traffic
@@ -138,6 +138,11 @@
         name: update
         tasks_from: switchover
 
+    - name: Stop read-only traffic
+      include_role:
+        name: update
+        tasks_from: stop_traffic
+
     - name: Stop Services
       include_role:
         name: update
@@ -166,6 +171,11 @@
       include_role:
         name: update
         tasks_from: start_services
+
+    - name: Start read-only traffic
+      include_role:
+        name: update
+        tasks_from: start_traffic
   tags:
     - update
     - update-primary

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -228,6 +228,7 @@
         PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
 
     - name: Check the current PostgreSQL version
+      run_once: true
       command: psql -tAXc "select current_setting('server_version')"
       register: postgres_version
       changed_when: false
@@ -244,6 +245,7 @@
         msg: 
           - "PostgreSQL HA cluster update completed."
           - "Current version: {{ postgres_version.stdout }}"
+      when: postgres_version.stdout is defined
   tags:
     - update
     - update-extensions

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -228,11 +228,13 @@
         PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
 
     - name: List the Patroni cluster members
+      run_once: true
       debug:
         msg: "{{ patronictl_result.stdout_lines }}"
       when: patronictl_result.stdout_lines is defined
 
     - name: Update completed
+      run_once: true
       debug:
         msg: "PostgreSQL HA cluster update completed."
   tags:

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -227,6 +227,11 @@
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
 
+    - name: Check the current PostgreSQL version
+      command: psql -tAXc "select current_setting('server_version')"
+      register: postgres_version
+      changed_when: false
+
     - name: List the Patroni cluster members
       run_once: true
       debug:
@@ -236,7 +241,9 @@
     - name: Update completed
       run_once: true
       debug:
-        msg: "PostgreSQL HA cluster update completed."
+        msg: 
+          - "PostgreSQL HA cluster update completed."
+          - "Current version: {{ postgres_version.stdout }}"
   tags:
     - update
     - update-extensions

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -1,0 +1,162 @@
+---
+- name: Update PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  vars_files:
+    - vars/main.yml
+  tasks:
+    - name: '[Prepare] Get Patroni Cluster Leader Node'
+      uri:
+        url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/leader
+        status_code: 200
+      register: patroni_leader_result
+      changed_when: false
+      failed_when: false
+      tags: always
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      add_host:
+        name: "{{ item }}"
+        groups: primary
+      when: hostvars[item]['patroni_leader_result']['status'] == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      add_host:
+        name: "{{ item }}"
+        groups: secondary
+      when: hostvars[item]['patroni_leader_result']['status'] != 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      tags: always
+
+    - name: "Print Patroni Cluster info"
+      debug:
+        msg:
+          - "Cluster Name: {{ patroni_cluster_name }}"
+          - "Cluster Leader: {{ ansible_hostname }}"
+      when: inventory_hostname in groups['primary']
+      tags: always
+
+- name: "(1/2) UPDATE: secondary"
+  hosts: secondary
+  serial: 1  # update replicas one by one
+  gather_facts: false
+  become: true
+  become_user: root
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  vars_files:
+    - vars/main.yml
+  vars:
+    target: postgres  # or 'patroni', 'system'
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+  tasks:
+    - name: Stop Services
+      include_role:
+        name: update
+        tasks_from: stop_services
+
+    - name: Update PostgreSQL
+      include_role:
+        name: update
+        tasks_from: postgres
+      when: target | lower == 'postgres'
+
+    - name: Update Patroni
+      include_role:
+        name: update
+        tasks_from: patroni
+      when: target | lower == 'patroni' or
+            (target | lower == 'system' and patroni_installation_method == "pip")
+
+    - name: Update all system packages (includes PostgreSQL and Patroni)
+      include_role:
+        name: update
+        tasks_from: system
+      when: target | lower == 'system'
+
+    - name: Start Services
+      include_role:
+        name: update
+        tasks_from: start_services
+  tags:
+    - update
+    - update-secondary
+
+- name: "(2/2) UPDATE: primary"
+  hosts: primary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  vars_files:
+    - vars/main.yml
+  vars:
+    target: postgres  # or 'patroni', 'system'
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+  tasks:
+    - name: "Switchover Patroni leader role"
+      include_role:
+        name: update
+        tasks_from: switchover
+
+    - name: Stop Services
+      include_role:
+        name: update
+        tasks_from: stop_services
+
+    - name: Update PostgreSQL
+      include_role:
+        name: update
+        tasks_from: postgres
+      when: target | lower == 'postgres'
+
+    - name: Update Patroni
+      include_role:
+        name: update
+        tasks_from: patroni
+      when: target | lower == 'patroni' or
+            (target | lower == 'system' and patroni_installation_method == "pip")
+
+    - name: Update all system packages (includes PostgreSQL and Patroni)
+      include_role:
+        name: update
+        tasks_from: system
+      when: target | lower == 'system'
+
+    - name: Start Services
+      include_role:
+        name: update
+        tasks_from: start_services
+  tags:
+    - update
+    - update-primary
+...

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -242,7 +242,7 @@
     - name: Update completed
       run_once: true
       debug:
-        msg: 
+        msg:
           - "PostgreSQL HA cluster update completed."
           - "Current version: {{ postgres_version.stdout }}"
       when: postgres_version.stdout is defined

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -67,6 +67,11 @@
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
       tags: always
   tasks:
+    - name: Stop read-only trafic
+      include_role:
+        name: update
+        tasks_from: stop_traffic
+
     - name: Stop Services
       include_role:
         name: update
@@ -95,6 +100,11 @@
       include_role:
         name: update
         tasks_from: start_services
+
+    - name: Start read-only trafic
+      include_role:
+        name: update
+        tasks_from: start_traffic
   tags:
     - update
     - update-secondary

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -208,7 +208,7 @@
   vars_files:
     - vars/main.yml
   vars:
-    update_extensions: true  # ot 'false', to avoid updating extensions
+    update_extensions: true  # or 'false', to avoid updating extensions
   tasks:
     - name: Update extensions
       include_role:

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -42,12 +42,30 @@
       when: inventory_hostname in groups['primary']
       tags: always
 
-- name: "(1/2) UPDATE: secondary"
+- name: "(1/3) PRE-UPDATE: Perform Pre-Checks"
+  hosts: 'primary:secondary'
+  gather_facts: false
+  become: true
+  become_user: postgres
+  any_errors_fatal: true
+  vars:
+    max_replication_lag_bytes: 10485760  # 10 MiB
+    max_transaction_sec: 15  # seconds
+  tasks:
+    - name: Running Pre-Checks
+      include_role:
+        name: update
+        tasks_from: pre_checks
+  tags:
+    - update
+    - pre-checks
+
+- name: "(2/3) UPDATE: secondary"
   hosts: secondary
   serial: 1  # update replicas one by one
   gather_facts: false
   become: true
-  become_user: root
+  become_method: sudo
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
   vars_files:
@@ -109,7 +127,7 @@
     - update
     - update-secondary
 
-- name: "(2/2) UPDATE: primary"
+- name: "(3/3) UPDATE: primary"
   hosts: primary
   gather_facts: false
   become: true

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -43,7 +43,7 @@
       when: inventory_hostname in groups['primary']
       tags: always
 
-- name: "(1/3) PRE-UPDATE: Perform Pre-Checks"
+- name: "(1/4) PRE-UPDATE: Perform Pre-Checks"
   hosts: 'primary:secondary'
   gather_facts: false
   become: true
@@ -61,7 +61,7 @@
     - update
     - pre-checks
 
-- name: "(2/3) UPDATE: secondary"
+- name: "(2/4) UPDATE: secondary"
   hosts: secondary
   serial: 1  # update replicas one by one
   gather_facts: false
@@ -128,7 +128,7 @@
     - update
     - update-secondary
 
-- name: "(3/3) UPDATE: primary"
+- name: "(3/4) UPDATE: primary"
   hosts: primary
   gather_facts: false
   become: true
@@ -195,8 +195,30 @@
       include_role:
         name: update
         tasks_from: start_traffic
+  tags:
+    - update
+    - update-primary
 
+- name: "(4/4) POST-UPDATE: Update extensions"
+  hosts: postgres_cluster
+  gather_facts: false
+  become: true
+  become_user: postgres
+  any_errors_fatal: true
+  vars_files:
+    - vars/main.yml
+  vars:
+    update_extensions: true  # ot 'false', to avoid updating extensions
+  tasks:
+    - name: Update extensions
+      include_role:
+        name: update
+        tasks_from: extensions
+      when: update_extensions | bool
+
+    # finish (info)
     - name: Check the Patroni cluster state
+      run_once: true
       become: true
       become_user: postgres
       command: patronictl -c /etc/patroni/patroni.yml list
@@ -208,11 +230,12 @@
     - name: List the Patroni cluster members
       debug:
         msg: "{{ patronictl_result.stdout_lines }}"
+      when: patronictl_result.stdout_lines is defined
 
     - name: Update completed
       debug:
         msg: "PostgreSQL HA cluster update completed."
   tags:
     - update
-    - update-primary
+    - update-extensions
 ...

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -61,7 +61,7 @@
     - update
     - pre-checks
 
-- name: "(2/4) UPDATE: secondary"
+- name: "(2/4) UPDATE: Secondary"
   hosts: secondary
   serial: 1  # update replicas one by one
   gather_facts: false
@@ -128,7 +128,7 @@
     - update
     - update-secondary
 
-- name: "(3/4) UPDATE: primary"
+- name: "(3/4) UPDATE: Primary"
   hosts: primary
   gather_facts: false
   become: true

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -24,6 +24,7 @@
       when: hostvars[item]['patroni_leader_result']['status'] == 200
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
+      tags: always
 
     - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
       add_host:


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/147

`update_pgcluster.yml` playbook is designed to update the PostgreSQL HA Cluster to a new minor version (for example 15.1->15.2).

By default, only PostgreSQL packages defined in the postgresql_packages variable are updated (vars/Debian.yml or vars/RedHat.yml). In addition, you can update Patroni or the entire system. 


**Update PostgreSQL**

`ansible-playbook update_pgcluster.yml`

**Update Patroni** 

`ansible-playbook update_pgcluster.yml -e target=patroni`

**Update all system packages (includes PostgreSQL and Patroni)**

`ansible-playbook update_pgcluster.yml -e target=system`
