### PR TITLE
Fix yaml[truthy] from all workflow files

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -25,10 +25,10 @@ skip_list:
   - yaml[line-length]
   - yaml[octal-values]
   - yaml[trailing-spaces]
-  - yaml[truthy]
 
 exclude_paths:
   - ../roles/consul/ # TODO - https://github.com/ansible-community/ansible-consul/pull/520
   - ../.venv
+  - ../.github
 # https://ansible-lint.readthedocs.io/configuring/
 # https://ansible-lint.readthedocs.io/rules/


### PR DESCRIPTION
The yaml[truthy] rule was removed from the ansible-lint configuration file, so it is no longer necessary to exclude it from the workflows. This commit removes the yaml[truthy] exclusion from all workflow files.