### PR TITLE
fix(balancers): install requirement packages

### DIFF
--- a/balancers.yml
+++ b/balancers.yml
@@ -72,6 +72,35 @@
       when: firewall_enabled_at_boot|bool
       tags: firewall
 
+    # Install packages from repository
+    # RedHat
+    - name: Install system packages
+      package:
+        name: "{{ item }}"
+        state: present
+      loop: "{{ system_packages }}"
+      register: package_status
+      until: package_status is success
+      delay: 5
+      retries: 3
+      environment: "{{ proxy_env | default({}) }}"
+      when: ansible_os_family == "RedHat" and installation_method == "repo"
+      tags: install_packages
+
+    # Debian
+    - name: Install system packages
+      apt:
+        name: "{{ item }}"
+        state: present
+      loop: "{{ system_packages }}"
+      environment: "{{ proxy_env | default({}) }}"
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      when: ansible_os_family == "Debian" and installation_method == "repo"
+      tags: install_packages
+
   roles:
     - role: ansible-role-firewall
       environment: "{{ proxy_env | default({}) }}"


### PR DESCRIPTION
Balancers must install a system_packages:
> An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'semanage'
fatal: [10.10.10.13]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libsemanage-python) on ...'s Python /usr/bin/python3. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
...ignoring
