### PR TITLE
Enable no-free-form rule and refactor tasks

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -13,7 +13,6 @@ skip_list:
   - name[missing] # All tasks should be named.
   - name[template] # Rule for checking task and play names
   - no-changed-when
-  - no-free-form
   - no-handler
   - no-relative-paths
   - package-latest

--- a/roles/ansible-role-firewall/handlers/main.yml
+++ b/roles/ansible-role-firewall/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
 - name: restart firewall
-  service: name=firewall state=restarted
+  service:
+    name: firewall
+    state: restarted

--- a/roles/consul/tasks/encrypt_gossip.yml
+++ b/roles/consul/tasks/encrypt_gossip.yml
@@ -10,7 +10,8 @@
       run_once: true
 
     - name: Save gossip encryption key from existing configuration
-      set_fact: consul_raw_key={{ consul_key_read.stdout }}
+      set_fact:
+        consul_raw_key: "{{ consul_key_read.stdout }}"
       ignore_errors: true
 
   when:
@@ -31,7 +32,8 @@
   delegate_to: 127.0.0.1
 
 - name: Read gossip encryption key for servers that require it
-  set_fact: consul_raw_key="{{ lookup('file', '/tmp/consul_raw.key') }}"
+  set_fact:
+    consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
   when:
     - consul_raw_key is not defined
     - bootstrap_state.stat.exists | bool
@@ -55,7 +57,8 @@
       run_once: true
 
     - name: Write gossip encryption key to fact
-      set_fact: consul_raw_key={{ consul_keygen.stdout }}
+      set_fact:
+        consul_raw_key: "{{ consul_keygen.stdout }}"
   when:
     - consul_raw_key is not defined
     - not bootstrap_state.stat.exists | bool


### PR DESCRIPTION
This pull request introduces two primary changes to the project:

1. The `no-free-form` rule was removed from the `skip_list` to enable it. This rule ensures that all tasks have a `task` key and are not free-form tasks. This change increases the robustness of the task structure in the project.

2. The service task in `ansible-role-firewall` and the `set_fact` tasks in the consul role were reformatted. Instead of using a free-form task structure, these tasks now use a dictionary for the service name, state, and variable assignment. This restructuring improves the readability and consistency of these tasks with other tasks in the playbook