### PR TITLE
Add role 'pre-cheks'

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ In this example, we add a node with the IP address 10.128.64.144
 [replica]
 10.128.64.142 hostname=pgnode02 postgresql_exists='true'
 10.128.64.143 hostname=pgnode03 postgresql_exists='true'
-10.128.64.144 hostname=pgnode04 postgresql_exists='false' new_node=true
+10.128.64.144 hostname=pgnode04 postgresql_exists=false new_node=true
 ```
 
 Run playbook:

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -174,16 +174,16 @@
 
     # optional
     - role: postgresql-users
-      when: is_master == "true" and postgresql_users | length > 0
+      when: is_master | bool and postgresql_users | length > 0
 
     - role: postgresql-databases
-      when: is_master == "true" and postgresql_databases | length > 0
+      when: is_master | bool and postgresql_databases | length > 0
 
     - role: postgresql-schemas
-      when: is_master == "true" and postgresql_schemas | length > 0
+      when: is_master | bool and postgresql_schemas | length > 0
 
     - role: postgresql-extensions
-      when: is_master == "true" and postgresql_extensions | length > 0
+      when: is_master | bool and postgresql_extensions | length > 0
 
     - role: pgbouncer/config
       when: pgbouncer_install|bool and pgbouncer_generate_userlist|bool

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -6,9 +6,23 @@
     - vars/main.yml
     - vars/system.yml
   pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
     - name: Set maintenance variable
       set_fact:
         postgresql_cluster_maintenance: true
+      tags: always
+
   roles:
     - role: pre-checks
       vars:

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -1,40 +1,25 @@
 ---
 - name: config_pgcluster.yml | Configuration PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
-  hosts: localhost
-  gather_facts: false
-  vars_files:
-    - vars/main.yml
-  vars:
-    minimal_ansible_version: 2.7.0
-    timescale_minimal_pg_version: 12 # if enable_timescale is defined
-  tasks:
-    - name: Checking ansible version
-      fail:
-        msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
-      when: ansible_version.full is version(minimal_ansible_version, '<')
-
-    - name: Checking PostgreSQL version
-      fail:
-        msg:
-          - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
-          - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
-      when:
-        - enable_timescale is defined
-        - enable_timescale | bool
-        - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
-
-- name: config_pgcluster.yml | Set maintenance variable
-  hosts: all
-  tasks:
-    - name: Set variable
-      set_fact:
-        postgresql_cluster_maintenance: true
-  tags: always
-
-- name: config_pgcluster.yml | Gathering facts from all servers
   hosts: all
   gather_facts: true
-  tags: always
+  vars_files:
+    - vars/main.yml
+    - vars/system.yml
+  pre_tasks:
+    - name: Set maintenance variable
+      set_fact:
+        postgresql_cluster_maintenance: true
+  roles:
+    - role: pre-checks
+      vars:
+        minimal_ansible_version: 2.7.0
+        timescale_minimal_pg_version: 12 # if enable_timescale is defined
+      tags: always
+
+    - role: hostname
+    - role: resolv_conf
+    - role: etc_hosts
+    - role: timezone
 
 - name: config_pgcluster.yml | Configure Postgres Cluster
   hosts: postgres_cluster
@@ -118,17 +103,15 @@
       when: firewall_enabled_at_boot|bool
       tags: firewall
 
-    - role: hostname
-    - role: resolv_conf
-    - role: etc_hosts
     - role: add-repository
     - role: packages
     - role: sudo
     - role: swap
     - role: sysctl
+    - role: transparent_huge_pages
     - role: pam_limits
+    - role: io-scheduler
     - role: locales
-    - role: timezone
     - role: ntp
     - role: ssh-keys
     - role: copy
@@ -162,35 +145,6 @@
     - name: Include OS-specific variables
       include_vars: "vars/RedHat.yml"
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
-      tags: always
-
-    # timescaledb (if enable_timescale is defined)
-    - block:
-        - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
-          set_fact:
-            # This complex line does several things:
-            # 1. It takes the current list of PostgreSQL parameters,
-            # 2. Removes any item where the option is 'shared_preload_libraries',
-            # 3. Then appends a new 'shared_preload_libraries' item at the end.
-            # The new value of this item is based on whether 'timescaledb' is already present in the old value.
-            # If it is not present, it appends ',timescaledb' to the old value. Otherwise, it leaves the value unchanged.
-            postgresql_parameters: >-
-              {{ postgresql_parameters | rejectattr('option', 'equalto', 'shared_preload_libraries') | list
-              + [{ 'option': 'shared_preload_libraries', 'value': new_value }] }}
-          vars:
-            # Find the last item in postgresql_parameters where the option is 'shared_preload_libraries'
-            shared_preload_libraries_item: "{{ postgresql_parameters | selectattr('option', 'equalto', 'shared_preload_libraries') | list | last | default({ 'value': '' }) }}"
-            # Determine the new value based on whether 'timescaledb' is already present
-            new_value: >-
-              {{
-                (shared_preload_libraries_item.value ~ (',' if shared_preload_libraries_item.value else '')
-                if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else shared_preload_libraries_item.value)
-                ~ ('timescaledb' if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else '')
-              }}
-      when:
-        - installation_method == "repo"
-        - enable_timescale is defined
-        - enable_timescale | bool
       tags: always
 
   roles:

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -37,6 +37,7 @@
           Architecture: "{{ ansible_architecture | default('N/A') }}"
           Virtualization type: "{{ ansible_virtualization_type | default('N/A') }}"
           Product name: "{{ ansible_product_name | default('N/A') }}"
+      tags: always
 
   roles:
     - role: pre-checks

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -265,16 +265,16 @@
 
     # optional
     - role: postgresql-users
-      when: is_master == "true" and postgresql_users | length > 0
+      when: is_master | bool and postgresql_users | length > 0
 
     - role: postgresql-databases
-      when: is_master == "true" and postgresql_databases | length > 0
+      when: is_master | bool and postgresql_databases | length > 0
 
     - role: postgresql-schemas
-      when: is_master == "true" and postgresql_schemas | length > 0
+      when: is_master | bool and postgresql_schemas | length > 0
 
     - role: postgresql-extensions
-      when: is_master == "true" and postgresql_extensions | length > 0
+      when: is_master | bool and postgresql_extensions | length > 0
 
     - role: pgbouncer/config
       when: pgbouncer_install|bool and pgbouncer_generate_userlist|bool

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -12,6 +12,18 @@
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
+    - name: Include OS-specific variables
+      include_vars: "vars/{{ ansible_os_family }}.yml"
+      when: not ansible_os_family == 'Rocky' and not ansible_os_family == 'AlmaLinux'
+      tags: always
+
+    # For compatibility with Ansible old versions
+    # (support for RockyLinux and AlmaLinux has been added to Ansible 2.11)
+    - name: Include OS-specific variables
+      include_vars: "vars/RedHat.yml"
+      when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
+      tags: always
+
     - name: System information
       debug:
         var: system_info

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -1,29 +1,5 @@
 ---
 - name: Deploy PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
-  hosts: localhost
-  gather_facts: false
-  vars_files:
-    - vars/main.yml
-  vars:
-    minimal_ansible_version: 2.7.0
-    timescale_minimal_pg_version: 12 # if enable_timescale is defined
-  tasks:
-    - name: Checking ansible version
-      fail:
-        msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
-      when: ansible_version.full is version(minimal_ansible_version, '<')
-
-    - name: Checking PostgreSQL version
-      fail:
-        msg:
-          - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
-          - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
-      when:
-        - enable_timescale is defined
-        - enable_timescale | bool
-        - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
-
-- name: deploy_pgcluster.yml | Gathering facts from all servers and preparing the system
   hosts: all
   become: true
   become_method: sudo
@@ -51,8 +27,14 @@
           Product name: "{{ ansible_product_name | default('N/A') }}"
 
   roles:
-    - role: resolv_conf
+    - role: pre-checks
+      vars:
+        minimal_ansible_version: 2.7.0
+        timescale_minimal_pg_version: 12 # if enable_timescale is defined
+      tags: always
+
     - role: hostname
+    - role: resolv_conf
     - role: etc_hosts
     - role: timezone
 
@@ -243,35 +225,6 @@
     - name: Include OS-specific variables
       include_vars: "vars/RedHat.yml"
       when: ansible_os_family == 'Rocky' or ansible_os_family == 'AlmaLinux'
-      tags: always
-
-    # timescaledb (if enable_timescale is defined)
-    - block:
-        - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
-          set_fact:
-            # This complex line does several things:
-            # 1. It takes the current list of PostgreSQL parameters,
-            # 2. Removes any item where the option is 'shared_preload_libraries',
-            # 3. Then appends a new 'shared_preload_libraries' item at the end.
-            # The new value of this item is based on whether 'timescaledb' is already present in the old value.
-            # If it is not present, it appends ',timescaledb' to the old value. Otherwise, it leaves the value unchanged.
-            postgresql_parameters: >-
-              {{ postgresql_parameters | rejectattr('option', 'equalto', 'shared_preload_libraries') | list
-              + [{ 'option': 'shared_preload_libraries', 'value': new_value }] }}
-          vars:
-            # Find the last item in postgresql_parameters where the option is 'shared_preload_libraries'
-            shared_preload_libraries_item: "{{ postgresql_parameters | selectattr('option', 'equalto', 'shared_preload_libraries') | list | last | default({ 'value': '' }) }}"
-            # Determine the new value based on whether 'timescaledb' is already present
-            new_value: >-
-              {{
-                (shared_preload_libraries_item.value ~ (',' if shared_preload_libraries_item.value else '')
-                if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else shared_preload_libraries_item.value)
-                ~ ('timescaledb' if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else '')
-              }}
-      when:
-        - installation_method == "repo"
-        - enable_timescale is defined
-        - enable_timescale | bool
       tags: always
 
   roles:

--- a/group_vars/master
+++ b/group_vars/master
@@ -1,4 +1,4 @@
 ---
 
-is_master: 'true'
-postgresql_exists: 'false'
+is_master: true
+postgresql_exists: false

--- a/group_vars/replica
+++ b/group_vars/replica
@@ -1,4 +1,4 @@
 ---
 
-is_master: 'false'
-postgresql_exists: 'false'
+is_master: false
+postgresql_exists: false

--- a/inventory
+++ b/inventory
@@ -31,12 +31,12 @@
 
 # PostgreSQL nodes
 [master]
-10.128.64.140 hostname=pgnode01 postgresql_exists='false'
+10.128.64.140 hostname=pgnode01 postgresql_exists=false
 
 [replica]
-10.128.64.142 hostname=pgnode02 postgresql_exists='false'
-10.128.64.143 hostname=pgnode03 postgresql_exists='false'
-#10.128.64.144 hostname=pgnode04 postgresql_exists='false' new_node=true
+10.128.64.142 hostname=pgnode02 postgresql_exists=false
+10.128.64.143 hostname=pgnode03 postgresql_exists=false
+#10.128.64.144 hostname=pgnode04 postgresql_exists=false new_node=true
 
 [postgres_cluster:children]
 master

--- a/roles/patroni/config/tasks/main.yml
+++ b/roles/patroni/config/tasks/main.yml
@@ -57,7 +57,7 @@
         body_format: json
       loop: "{{ postgresql_parameters }}"
       when: item.value == "null"
-  when: is_master == "true"
+  when: is_master | bool
   tags: patroni, patroni_conf
 
 - name: Delete postgresql parameters from "/etc/patroni/patroni.yml"

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -444,8 +444,8 @@
       loop:
         - absent
         - directory
-      when: (is_master == "true" and patroni_cluster_bootstrap_method != "pgbackrest")
-            or (is_master != "true" and 'pgbackrest' not in patroni_create_replica_methods)  # --delta restore
+      when: (is_master | bool and patroni_cluster_bootstrap_method != "pgbackrest")
+            or (not is_master | bool and 'pgbackrest' not in patroni_create_replica_methods)  # --delta restore
 
     - name: Prepare PostgreSQL | make sure the custom WAL directory "{{ postgresql_wal_dir }}" is empty
       file:
@@ -458,9 +458,9 @@
         - absent
         - directory
       when: (postgresql_wal_dir is defined and postgresql_wal_dir | length > 0) and
-            ((is_master == "true" and patroni_cluster_bootstrap_method != "pgbackrest")
-              or (is_master != "true" and 'pgbackrest' not in patroni_create_replica_methods))  # --delta restore
-  when: postgresql_exists != "true" or patroni_cluster_bootstrap_method != "initdb"
+            ((is_master | bool and patroni_cluster_bootstrap_method != "pgbackrest")
+              or (not is_master | bool and 'pgbackrest' not in patroni_create_replica_methods))  # --delta restore
+  when: not postgresql_exists | bool or patroni_cluster_bootstrap_method != "initdb"
   tags: patroni, point_in_time_recovery
 
 - block:  # when postgresql exists
@@ -543,7 +543,7 @@
             state: present
           become: true
           become_user: postgres
-      when: is_master == "true"
+      when: is_master | bool
 
     - name: Prepare PostgreSQL | check PostgreSQL is started
       become: true
@@ -588,7 +588,7 @@
       register: pg_ctl_stop_result
       failed_when: pg_ctl_stop_result.rc != 3
       changed_when: false
-  when: postgresql_exists == "true" and patroni_cluster_bootstrap_method == "initdb"
+  when: postgresql_exists | bool and patroni_cluster_bootstrap_method == "initdb"
   tags: patroni, patroni_start_master
 
 - block:  # PITR (custom bootstrap)
@@ -612,13 +612,13 @@
       systemd:
         name: patroni
         state: stopped
-      when: is_master != "true"
+      when: not is_master | bool
 
     - name: Stop patroni service on the Master server (if running)
       systemd:
         name: patroni
         state: stopped
-      when: is_master == "true"
+      when: is_master | bool
 
     - name: Remove patroni cluster "{{ patroni_cluster_name }}" from DCS (if exist)
       become: true
@@ -636,7 +636,7 @@
         patronictl_remove_result.rc != 0
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
-      when: is_master == "true"
+      when: is_master | bool
       vars:
         ansible_python_interpreter: /usr/bin/python3
 
@@ -648,7 +648,7 @@
           async: 86400  # timeout 24 hours
           poll: 0
           register: pgbackrest_restore_master
-          when: is_master == "true"
+          when: is_master | bool
 
           # if patroni_create_replica_methods: "pgbackrest"
         - name: Run "{{ pgbackrest_patroni_cluster_restore_command }}" on Replica
@@ -658,7 +658,7 @@
           async: 86400  # timeout 24 hours
           poll: 0
           register: pgbackrest_restore_replica
-          when: is_master != "true" and 'pgbackrest' in patroni_create_replica_methods
+          when: not is_master | bool and 'pgbackrest' in patroni_create_replica_methods
 
         - name: Waiting for restore from backup
           async_status:
@@ -684,14 +684,14 @@
         - name: Start PostgreSQL for Recovery  # Debian
           command: "/usr/bin/pg_ctlcluster {{ postgresql_version }} {{ postgresql_cluster_name }} start -o '-c hot_standby=off'"
           when: ansible_os_family == "Debian" and
-                (is_master == "true" or
-                (is_master != "true" and 'pgbackrest' in patroni_create_replica_methods))
+                (is_master | bool or
+                (not is_master | bool and 'pgbackrest' in patroni_create_replica_methods))
 
         - name: Start PostgreSQL for Recovery  # RedHat or PostgresPro
           command: "{{ postgresql_bin_dir }}/pg_ctl start -D {{ postgresql_data_dir }} -o '-c hot_standby=off'"
           when: (ansible_os_family == "RedHat" or postgresql_packages|join(" ") is search("postgrespro")) and
-                (is_master == "true" or
-                (is_master != "true" and 'pgbackrest' in patroni_create_replica_methods))
+                (is_master | bool or
+                (not is_master | bool and 'pgbackrest' in patroni_create_replica_methods))
 
         - name: Waiting for PostgreSQL Recovery to complete (WAL apply)
           command: "{{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -tAc 'SELECT pg_is_in_recovery()'"
@@ -701,8 +701,8 @@
           delay: 30
           changed_when: false
           failed_when: false
-          when: is_master == "true" or
-                (is_master != "true" and 'pgbackrest' in patroni_create_replica_methods)
+          when: is_master | bool or
+                (not is_master | bool and 'pgbackrest' in patroni_create_replica_methods)
 
         - name: Check that PostgreSQL is stopped
           command: "{{ postgresql_bin_dir }}/pg_ctl status -D {{ postgresql_data_dir }}"
@@ -828,7 +828,7 @@
       retries: 10
       delay: 2
       when: patroni_standby_cluster.host is not defined or patroni_standby_cluster.host | length < 1
-  when: is_master == "true"
+  when: is_master | bool
   tags: patroni, patroni_start_master, point_in_time_recovery
 
 - block:  # pg_hba (using a templates/pg_hba.conf.j2)
@@ -840,9 +840,9 @@
         group: postgres
         mode: 0640
       register: generate_pg_hba
-      when: is_master == "true" or
-            ((is_master != "true" and postgresql_conf_dir != postgresql_data_dir)
-            or postgresql_exists == "true")
+      when: is_master | bool or
+            ((not is_master | bool and postgresql_conf_dir != postgresql_data_dir)
+            or postgresql_exists | bool)
 
     - name: Prepare PostgreSQL | reload for apply the pg_hba.conf
       become: true
@@ -863,7 +863,7 @@
       retries: 1200  # timeout 10 hours
       delay: 30
       changed_when: false
-      when: is_master == "true"
+      when: is_master | bool
 
     - name: Make sure the superuser and replication users are present, and password does not differ from the specified
       postgresql_user:
@@ -880,7 +880,7 @@
       loop_control:
         label: "{{ item.name }}"
       when:
-        - is_master == "true"
+        - is_master | bool
         - (patroni_superuser_username and patroni_superuser_password) is defined
         - (patroni_superuser_username and patroni_superuser_password) | length > 0
         - (patroni_replication_username and patroni_replication_password) is defined
@@ -899,7 +899,7 @@
         label: "{{ item.name }}"
       ignore_errors: true
       when:
-        - is_master == "true"
+        - is_master | bool
         - (postgresql_users is defined and postgresql_users | length > 0)
 
     - name: Update postgresql authentication in patroni.yml
@@ -971,7 +971,7 @@
       until: replica_result.status == 200
       retries: 1200  # timeout 10 hours
       delay: 30
-  when: is_master != "true"
+  when: not is_master | bool
   tags: patroni, patroni_start_replica, point_in_time_recovery
 
 # create symlink pg_xlog/pg_wal to custom WAL dir

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -410,19 +410,6 @@
         state: directory
         mode: 0700
 
-    - name: Prepare PostgreSQL | check that data directory "{{ postgresql_data_dir }}" is not initialized
-      stat:
-        path: "{{ postgresql_data_dir }}/PG_VERSION"
-      register: pgdata_initialized
-      when: patroni_cluster_bootstrap_method == "initdb"
-
-    - name: Prepare PostgreSQL | data directory check result
-      fail:
-        msg: "Whoops! data directory {{ postgresql_data_dir }} is already initialized"
-      when: pgdata_initialized.stat.exists is defined and
-            pgdata_initialized.stat.exists
-      tags: patroni, patroni_check_init
-
       # for Debian based distros only
       # patroni bootstrap failure is possible if the postgresql config files are missing
     - name: Prepare PostgreSQL | make sure the postgresql config files exists
@@ -477,17 +464,6 @@
   tags: patroni, point_in_time_recovery
 
 - block:  # when postgresql exists
-    - name: Prepare PostgreSQL | check that data directory "{{ postgresql_data_dir }}" is initialized
-      stat:
-        path: "{{ postgresql_data_dir }}/PG_VERSION"
-      register: pgdata_initialized
-
-    - name: Prepare PostgreSQL | data directory check result
-      fail:
-        msg: "Whoops! data directory {{ postgresql_data_dir }} is not initialized"
-      when: not pgdata_initialized.stat.exists
-      tags: patroni, patroni_check_init
-
     - block:  # for master only
         - name: Prepare PostgreSQL | check PostgreSQL is started on Master
           become: true

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -91,12 +91,12 @@ bootstrap:
     {% endif %}
   {% endif %}
 
-{% if postgresql_exists == 'true' %}
+{% if postgresql_exists|bool %}
 #  initdb:  # List options to be passed on to initdb
 #    - encoding: UTF8
 #    - data-checksums
 {% endif %}
-{% if postgresql_exists == 'false' %}
+{% if not postgresql_exists|bool %}
   initdb:  # List options to be passed on to initdb
     - encoding: {{ postgresql_encoding }}
     - locale: {{ postgresql_locale }}

--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -8,58 +8,6 @@
     mode: 0750
   tags: pgbouncer, pgbouncer_conf
 
-# This task calculates the defined_pool_size for each defined pgbouncer pool.
-# The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
-# If 'pool_size' is defined in 'pool_parameters', it takes that value.
-# If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
-# The calculated pool size is then added to the total 'defined_pool_size'.
-- name: Calculate pool_size
-  set_fact:
-    defined_pool_size: "{{ defined_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
-  loop: "{{ pgbouncer_pools|default([]) }}"
-  tags: pgbouncer_conf, pgbouncer
-
-# This task calculates the total pool size across all databases.
-# If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'defined_pool_size'.
-# Otherwise, it adds the 'defined_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
-# This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'defined_pool_size'.
-- name: Calculate total_pool_size
-  set_fact:
-    total_pool_size: >-
-      {{
-        (defined_pool_size|int)
-        if (postgresql_databases is not defined or postgresql_databases|default([]) == [])
-        else
-        ((defined_pool_size|int)
-        +
-        (postgresql_databases|default([]) | rejectattr('db', 'in', pgbouncer_pools|map(attribute='dbname')|list)|length) * (pgbouncer_default_pool_size|default(0)|int))
-      }}
-  tags: pgbouncer_conf, pgbouncer
-
-- name: Show total pool size
-  run_once: true
-  debug:
-    var: total_pool_size
-  tags: pgbouncer_conf, pgbouncer
-
-# This task sets the value for max_connections from the provided variables, defaulting to 100 if not explicitly set.
-# It loops through the 'postgresql_parameters' list and, if 'max_connections' is found in the option, it sets the 'max_connections' value accordingly.
-- name: Set max_connections from vars or use default
-  set_fact:
-    max_connections: "{{ (item.value|default(100))|int }}"
-  when: item.option == "max_connections"
-  loop: "{{ postgresql_parameters|default([]) }}"
-  tags: pgbouncer_conf, pgbouncer
-
-# This task fails the playbook execution if the total pool size is greater than max_connections.
-# It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
-# If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
-- name: Failed when total_pool_size > max_connections
-  fail:
-    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: pgbouncer_pools|default([]) | length > 0 and total_pool_size | int > max_connections | default(100) | int
-  tags: pgbouncer_conf, pgbouncer
-
 - name: Update pgbouncer.ini
   template:
     src: ../templates/pgbouncer.ini.j2

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -84,58 +84,6 @@
     dest: /etc/logrotate.d/pgbouncer
   tags: pgbouncer_logrotate, pgbouncer
 
-# This task calculates the defined_pool_size for each defined pgbouncer pool.
-# The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
-# If 'pool_size' is defined in 'pool_parameters', it takes that value.
-# If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
-# The calculated pool size is then added to the total 'defined_pool_size'.
-- name: Calculate pool_size
-  set_fact:
-    defined_pool_size: "{{ defined_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
-  loop: "{{ pgbouncer_pools|default([]) }}"
-  tags: pgbouncer_conf, pgbouncer
-
-# This task calculates the total pool size across all databases.
-# If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'defined_pool_size'.
-# Otherwise, it adds the 'defined_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
-# This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'defined_pool_size'.
-- name: Calculate total_pool_size
-  set_fact:
-    total_pool_size: >-
-      {{
-        (defined_pool_size|int)
-        if (postgresql_databases is not defined or postgresql_databases|default([]) == [])
-        else
-        ((defined_pool_size|int)
-        +
-        (postgresql_databases|default([]) | rejectattr('db', 'in', pgbouncer_pools|map(attribute='dbname')|list)|length) * (pgbouncer_default_pool_size|default(0)|int))
-      }}
-  tags: pgbouncer_conf, pgbouncer
-
-- name: Show total pool size
-  run_once: true
-  debug:
-    var: total_pool_size
-  tags: pgbouncer_conf, pgbouncer
-
-# This task sets the value for max_connections from the provided variables, defaulting to 100 if not explicitly set.
-# It loops through the 'postgresql_parameters' list and, if 'max_connections' is found in the option, it sets the 'max_connections' value accordingly.
-- name: Set max_connections from vars or use default
-  set_fact:
-    max_connections: "{{ (item.value|default(100))|int }}"
-  when: item.option == "max_connections"
-  loop: "{{ postgresql_parameters|default([]) }}"
-  tags: pgbouncer_conf, pgbouncer
-
-# This task fails the playbook execution if the total pool size is greater than max_connections.
-# It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
-# If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
-- name: Failed when total_pool_size > max_connections
-  fail:
-    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
-  when: pgbouncer_pools|default([]) | length > 0 and total_pool_size | int > max_connections | default(100) | int
-  tags: pgbouncer_conf, pgbouncer
-
 - name: Configure pgbouncer.ini
   template:
     src: templates/pgbouncer.ini.j2

--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Checking ansible version
+  fail:
+    msg: "Ansible version must be {{ minimal_ansible_version }} or higher"
+  delegate_to: localhost
+  when:
+    - ansible_version.full is version(minimal_ansible_version, '<')
+
+- name: Perform pre-checks for timescaledb
+  include_tasks: timescaledb.yml
+  when:
+    - enable_timescale is defined
+    - enable_timescale | bool
+    - inventory_hostname in groups['postgres_cluster']
+
+- name: Perform pre-checks for pgbouncer
+  include_tasks: pgbouncer.yml
+  when:
+    - pgbouncer_install is defined
+    - pgbouncer_install | bool
+    - inventory_hostname in groups['postgres_cluster']

--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -8,14 +8,14 @@
     - ansible_version.full is version(minimal_ansible_version, '<')
 
 - name: Perform pre-checks for timescaledb
-  include_tasks: timescaledb.yml
+  import_tasks: timescaledb.yml
   when:
     - enable_timescale is defined
     - enable_timescale | bool
     - inventory_hostname in groups['postgres_cluster']
 
 - name: Perform pre-checks for pgbouncer
-  include_tasks: pgbouncer.yml
+  import_tasks: pgbouncer.yml
   when:
     - pgbouncer_install is defined
     - pgbouncer_install | bool

--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -20,3 +20,8 @@
     - pgbouncer_install is defined
     - pgbouncer_install | bool
     - inventory_hostname in groups['postgres_cluster']
+
+- name: Perform pre-checks for patroni
+  import_tasks: patroni.yml
+  when:
+    - inventory_hostname in groups['postgres_cluster']

--- a/roles/pre-checks/tasks/patroni.yml
+++ b/roles/pre-checks/tasks/patroni.yml
@@ -14,7 +14,9 @@
       when:
         - pgdata_initialized.stat.exists is defined
         - pgdata_initialized.stat.exists
-  when: not postgresql_exists | bool
+  when:
+    - not postgresql_exists | bool
+    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml
 
 # when postgresql exists
 - block:
@@ -29,4 +31,6 @@
       when:
         - pgdata_initialized.stat.exists is defined
         - not pgdata_initialized.stat.exists
-  when: postgresql_exists | bool
+  when:
+    - postgresql_exists | bool
+    - not (postgresql_cluster_maintenance|default(false)|bool) # exclude for config_pgcluster.yml

--- a/roles/pre-checks/tasks/patroni.yml
+++ b/roles/pre-checks/tasks/patroni.yml
@@ -1,0 +1,32 @@
+---
+
+# when postgresql NOT exists
+- block:
+    - name: PostgreSQL | check that data directory "{{ postgresql_data_dir }}" is not initialized
+      stat:
+        path: "{{ postgresql_data_dir }}/PG_VERSION"
+      register: pgdata_initialized
+      when: patroni_cluster_bootstrap_method == "initdb"
+
+    - name: PostgreSQL | data directory check result
+      fail:
+        msg: "Whoops! data directory {{ postgresql_data_dir }} is already initialized"
+      when:
+        - pgdata_initialized.stat.exists is defined
+        - pgdata_initialized.stat.exists
+  when: not postgresql_exists | bool
+
+# when postgresql exists
+- block:
+    - name: PostgreSQL | check that data directory "{{ postgresql_data_dir }}" is initialized
+      stat:
+        path: "{{ postgresql_data_dir }}/PG_VERSION"
+      register: pgdata_initialized
+
+    - name: PostgreSQL | data directory check result
+      fail:
+        msg: "Whoops! data directory {{ postgresql_data_dir }} is not initialized"
+      when:
+        - pgdata_initialized.stat.exists is defined
+        - not pgdata_initialized.stat.exists
+  when: postgresql_exists | bool

--- a/roles/pre-checks/tasks/pgbouncer.yml
+++ b/roles/pre-checks/tasks/pgbouncer.yml
@@ -48,4 +48,3 @@
   when:
     - pgbouncer_pools|default([]) | length > 0
     - total_pool_size | int > max_connections | default(100) | int
-

--- a/roles/pre-checks/tasks/pgbouncer.yml
+++ b/roles/pre-checks/tasks/pgbouncer.yml
@@ -48,6 +48,7 @@
 # It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
 # If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
 - name: Failed when pgbouncer_total_pool_size > max_connections
+  run_once: true
   fail:
     msg: "pgbouncer_total_pool_size: {{ pgbouncer_total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
   when:

--- a/roles/pre-checks/tasks/pgbouncer.yml
+++ b/roles/pre-checks/tasks/pgbouncer.yml
@@ -1,0 +1,51 @@
+---
+
+# This task calculates the defined_pool_size for each defined pgbouncer pool.
+# The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
+# If 'pool_size' is defined in 'pool_parameters', it takes that value.
+# If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
+# The calculated pool size is then added to the total 'defined_pool_size'.
+- name: Calculate pool_size
+  set_fact:
+    defined_pool_size: "{{ defined_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
+  loop: "{{ pgbouncer_pools|default([]) }}"
+
+# This task calculates the total pool size across all databases.
+# If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'defined_pool_size'.
+# Otherwise, it adds the 'defined_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
+# This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'defined_pool_size'.
+- name: Calculate total_pool_size
+  set_fact:
+    total_pool_size: >-
+      {{
+        (defined_pool_size|int)
+        if (postgresql_databases is not defined or postgresql_databases|default([]) == [])
+        else
+        ((defined_pool_size|int)
+        +
+        (postgresql_databases|default([]) | rejectattr('db', 'in', pgbouncer_pools|map(attribute='dbname')|list)|length) * (pgbouncer_default_pool_size|default(0)|int))
+      }}
+
+- name: Show total pool size
+  run_once: true
+  debug:
+    var: total_pool_size
+
+# This task sets the value for max_connections from the provided variables, defaulting to 100 if not explicitly set.
+# It loops through the 'postgresql_parameters' list and, if 'max_connections' is found in the option, it sets the 'max_connections' value accordingly.
+- name: Set max_connections from vars or use default
+  set_fact:
+    max_connections: "{{ (item.value|default(100))|int }}"
+  when: item.option == "max_connections"
+  loop: "{{ postgresql_parameters|default([]) }}"
+
+# This task fails the playbook execution if the total pool size is greater than max_connections.
+# It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
+# If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
+- name: Failed when total_pool_size > max_connections
+  fail:
+    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
+  when:
+    - pgbouncer_pools|default([]) | length > 0
+    - total_pool_size | int > max_connections | default(100) | int
+

--- a/roles/pre-checks/tasks/pgbouncer.yml
+++ b/roles/pre-checks/tasks/pgbouncer.yml
@@ -1,50 +1,55 @@
 ---
 
-# This task calculates the defined_pool_size for each defined pgbouncer pool.
-# The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
-# If 'pool_size' is defined in 'pool_parameters', it takes that value.
-# If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
-# The calculated pool size is then added to the total 'defined_pool_size'.
-- name: Calculate pool_size
-  set_fact:
-    defined_pool_size: "{{ defined_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
-  loop: "{{ pgbouncer_pools|default([]) }}"
-
-# This task calculates the total pool size across all databases.
-# If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'defined_pool_size'.
-# Otherwise, it adds the 'defined_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
-# This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'defined_pool_size'.
-- name: Calculate total_pool_size
-  set_fact:
-    total_pool_size: >-
-      {{
-        (defined_pool_size|int)
-        if (postgresql_databases is not defined or postgresql_databases|default([]) == [])
-        else
-        ((defined_pool_size|int)
-        +
-        (postgresql_databases|default([]) | rejectattr('db', 'in', pgbouncer_pools|map(attribute='dbname')|list)|length) * (pgbouncer_default_pool_size|default(0)|int))
-      }}
-
-- name: Show total pool size
-  run_once: true
-  debug:
-    var: total_pool_size
-
 # This task sets the value for max_connections from the provided variables, defaulting to 100 if not explicitly set.
 # It loops through the 'postgresql_parameters' list and, if 'max_connections' is found in the option, it sets the 'max_connections' value accordingly.
 - name: Set max_connections from vars or use default
+  run_once: true
   set_fact:
     max_connections: "{{ (item.value|default(100))|int }}"
   when: item.option == "max_connections"
   loop: "{{ postgresql_parameters|default([]) }}"
 
+# This task calculates the pgbouncer_pool_size for each defined pgbouncer pool.
+# The pool size for each pool is extracted from its 'pool_parameters' string using a regular expression.
+# If 'pool_size' is defined in 'pool_parameters', it takes that value.
+# If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
+# The calculated pool size is then added to the total 'pgbouncer_pool_size'.
+- name: Calculate pgbouncer pool_size
+  run_once: true
+  set_fact:
+    pgbouncer_pool_size: "{{ pgbouncer_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
+  loop: "{{ pgbouncer_pools|default([]) }}"
+
+# This task calculates the total pool size across all databases.
+# If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'pgbouncer_pool_size'.
+# Otherwise, it adds the 'pgbouncer_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
+# This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'pgbouncer_pool_size'.
+- name: Calculate pgbouncer total pool_size
+  run_once: true
+  set_fact:
+    pgbouncer_total_pool_size: >-
+      {{
+        (pgbouncer_pool_size|int)
+        if (postgresql_databases is not defined or postgresql_databases|default([]) == [])
+        else
+        ((pgbouncer_pool_size|int)
+        +
+        (postgresql_databases|default([]) | rejectattr('db', 'in', pgbouncer_pools|map(attribute='dbname')|list)|length) * (pgbouncer_default_pool_size|default(0)|int))
+      }}
+  when: pgbouncer_pool_size is defined
+
+- name: Show pgbouncer total pool_size
+  run_once: true
+  debug:
+    var: pgbouncer_total_pool_size
+  when: pgbouncer_total_pool_size is defined
+
 # This task fails the playbook execution if the total pool size is greater than max_connections.
 # It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
 # If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
-- name: Failed when total_pool_size > max_connections
+- name: Failed when pgbouncer_total_pool_size > max_connections
   fail:
-    msg: "total_pool_size: {{ total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
+    msg: "pgbouncer_total_pool_size: {{ pgbouncer_total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"
   when:
     - pgbouncer_pools|default([]) | length > 0
-    - total_pool_size | int > max_connections | default(100) | int
+    - pgbouncer_total_pool_size | int > max_connections | default(100) | int

--- a/roles/pre-checks/tasks/pgbouncer.yml
+++ b/roles/pre-checks/tasks/pgbouncer.yml
@@ -14,7 +14,7 @@
 # If 'pool_size' is defined in 'pool_parameters', it takes that value.
 # If 'pool_size' is not defined, it uses pgbouncer_default_pool_size if available, otherwise 0.
 # The calculated pool size is then added to the total 'pgbouncer_pool_size'.
-- name: Calculate pgbouncer pool_size
+- name: PgBouncer | Calculate pool_size
   run_once: true
   set_fact:
     pgbouncer_pool_size: "{{ pgbouncer_pool_size|default(0)|int + (item.pool_parameters|regex_search('pool_size=(\\d+)', multiline=False)|regex_replace('[^0-9]', '')|default(pgbouncer_default_pool_size|default(0), true)|int) }}"
@@ -24,7 +24,7 @@
 # If 'postgresql_databases' is not defined or is an empty list, the total pool size will be equal to the 'pgbouncer_pool_size'.
 # Otherwise, it adds the 'pgbouncer_pool_size' to the product of the default pool size (or 0 if not defined) and the number of databases not already defined in 'pgbouncer_pools'.
 # This means it checks the 'postgresql_databases' against 'pgbouncer_pools' and for each database that does not have a corresponding pool, it adds the 'pgbouncer_default_pool_size' (or 0 if not defined) to the 'pgbouncer_pool_size'.
-- name: Calculate pgbouncer total pool_size
+- name: PgBouncer | Calculate total pool_size
   run_once: true
   set_fact:
     pgbouncer_total_pool_size: >-
@@ -38,7 +38,7 @@
       }}
   when: pgbouncer_pool_size is defined
 
-- name: Show pgbouncer total pool_size
+- name: PgBouncer | Show total pool_size
   run_once: true
   debug:
     var: pgbouncer_total_pool_size
@@ -47,7 +47,7 @@
 # This task fails the playbook execution if the total pool size is greater than max_connections.
 # It checks if 'pgbouncer_pools' is defined and has length > 0 and whether the total pool size is greater than max_connections.
 # If both conditions are met, the execution is stopped with a message indicating that the settings need to be changed.
-- name: Failed when pgbouncer_total_pool_size > max_connections
+- name: PgBouncer | Failed when pgbouncer_total_pool_size > max_connections
   run_once: true
   fail:
     msg: "pgbouncer_total_pool_size: {{ pgbouncer_total_pool_size  }} > max_connections: {{ max_connections }}. Need change settings"

--- a/roles/pre-checks/tasks/timescaledb.yml
+++ b/roles/pre-checks/tasks/timescaledb.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Checking PostgreSQL version
+- name: TimescaleDB | Checking PostgreSQL version
   run_once: true
   fail:
     msg:
@@ -10,7 +10,7 @@
     - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
 
 - block:
-    - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
+    - name: TimescaleDB | Ensure 'timescaledb' is in 'shared_preload_libraries'
       set_fact:
         # This complex line does several things:
         # 1. It takes the current list of PostgreSQL parameters,

--- a/roles/pre-checks/tasks/timescaledb.yml
+++ b/roles/pre-checks/tasks/timescaledb.yml
@@ -34,4 +34,3 @@
   when:
     - enable_timescale is defined
     - enable_timescale | bool
-

--- a/roles/pre-checks/tasks/timescaledb.yml
+++ b/roles/pre-checks/tasks/timescaledb.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Checking PostgreSQL version
+  run_once: true
+  fail:
+    msg:
+      - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the TimescaleDB."
+      - "PostgreSQL version must be {{ timescale_minimal_pg_version }} or higher."
+  when:
+    - postgresql_version|string is version(timescale_minimal_pg_version|string, '<')
+
+- block:
+    - name: Ensure 'timescaledb' is in 'shared_preload_libraries'
+      set_fact:
+        # This complex line does several things:
+        # 1. It takes the current list of PostgreSQL parameters,
+        # 2. Removes any item where the option is 'shared_preload_libraries',
+        # 3. Then appends a new 'shared_preload_libraries' item at the end.
+        # The new value of this item is based on whether 'timescaledb' is already present in the old value.
+        # If it is not present, it appends ',timescaledb' to the old value. Otherwise, it leaves the value unchanged.
+        postgresql_parameters: >-
+          {{ postgresql_parameters | rejectattr('option', 'equalto', 'shared_preload_libraries') | list
+          + [{ 'option': 'shared_preload_libraries', 'value': new_value }] }}
+      vars:
+        # Find the last item in postgresql_parameters where the option is 'shared_preload_libraries'
+        shared_preload_libraries_item: "{{ postgresql_parameters | selectattr('option', 'equalto', 'shared_preload_libraries') | list | last | default({ 'value': '' }) }}"
+        # Determine the new value based on whether 'timescaledb' is already present
+        new_value: >-
+          {{
+            (shared_preload_libraries_item.value ~ (',' if shared_preload_libraries_item.value else '')
+            if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else shared_preload_libraries_item.value)
+            ~ ('timescaledb' if 'timescaledb' not in shared_preload_libraries_item.value.split(',') else '')
+          }}
+  when:
+    - enable_timescale is defined
+    - enable_timescale | bool
+


### PR DESCRIPTION
#### Summary of Changes:

This PR introduces a new role '`pre-checks`', to our Ansible playbook for the PostgreSQL cluster project. The purpose of this role is to consolidate various preliminary checks scattered throughout the code into one cohesive role. This new role is designed to run before any cluster deployment begins.

#### Why this Change is Necessary:

The creation of the pre-checks role aims to improve the overall readability, maintainability, and failure handling of our playbook. By centralizing all preliminary checks, we can prevent scenarios where the playbook halts in the middle due to a failed check for a specific role. Instead, all checks are performed upfront, ensuring that actual deployment will only proceed if all checks pass.

#### Key Points:

The pre-checks role will be the first role executed during the playbook run. All existing preliminary checks from other roles will be migrated into this role. Future checks can be easily added to this role, simplifying the process for further updates or additions.

Expected Outcome:

With these changes, we anticipate smoother playbook executions with fewer disruptions. This should enhance the user experience by providing clear, upfront information about any issues that may affect the deployment of the cluster.