### PR TITLE
requirements.dev: Update docker-py to version 6.1.0

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,7 @@
 ansible-lint==6.15.0
 yamllint==1.31.0
-molecule==5.0.1
-molecule-plugins[docker]==23.4.1
+molecule==5.0.0
+molecule-plugins[docker]==23.4.0
 docker==6.1.0
-ansible-compat==4.0.2
-urllib3==2.0.2
-requests=2.30.0
+ansible-compat==3.0.1
+urllib3==1.26.15

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,4 @@ molecule==5.0.0
 molecule-plugins[docker]==23.4.0
 docker==6.1.0
 ansible-compat==3.0.1
+urllib3==1.26.15

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,8 @@
 ansible-lint==6.15.0
 yamllint==1.31.0
-molecule==5.0.0
-molecule-plugins[docker]==23.4.0
+molecule==5.0.1
+molecule-plugins[docker]==23.4.1
 docker==6.1.0
-ansible-compat==3.0.1
-urllib3==1.26.15
+ansible-compat==4.0.2
+urllib3==2.0.2
+requests=2.30.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,5 +2,5 @@ ansible-lint==6.15.0
 yamllint==1.31.0
 molecule==5.0.0
 molecule-plugins[docker]==23.4.0
-docker==6.0.1
+docker==6.1.0
 ansible-compat==3.0.1


### PR DESCRIPTION
urllib3 v2 incompatibility: https://github.com/docker/docker-py/issues/3113

Release notes: https://github.com/docker/docker-py/releases/tag/6.1.0