### PR TITLE
Cleanup of ansible-lint.yml file

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -24,5 +24,3 @@ skip_list:
 exclude_paths:
   - ../.venv
   - ../.github
-# https://ansible-lint.readthedocs.io/configuring/
-# https://ansible-lint.readthedocs.io/rules/

--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -19,8 +19,6 @@ skip_list:
   - package-latest
   - risky-file-permissions # TODO
   - role-name
-  - role-name[path]
-  - run-once[task]
   - yaml[line-length]
 
 exclude_paths:

--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -23,7 +23,6 @@ skip_list:
   - run-once[task]
   - schema[tasks]
   - yaml[line-length]
-  - yaml[trailing-spaces]
 
 exclude_paths:
   - ../.venv

--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -21,7 +21,6 @@ skip_list:
   - role-name
   - role-name[path]
   - run-once[task]
-  - schema[tasks]
   - yaml[line-length]
 
 exclude_paths:


### PR DESCRIPTION
This pull request includes several changes aimed at cleaning up and improving the readability of the `ansible-lint.yml` file:

1. Removal of the `trailing-spaces` rule from `skip_list`. This rule was removed in order to enforce the rule and ensure that there are no trailing spaces in the YAML files.

2. Removal of the `schema[tasks]` rule from `skip_list`. This rule is no longer necessary and thus has been removed.

3. Removal of `role-name[path]` and `run-once[task]` items from `skip_list`. These items are no longer needed. The `role-name[path]` item was removed because it is redundant with the `role-name` item. The `run-once[task]` item was removed because it is not used in the project.

4. Removal of commented out lines. These lines were not providing any value and were just cluttering the file.

All these changes are aimed at improving the readability and efficiency of the `ansible-lint.yml` file.