### PR TITLE
Simple cluster deployment with timescaledb

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,6 +22,7 @@ skip_list:
   - no-relative-paths
   - key-order[task] # TODO
   - no-free-form
+  - var-naming[no-role-prefix]
 
 exclude_paths:
   - roles/consul/ # TODO - https://github.com/ansible-community/ansible-consul/pull/520

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -7,11 +7,22 @@
     - vars/main.yml
   vars:
     minimal_ansible_version: 2.7.0
+    timescale_minimal_pg_version: 12  # if enable_timescale is defined
   tasks:
     - name: Checking ansible version
       fail:
         msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
       when: ansible_version.full is version(minimal_ansible_version, '<')
+
+    - name: Checking PostgreSQL version
+      fail:
+        msg:
+         - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
+         - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
+      when:
+       - enable_timescale is defined
+       - enable_timescale | bool
+       - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
 
 - name: Set maintenance variable
   hosts: all
@@ -149,6 +160,36 @@
     - name: Include OS-specific variables
       include_vars: "vars/RedHat.yml"
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # timescaledb (if enable_timescale is defined)
+    - block:
+        - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
+          set_fact:
+            # This complex line does several things:
+            # 1. It takes the current list of PostgreSQL parameters,
+            # 2. Removes any item where the option is 'shared_preload_libraries',
+            # 3. Then appends a new 'shared_preload_libraries' item at the end.
+            # The new value of this item is based on whether 'timescaledb' is already present in the old value.
+            # If it is not present, it appends ',timescaledb' to the old value. Otherwise, it leaves the value unchanged.
+            postgresql_parameters: >-
+              {{ postgresql_parameters | rejectattr('option', 'equalto', 'shared_preload_libraries') | list
+              + [{ 'option': 'shared_preload_libraries', 'value': new_value }] }}
+          vars:
+            # Find the last item in postgresql_parameters where the option is 'shared_preload_libraries'
+            shared_preload_libraries_item:
+              "{{ postgresql_parameters | selectattr('option', 'equalto', 'shared_preload_libraries') | list | last | default({ 'value': '' }) }}"
+            # Determine the new value based on whether 'timescaledb' is already present
+            new_value: >-
+              {{
+                (shared_preload_libraries_item.value ~ (',' if shared_preload_libraries_item.value else '')
+                if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else shared_preload_libraries_item.value)
+                ~ ('timescaledb' if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else '')
+              }}
+      when:
+        - installation_method == "repo"
+        - enable_timescale is defined
+        - enable_timescale | bool
       tags: always
 
   roles:

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -17,8 +17,8 @@
     - name: Checking PostgreSQL version
       fail:
         msg:
-         - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
-         - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
+          - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
+          - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
       when:
        - enable_timescale is defined
        - enable_timescale | bool

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -20,9 +20,9 @@
           - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
           - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
       when:
-       - enable_timescale is defined
-       - enable_timescale | bool
-       - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
+        - enable_timescale is defined
+        - enable_timescale | bool
+        - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
 
 - name: Set maintenance variable
   hosts: all

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -17,8 +17,8 @@
     - name: Checking PostgreSQL version
       fail:
         msg:
-         - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
-         - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
+          - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
+          - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
       when:
        - enable_timescale is defined
        - enable_timescale | bool

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -20,9 +20,9 @@
           - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
           - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
       when:
-       - enable_timescale is defined
-       - enable_timescale | bool
-       - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
+        - enable_timescale is defined
+        - enable_timescale | bool
+        - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
 
 - name: Gathering facts from all servers and preparing the system
   hosts: all

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -7,11 +7,22 @@
     - vars/main.yml
   vars:
     minimal_ansible_version: 2.7.0
+    timescale_minimal_pg_version: 12  # if enable_timescale is defined
   tasks:
     - name: Checking ansible version
       fail:
         msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
       when: ansible_version.full is version(minimal_ansible_version, '<')
+
+    - name: Checking PostgreSQL version
+      fail:
+        msg:
+         - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
+         - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
+      when:
+       - enable_timescale is defined
+       - enable_timescale | bool
+       - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
 
 - name: Gathering facts from all servers and preparing the system
   hosts: all
@@ -227,6 +238,36 @@
     - name: Include OS-specific variables
       include_vars: "vars/RedHat.yml"
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # timescaledb (if enable_timescale is defined)
+    - block:
+        - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
+          set_fact:
+            # This complex line does several things:
+            # 1. It takes the current list of PostgreSQL parameters,
+            # 2. Removes any item where the option is 'shared_preload_libraries',
+            # 3. Then appends a new 'shared_preload_libraries' item at the end.
+            # The new value of this item is based on whether 'timescaledb' is already present in the old value.
+            # If it is not present, it appends ',timescaledb' to the old value. Otherwise, it leaves the value unchanged.
+            postgresql_parameters: >-
+              {{ postgresql_parameters | rejectattr('option', 'equalto', 'shared_preload_libraries') | list
+              + [{ 'option': 'shared_preload_libraries', 'value': new_value }] }}
+          vars:
+            # Find the last item in postgresql_parameters where the option is 'shared_preload_libraries'
+            shared_preload_libraries_item:
+              "{{ postgresql_parameters | selectattr('option', 'equalto', 'shared_preload_libraries') | list | last | default({ 'value': '' }) }}"
+            # Determine the new value based on whether 'timescaledb' is already present
+            new_value: >-
+              {{
+                (shared_preload_libraries_item.value ~ (',' if shared_preload_libraries_item.value else '')
+                if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else shared_preload_libraries_item.value)
+                ~ ('timescaledb' if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else '')
+              }}
+      when:
+        - installation_method == "repo"
+        - enable_timescale is defined
+        - enable_timescale | bool
       tags: always
 
   roles:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,7 +19,7 @@
     - name: Set variables for TimescaleDB cluster deployment test
       set_fact:
         enable_timescale: true
-      when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04')
+      when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '<'))
 
 - import_playbook: ../../deploy_pgcluster.yml
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,6 +14,7 @@
         with_haproxy_load_balancing: true
         consul_node_role: server  # if dcs_type: "consul"
         consul_bootstrap_expect: true  # if dcs_type: "consul"
+        enable_timescale: true  # TimescaleDB cluster deployment test
         cacheable: true
 
 - import_playbook: ../../deploy_pgcluster.yml

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,8 +14,12 @@
         with_haproxy_load_balancing: true
         consul_node_role: server  # if dcs_type: "consul"
         consul_bootstrap_expect: true  # if dcs_type: "consul"
-        enable_timescale: true  # TimescaleDB cluster deployment test
         cacheable: true
+
+    - name: Set variables for TimescaleDB cluster deployment test
+      set_fact:
+        enable_timescale: true
+      when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04')
 
 - import_playbook: ../../deploy_pgcluster.yml
 

--- a/roles/add-repository/tasks/main.yml
+++ b/roles/add-repository/tasks/main.yml
@@ -169,4 +169,36 @@
   when: installation_method == "repo" and ansible_os_family == "RedHat"
   tags: add_repo
 
+# timescaledb (if enable_timescale is defined)
+- block:
+    # Debian based
+    - name: Add TimescaleDB repository apt-key
+      apt_key:
+        url: "https://packagecloud.io/timescale/timescaledb/gpgkey"
+        state: present
+      when: ansible_os_family == "Debian"
+
+    - name: Add TimescaleDB repository
+      apt_repository:
+        repo: "deb https://packagecloud.io/timescale/timescaledb/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main"
+        state: present
+        update_cache: true
+      when: ansible_os_family == "Debian"
+
+    # RedHat based
+    - name: Add TimescaleDB repository
+      yum_repository:
+        name: "timescale_timescaledb"
+        description: "timescaledb repo"
+        baseurl: "https://packagecloud.io/timescale/timescaledb/el/{{ ansible_distribution_major_version }}/x86_64"
+        gpgkey: "https://packagecloud.io/timescale/timescaledb/gpgkey"
+        gpgcheck: "no"
+      when: ansible_os_family == "RedHat"
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - enable_timescale is defined
+    - enable_timescale | bool
+  tags: add_repo
+
 ...

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -145,4 +145,22 @@
   when: ansible_os_family == "Debian" and installation_method == "repo"
   tags: install_packages, install_postgres
 
+# timescaledb (if enable_timescale is defined)
+- name: Install TimescaleDB package
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - timescaledb-2-postgresql-{{ postgresql_version }}
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - enable_timescale is defined
+    - enable_timescale | bool
+  tags: install_packages, install_postgres, install_timescaledb
+
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -174,7 +174,7 @@ postgresql_parameters:
   - { option: "max_connections", value: "500" }
   - { option: "superuser_reserved_connections", value: "5" }
   - { option: "password_encryption", value: "{{ postgresql_password_encryption_algorithm }}" }
-  - { option: "max_locks_per_transaction", value: "64" }  # raise this value (ex. 512) if you have queries that touch many different tables (partitioning)
+  - { option: "max_locks_per_transaction", value: "512" }
   - { option: "max_prepared_transactions", value: "0" }
   - { option: "huge_pages", value: "try" }  # or "on" if you set "vm_nr_hugepages" in kernel parameters
   - { option: "shared_buffers", value: "{{ (ansible_memtotal_mb * 0.25)|int }}MB" }  # by default, 25% of RAM


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/235 , related issue: https://github.com/vitabaks/postgresql_cluster/issues/31

### Simple cluster deployment with timescaledb 

Now, to deploy a PostgreSQL High-Availability Cluster (based on "Patroni") with the [TimescaleDB](https://www.timescale.com) extension, you just need to specify only one variable `enable_timescale=true`

Example:

```
ansible-playbook deploy_pgcluster.yml -e "enable_timescale=true"
```

Note: supported PostgreSQL versions from 12 to 15