### PR TITLE
Improvements and simplification of the cluster scaling process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ During the run this playbook, the new nodes will be prepared in the same way as 
 1. Add a new node to the inventory file with the variable `new_node=true`
 2. Run `add_pgnode.yml` playbook 
 
-In this example, we add a node with the address 10.128.64.144
+In this example, we add a node with the IP address 10.128.64.144
 
 ```
 [master]
@@ -323,29 +323,34 @@ ansible-playbook add_pgnode.yml
 
 <details><summary>Add new haproxy balancer node</summary><p>
 
-During the run this playbook, the new balancer node will be prepared in the same way as when first deployment the cluster. But unlike the initial deployment, **all necessary configuration files will be copied from the server specified in the [master] group**.
+During the run this playbook, the new balancer node will be prepared in the same way as when first deployment the cluster. But unlike the initial deployment, all necessary **configuration files will be copied from the first server specified in the inventory file in the "balancers" group**.
 
 > :heavy_exclamation_mark: Please test it in your test enviroment before using in a production.
 
 ###### Steps to add a new balancer node:
 
-1. Go to the playbook directory
+Note: Used if the `with_haproxy_load_balancing` variable is set to `true`
 
-2. Edit the inventory file
+1. Add a new node to the inventory file with the variable `new_node=true`
 
-Specify the ip address of one of the existing balancer nodes in the [master] group, and the new balancer node (which you want to add) in the [balancers] group.
+2. Run `add_balancer.yml` playbook 
 
-> :heavy_exclamation_mark: Attention! The list of Firewall ports is determined dynamically based on the group in which the host is specified. \
-If you adding a new haproxy balancer node to one of the existing nodes from the [etcd_cluster] or [master]/[replica] groups, you can rewrite the iptables rules! \
-See firewall_allowed_tcp_ports_for.balancers variable in the system.yml file.
 
-3. Edit the `main.yml` variable file
+ In this example, we add a balancer node with the IP address 10.128.64.144
 
-Specify `with_haproxy_load_balancing: true`
+```
+[balancers]
+10.128.64.140
+10.128.64.142
+10.128.64.143
+10.128.64.144 new_node=true
+```
 
-4. Run playbook:
+Run playbook:
 
-`ansible-playbook add_balancer.yml`
+```
+ansible-playbook add_balancer.yml
+```
 
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ In addition to deploying new clusters, this playbook also support the deployment
 - [Deployment: quick start](#deployment-quick-start)
 - [Variables](#variables)
 - [Cluster Scaling](#cluster-scaling)
-    - [Preparation:](#preparation)
-    - [Steps to add a new node:](#steps-to-add-a-new-node)
-    - [Steps to add a new banlancer node:](#steps-to-add-a-new-banlancer-node)
+    - [Steps to add a new postgres node](#steps-to-add-a-new-postgres-node)
+    - [Steps to add a new balancer node](#steps-to-add-a-new-balancer-node)
 - [Restore and Cloning](#restore-and-cloning)
     - [Create cluster with pgBackRest:](#create-cluster-with-pgbackrest)
     - [Create cluster with WAL-G:](#create-cluster-with-wal-g)
@@ -287,49 +286,48 @@ See the vars/[main.yml](./vars/main.yml), [system.yml](./vars/system.yml) and ([
 
 
 ## Cluster Scaling
-Add new postgresql node to existing cluster
-<details><summary>Click here to expand...</summary><p>
 
 After you successfully deployed your PostgreSQL HA cluster, you may need to scale it further. \
 Use the `add_pgnode.yml` playbook for this.
 
-> :grey_exclamation: This playbook does not scaling the etcd cluster and haproxy balancers.
+<details><summary>Add new postgresql node to existing cluster</summary><p>
+
+> This playbook does not scaling the etcd cluster or consul cluster.
 
 During the run this playbook, the new nodes will be prepared in the same way as when first deployment the cluster. But unlike the initial deployment, all the necessary **configuration files will be copied from the master server**.
 
-###### Preparation:
+###### Steps to add a new Postgres node:
 
-1. Add a new node (*or subnet*) to the `pg_hba.conf` file on all nodes in your cluster
-2. Apply pg_hba.conf for all PostgreSQL (see `patronictl reload --help`)
+1. Add a new node to the inventory file with the variable `new_node=true`
+2. Run `add_pgnode.yml` playbook 
 
-###### Steps to add a new node:
+In this example, we add a node with the address 10.128.64.144
 
-3. Go to the playbook directory
-4. Edit the inventory file
+```
+[master]
+10.128.64.140 hostname=pgnode01 postgresql_exists='true'
 
-Specify the ip address of one of the nodes of the cluster in the [master] group, and the new node (which you want to add) in the [replica] group.
+[replica]
+10.128.64.142 hostname=pgnode02 postgresql_exists='true'
+10.128.64.143 hostname=pgnode03 postgresql_exists='true'
+10.128.64.144 hostname=pgnode04 postgresql_exists='false' new_node=true
+```
 
-5. Edit the variable files
+Run playbook:
 
-Variables that should be the same on all cluster nodes: \
-`with_haproxy_load_balancing`,` postgresql_version`, `postgresql_data_dir`,` postgresql_conf_dir`.
-
-6. Run playbook:
-
-`ansible-playbook add_pgnode.yml`
+```
+ansible-playbook add_pgnode.yml
+```
 
 </p></details>
 
-Add new haproxy balancer node
-<details><summary>Click here to expand...</summary><p>
-
-Use the `add_balancer.yml` playbook for this.
+<details><summary>Add new haproxy balancer node</summary><p>
 
 During the run this playbook, the new balancer node will be prepared in the same way as when first deployment the cluster. But unlike the initial deployment, **all necessary configuration files will be copied from the server specified in the [master] group**.
 
 > :heavy_exclamation_mark: Please test it in your test enviroment before using in a production.
 
-###### Steps to add a new banlancer node:
+###### Steps to add a new balancer node:
 
 1. Go to the playbook directory
 

--- a/README.md
+++ b/README.md
@@ -325,8 +325,6 @@ ansible-playbook add_pgnode.yml
 
 During the run this playbook, the new balancer node will be prepared in the same way as when first deployment the cluster. But unlike the initial deployment, all necessary **configuration files will be copied from the first server specified in the inventory file in the "balancers" group**.
 
-> :heavy_exclamation_mark: Please test it in your test enviroment before using in a production.
-
 ###### Steps to add a new balancer node:
 
 Note: Used if the `with_haproxy_load_balancing` variable is set to `true`

--- a/add_balancer.yml
+++ b/add_balancer.yml
@@ -38,6 +38,7 @@
         new_nodes: "{{ new_nodes | default([]) + [item] }}"
       when: hostvars[item]['new_node'] | default(false) | bool
       loop: "{{ groups['balancers'] }}"
+      tags: always
 
     # Stop, if no nodes found with new_node variable
     - name: "Pre-Check error. No nodes found with new_node set to true"
@@ -50,6 +51,7 @@
       run_once: true
       debug:
         var: new_nodes
+      tags: always
 
     - name: Update apt cache
       apt:
@@ -121,6 +123,7 @@
         groups: new_balancer
       loop: "{{ new_nodes }}"
       changed_when: false
+      tags: always
 
 - hosts: new_balancer
   become: true

--- a/add_balancer.yml
+++ b/add_balancer.yml
@@ -1,11 +1,132 @@
 ---
 
-- name: Add haproxy balancer node
+- name: Add haproxy balancer node (to the cluster "{{ patroni_cluster_name }}")
   hosts: balancers
   become: true
   become_method: sudo
   any_errors_fatal: true
   gather_facts: true
+  vars_files:
+    - vars/main.yml
+    - vars/system.yml
+
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    - name: '[Pre-Check] Checking Linux distribution'
+      fail:
+        msg: "{{ ansible_distribution }} is not supported"
+      when: ansible_distribution not in os_valid_distributions
+
+    - name: '[Pre-Check] Checking version of OS Linux'
+      fail:
+        msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
+      when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
+
+    - name: '[Pre-Check] Check if there is a node with new_node set to true'
+      set_fact:
+        new_nodes: "{{ new_nodes | default([]) + [item] }}"
+      when: hostvars[item]['new_node'] | default(false) | bool
+      loop: "{{ groups['balancers'] }}"
+
+    # Stop, if no nodes found with new_node variable
+    - name: "Pre-Check error. No nodes found with new_node set to true"
+      run_once: true
+      fail:
+        msg: "Please specify the new_node=true variable for the new balancer server to add it to the existing cluster."
+      when: new_nodes | default([]) | length < 1
+
+    - name: Print a list of new balancer nodes
+      run_once: true
+      debug:
+        var: new_nodes
+
+    - name: Update apt cache
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      environment: "{{ proxy_env | default({}) }}"
+      when:
+        - new_node | default(false) | bool
+        - ansible_os_family == "Debian"
+        - installation_method == "repo"
+
+    - name: Make sure the gnupg and apt-transport-https packages are present
+      apt:
+        pkg:
+          - gnupg
+          - apt-transport-https
+        state: present
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      environment: "{{ proxy_env | default({}) }}"
+      when:
+        - new_node | default(false) | bool
+        - ansible_os_family == "Debian"
+        - installation_method == "repo"
+
+    - name: Build a firewall_ports_dynamic_var
+      set_fact:
+        firewall_ports_dynamic_var: "{{ firewall_ports_dynamic_var | default([]) + (firewall_allowed_tcp_ports_for[item]) }}"
+      loop: "{{ hostvars[inventory_hostname].group_names }}"
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
+      tags: firewall
+
+    - name: Build a firewall_rules_dynamic_var
+      set_fact:
+        firewall_rules_dynamic_var: "{{ firewall_rules_dynamic_var | default([]) + (firewall_additional_rules_for[item]) }}"
+      loop: "{{ hostvars[inventory_hostname].group_names }}"
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
+      tags: firewall
+
+  roles:
+    - role: ansible-role-firewall
+      environment: "{{ proxy_env | default({}) }}"
+      vars:
+        firewall_allowed_tcp_ports: "{{ firewall_ports_dynamic_var | unique }}"
+        firewall_additional_rules: "{{ firewall_rules_dynamic_var | unique }}"
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
+      tags: firewall
+
+    - role: sysctl
+      when:
+        - new_node | default(false) | bool
+
+  tasks:
+    - name: Add host to group new_balancer (in-memory inventory)
+      add_host:
+        name: "{{ item }}"
+        groups: new_balancer
+      loop: "{{ new_nodes }}"
+      changed_when: false
+
+- hosts: new_balancer
+  become: true
+  become_method: sudo
+  gather_facts: true
+  any_errors_fatal: true
   vars_files:
     - vars/main.yml
     - vars/system.yml
@@ -25,66 +146,9 @@
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
       tags: always
 
-    - name: Checking Linux distribution
-      fail:
-        msg: "{{ ansible_distribution }} is not supported"
-      when: ansible_distribution not in os_valid_distributions
-
-    - name: Checking version of OS Linux
-      fail:
-        msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
-      when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
-
-    - name: Update apt cache
-      apt:
-        update_cache: true
-        cache_valid_time: 3600
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-      environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method == "repo"
-
-    - name: Make sure the gnupg and apt-transport-https packages are present
-      apt:
-        pkg:
-          - gnupg
-          - apt-transport-https
-        state: present
-      register: apt_status
-      until: apt_status is success
-      delay: 5
-      retries: 3
-      environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method == "repo"
-
-    - name: Build a firewall_ports_dynamic_var
-      set_fact:
-        firewall_ports_dynamic_var: "{{ firewall_ports_dynamic_var | default([]) + (firewall_allowed_tcp_ports_for[item]) }}"
-      loop: "{{ hostvars[inventory_hostname].group_names }}"
-      when: firewall_enabled_at_boot|bool
-      tags: firewall
-
-    - name: Build a firewall_rules_dynamic_var
-      set_fact:
-        firewall_rules_dynamic_var: "{{ firewall_rules_dynamic_var | default([]) + (firewall_additional_rules_for[item]) }}"
-      loop: "{{ hostvars[inventory_hostname].group_names }}"
-      when: firewall_enabled_at_boot|bool
-      tags: firewall
-
   roles:
-    - role: ansible-role-firewall
-      environment: "{{ proxy_env | default({}) }}"
-      vars:
-        firewall_allowed_tcp_ports: "{{ firewall_ports_dynamic_var | unique }}"
-        firewall_additional_rules: "{{ firewall_rules_dynamic_var | unique }}"
-      when: firewall_enabled_at_boot|bool
-      tags: firewall
-
     - role: hostname
     - role: resolv_conf
-    - role: sysctl
 
     - role: haproxy
       when: with_haproxy_load_balancing|bool

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -122,6 +122,10 @@
       when:
         - new_node | default(false) | bool
 
+    - role: ssh-keys
+      when:
+        - enable_ssh_key_based_authentication | default(false) | bool
+
   tasks:
     - name: Add host to group new_replica (in-memory inventory)
       add_host:
@@ -166,7 +170,6 @@
     - role: locales
     - role: timezone
     - role: ntp
-    - role: ssh-keys
     - role: copy
 
 - hosts: pgbackrest:new_replica

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -40,6 +40,7 @@
         new_nodes: "{{ new_nodes | default([]) + [item] }}"
       when: hostvars[item]['new_node'] | default(false) | bool
       loop: "{{ groups['replica'] }}"
+      tags: always
 
     # Stop, if no nodes found with new_node variable
     - name: "Pre-Check error. No nodes found with new_node set to true"
@@ -52,6 +53,7 @@
       run_once: true
       debug:
         var: new_nodes
+      tags: always
 
     - name: Add a new node to pg_hba.conf on existing cluster nodes
       include_role:
@@ -133,6 +135,7 @@
         groups: new_replica
       loop: "{{ new_nodes }}"
       changed_when: false
+      tags: always
 
 - hosts: new_replica
   become: true

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: PostgreSQL High-Availability Cluster Scaling (add replica node)
-  hosts: replica
+- name: PostgreSQL High-Availability Cluster Scaling (add a replica node to the cluster "{{ patroni_cluster_name }}")
+  hosts: postgres_cluster
   become: true
   become_method: sudo
   any_errors_fatal: true
@@ -23,15 +23,33 @@
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
       tags: always
 
-    - name: Checking Linux distribution
+    - name: '[Pre-Check] Checking Linux distribution'
       fail:
         msg: "{{ ansible_distribution }} is not supported"
       when: ansible_distribution not in os_valid_distributions
 
-    - name: Checking version of OS Linux
+    - name: '[Pre-Check] Checking version of OS Linux'
       fail:
         msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
       when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
+
+    - name: '[Pre-Check] Check if there is a node with new_node set to true'
+      set_fact:
+        new_nodes: "{{ new_nodes | default([]) + [item] }}"
+      when: hostvars[item]['new_node'] | default(false) | bool
+      loop: "{{ groups['replica'] }}"
+
+    # Stop, if no nodes found with new_node variable
+    - name: "Pre-Check error. No nodes found with new_node set to true"
+      run_once: true
+      fail:
+        msg: "Please specify the new_node=true variable for the new server to add it to the existing cluster."
+      when: new_nodes | default([]) | length < 1
+
+    - name: Print a list of new nodes
+      run_once: true
+      debug:
+        var: new_nodes
 
     - name: Update apt cache
       apt:
@@ -42,7 +60,10 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method == "repo"
+      when:
+        - new_node | default(false) | bool
+        - ansible_os_family == "Debian"
+        - installation_method == "repo"
 
     - name: Make sure the gnupg and apt-transport-https packages are present
       apt:
@@ -55,20 +76,27 @@
       delay: 5
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
-      when: ansible_os_family == "Debian" and installation_method == "repo"
+      when:
+        - new_node | default(false) | bool
+        - ansible_os_family == "Debian"
+        - installation_method == "repo"
 
     - name: Build a firewall_ports_dynamic_var
       set_fact:
         firewall_ports_dynamic_var: "{{ firewall_ports_dynamic_var | default([]) + (firewall_allowed_tcp_ports_for[item]) }}"
       loop: "{{ hostvars[inventory_hostname].group_names }}"
-      when: firewall_enabled_at_boot|bool
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
       tags: firewall
 
     - name: Build a firewall_rules_dynamic_var
       set_fact:
         firewall_rules_dynamic_var: "{{ firewall_rules_dynamic_var | default([]) + (firewall_additional_rules_for[item]) }}"
       loop: "{{ hostvars[inventory_hostname].group_names }}"
-      when: firewall_enabled_at_boot|bool
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
       tags: firewall
 
   roles:
@@ -77,9 +105,46 @@
       vars:
         firewall_allowed_tcp_ports: "{{ firewall_ports_dynamic_var | unique }}"
         firewall_additional_rules: "{{ firewall_rules_dynamic_var | unique }}"
-      when: firewall_enabled_at_boot|bool
+      when:
+        - new_node | default(false) | bool
+        - firewall_enabled_at_boot | bool
       tags: firewall
 
+    - role: sysctl
+      when:
+        - new_node | default(false) | bool
+
+  tasks:
+    - name: Add host to group new_replica (in-memory inventory)
+      add_host:
+        name: "{{ item }}"
+        groups: new_replica
+      loop: "{{ new_nodes }}"
+      changed_when: false
+
+- hosts: new_replica
+  become: true
+  become_method: sudo
+  gather_facts: true
+  any_errors_fatal: true
+  vars_files:
+    - vars/main.yml
+    - vars/system.yml
+
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
+  roles:
     - role: hostname
     - role: resolv_conf
     - role: etc_hosts
@@ -87,7 +152,6 @@
     - role: packages
     - role: sudo
     - role: swap
-    - role: sysctl
     - role: transparent_huge_pages
     - role: pam_limits
     - role: io-scheduler
@@ -97,7 +161,7 @@
     - role: ssh-keys
     - role: copy
 
-- hosts: pgbackrest:postgres_cluster
+- hosts: pgbackrest:new_replica
   become: true
   become_method: sudo
   gather_facts: true
@@ -124,7 +188,7 @@
   when: dcs_type == "consul"
   tags: consul
 
-- hosts: replica
+- hosts: new_replica
   become: true
   become_method: sudo
   gather_facts: true

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -6,6 +6,8 @@
   become_method: sudo
   any_errors_fatal: true
   gather_facts: true
+  handlers:
+    - include: roles/patroni/handlers/main.yml
   vars_files:
     - vars/main.yml
     - vars/system.yml
@@ -50,6 +52,12 @@
       run_once: true
       debug:
         var: new_nodes
+
+    - name: Add a new node to pg_hba.conf on existing cluster nodes
+      include_role:
+        name: patroni/config
+        tasks_from: pg_hba
+      when: not new_node | default(false) | bool
 
     - name: Update apt cache
       apt:

--- a/inventory
+++ b/inventory
@@ -3,6 +3,7 @@
 
 # "postgresql_exists='true'" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
+# "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
 
 # In this example, all components will be installed on PostgreSQL nodes.
 # You can deploy the haproxy balancers and the etcd or consul cluster on other dedicated servers (recomended).
@@ -34,6 +35,7 @@
 [replica]
 10.128.64.142 hostname=pgnode02 postgresql_exists='false'
 10.128.64.143 hostname=pgnode03 postgresql_exists='false'
+#10.128.64.144 hostname=pgnode04 postgresql_exists='false' new_node=true
 
 [postgres_cluster:children]
 master

--- a/inventory
+++ b/inventory
@@ -27,6 +27,7 @@
 10.128.64.140
 10.128.64.142
 10.128.64.143
+#10.128.64.144 new_node=true
 
 # PostgreSQL nodes
 [master]

--- a/roles/confd/tasks/main.yml
+++ b/roles/confd/tasks/main.yml
@@ -57,7 +57,7 @@
   tags: confd_conf, confd
 
 - block:  # for add_balancer.yml
-    - name: Fetch confd.toml, haproxy.toml, haproxy.tmpl conf files from master
+    - name: "Fetch confd.toml, haproxy.toml, haproxy.tmpl conf files from {{ groups.balancers[0] }}"
       run_once: true
       fetch:
         src: "{{ item }}"
@@ -68,7 +68,7 @@
         - /etc/confd/confd.toml
         - /etc/confd/conf.d/haproxy.toml
         - /etc/confd/templates/haproxy.tmpl
-      delegate_to: "{{ groups.master[0] }}"
+      delegate_to: "{{ groups.balancers[0] }}"
 
     - name: Copy confd.toml, haproxy.toml, haproxy.tmpl conf files to replica
       copy:
@@ -81,6 +81,17 @@
       loop_control:
         label: "{{ item.dest }}"
       notify: "restart confd"
+
+    - name: Remove confd.toml, haproxy.toml, haproxy.tmpl files from localhost
+      run_once: true
+      file:
+        path: "files/{{ item }}"
+        state: absent
+      loop:
+        - confd.toml
+        - haproxy.toml
+        - haproxy.tmpl
+      delegate_to: localhost
 
     - name: Prepare haproxy.tmpl template file (replace "bind" for stats)
       lineinfile:

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -400,7 +400,7 @@
   tags: haproxy, haproxy_service, load_balancing
 
 - block:  # for add_balancer.yml
-    - name: Fetch haproxy.cfg file from master
+    - name: "Fetch haproxy.cfg file from {{ groups.balancers[0] }}"
       run_once: true
       fetch:
         src: /etc/haproxy/haproxy.cfg
@@ -408,7 +408,7 @@
         validate_checksum: true
         flat: true
       notify: "restart haproxy"
-      delegate_to: "{{ groups.master[0] }}"
+      delegate_to: "{{ groups.balancers[0] }}"
 
     - name: Copy haproxy.cfg file to replica
       copy:
@@ -417,6 +417,13 @@
         owner: haproxy
         group: haproxy
       notify: "restart haproxy"
+
+    - name: Remove haproxy.cfg file from localhost
+      run_once: true
+      file:
+        path: files/haproxy.cfg
+        state: absent
+      delegate_to: localhost
 
     - name: Prepare haproxy.cfg conf file (replace "bind")
       lineinfile:

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -51,14 +51,14 @@
   tags: keepalived_conf, keepalived
 
 - block:  # for add_balancer.yml
-    - name: Fetch keepalived.conf conf file from master
+    - name: "Fetch keepalived.conf conf file from {{ groups.balancers[0] }}"
       run_once: true
       fetch:
         src: /etc/keepalived/keepalived.conf
         dest: files/keepalived.conf
         validate_checksum: true
         flat: true
-      delegate_to: "{{ groups.master[0] }}"
+      delegate_to: "{{ groups.balancers[0] }}"
 
     - name: Copy keepalived.conf conf file to replica
       copy:
@@ -66,6 +66,13 @@
         dest: /etc/keepalived/keepalived.conf
       notify: "restart keepalived"
 
+    - name: Remove keepalived.conf file from localhost
+      run_once: true
+      file:
+        path: files/keepalived.conf
+        state: absent
+      delegate_to: localhost
+ 
     - name: Prepare keepalived.conf conf file (replace "interface")
       lineinfile:
         path: /etc/keepalived/keepalived.conf

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -72,7 +72,7 @@
         path: files/keepalived.conf
         state: absent
       delegate_to: localhost
- 
+
     - name: Prepare keepalived.conf conf file (replace "interface")
       lineinfile:
         path: /etc/keepalived/keepalived.conf

--- a/roles/patroni/config/tasks/main.yml
+++ b/roles/patroni/config/tasks/main.yml
@@ -39,16 +39,6 @@
   notify: "reload patroni"
   tags: patroni, patroni_conf
 
-- name: Update pg_hba.conf
-  template:
-    src: ../templates/pg_hba.conf.j2
-    dest: "{{ postgresql_conf_dir }}/pg_hba.conf"
-    owner: postgres
-    group: postgres
-    mode: 0640
-  notify: "reload postgres"
-  tags: patroni, patroni_conf, pg_hba, pg_hba_generate
-
 - block:
     - name: Update postgresql parameters in DCS
       uri:
@@ -78,5 +68,9 @@
   loop: "{{ postgresql_parameters }}"
   when: item.value == "null"
   tags: patroni, patroni_conf
+
+# Update pg_hba.conf
+- import_tasks: pg_hba.yml
+  tags: patroni, patroni_conf, pg_hba, pg_hba_generate
 
 ...

--- a/roles/patroni/config/tasks/pg_hba.yml
+++ b/roles/patroni/config/tasks/pg_hba.yml
@@ -1,0 +1,11 @@
+---
+- name: Update pg_hba.conf
+  template:
+    src: ../templates/pg_hba.conf.j2
+    dest: "{{ postgresql_conf_dir }}/pg_hba.conf"
+    owner: postgres
+    group: postgres
+    mode: 0640
+  notify: "reload postgres"
+  tags: pg_hba, pg_hba_generate
+...


### PR DESCRIPTION
Playbook `add_pgnode.yml`

- Previously, you had to add a new node yourself to the pg_hba.conf file on all nodes of existing cluster before adding a new node to the cluster. Now it will be done automatically.

- Previously, it was necessary to add a new node (which you want to add to existing cluster) in the [replica] group and at the same time remove other nodes from the replica group from inventory in order to add_pgnode.yml playbook was executed specifically for the new server. \
Now you do not need to do this, you just need to specify the variable `new_node=true` for the server that you are adding to the cluster and the playbook will be executed only on this server.

Playbook `add_balancer.yml`

- Previously, configuration files were copied from the server from the master group. This is not very convenient, for example, when the load balancers are placed on separate servers. Now the files are copied from the first server specified in the inventory file in the balancers group.
- Specify the variable `new_node=true` for the balancer server that you are adding to the cluster and the playbook will be executed only on this server.