### PR TITLE
Add restart option in config_pgcluster.yml

### DIFF
--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -219,3 +219,189 @@
 
     - role: pgbouncer/config
       when: pgbouncer_install|bool and pgbouncer_generate_userlist|bool
+
+- name: config_pgcluster.yml | Check needed restart cluster and prepare for it
+  hosts: postgres_cluster
+  gather_facts: true
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  vars_files:
+    - vars/main.yml
+  tasks:
+    - name: "[Prepare] Get Patroni Cluster Leader Node"
+      uri:
+        url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/leader
+        status_code: 200
+      register: patroni_leader_result
+      changed_when: false
+      failed_when: false
+      tags: patroni_conf
+
+    - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
+      add_host:
+        name: "{{ item }}"
+        groups: primary
+      when: hostvars[item]['patroni_leader_result']['status'] == 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      tags: patroni_conf
+
+    - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
+      add_host:
+        name: "{{ item }}"
+        groups: secondary
+      when: hostvars[item]['patroni_leader_result']['status'] != 200
+      loop: "{{ groups['postgres_cluster'] }}"
+      changed_when: false
+      tags: patroni_conf
+
+    - name: "Print Patroni Cluster info"
+      debug:
+        msg:
+          - "Cluster Name: {{ patroni_cluster_name }}"
+          - "Cluster Leader: {{ ansible_hostname }}"
+      when: inventory_hostname in groups['primary']
+      tags: patroni_conf
+
+    - name: "Get count pg settings needed restart"
+      postgresql_query:
+        login_host: 'localhost'
+        login_user: '{{ patroni_superuser_username }}'
+        port: '{{ postgresql_port }}'
+        db: postgres
+        query: select count(*) as cnt from pg_settings where pending_restart is true
+      register: x
+      run_once: true
+      tags: patroni_conf
+
+    - name: "Set pg_pending_restart_count variable"
+      set_fact:
+        pg_pending_restart_count: "{{x.query_result[0].cnt}}"
+      tags: patroni_conf
+
+    - name: "Print pg_pending_restart_count"
+      debug: var=pg_pending_restart_count
+      tags:
+        - patroni_conf
+
+- name: config_pgcluster.yml | Restart patroni on secondary after config settings if need
+  hosts: secondary
+  serial: 1 # restart replicas one by one
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  vars_files:
+    - vars/main.yml
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+  tasks:
+    - name: Stop read-only traffic
+      include_role:
+        name: update
+        tasks_from: stop_traffic
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Stop Services
+      include_role:
+        name: update
+        tasks_from: stop_services
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Start Services
+      include_role:
+        name: update
+        tasks_from: start_services
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Start read-only traffic
+      include_role:
+        name: update
+        tasks_from: start_traffic
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+  tags:
+    - patroni_conf
+
+- name: config_pgcluster.yml | Restart patroni on master after config settings if need
+  hosts: primary
+  gather_facts: false
+  become: true
+  become_method: sudo
+  any_errors_fatal: true
+  environment: "{{ proxy_env | default({}) }}"
+  vars_files:
+    - vars/main.yml
+  pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+  tasks:
+    - name: "Switchover Patroni leader role"
+      include_role:
+        name: update
+        tasks_from: switchover
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Stop read-only traffic
+      include_role:
+        name: update
+        tasks_from: stop_traffic
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Stop Services
+      include_role:
+        name: update
+        tasks_from: stop_services
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Start Services
+      include_role:
+        name: update
+        tasks_from: start_services
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+
+    - name: Start read-only traffic
+      include_role:
+        name: update
+        tasks_from: start_traffic
+      when:
+        - pending_restart | bool
+        - pg_pending_restart_count | int > 0
+  tags:
+    - patroni_conf

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -251,6 +251,8 @@ postgresql_parameters:
 #  - { option: "", value: "" }
 #  - { option: "", value: "" }
 
+#set this variable to TRUE if you want automatic restart cluster after changing postgresql_variable that need restart in config_pgcluster.yml playbook
+pending_restart: False
 
 # specify additional hosts that will be added to the pg_hba.conf
 postgresql_pg_hba:


### PR DESCRIPTION
This MR add next functionality:
If changed postgresql_variable parameter, who need restart postgresql service and you set variable "pending_restart", True value, than patroni cluster will be restarted.