### PR TITLE
Automate 'archive_command' configuration for pgBackRest and WAL-G

### DIFF
--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -25,3 +25,10 @@
   import_tasks: patroni.yml
   when:
     - inventory_hostname in groups['postgres_cluster']
+
+- name: Perform pre-checks for pgbackrest
+  import_tasks: pgbackrest.yml
+  when:
+    - pgbackrest_install is defined
+    - pgbackrest_install | bool
+    - inventory_hostname in groups['postgres_cluster']

--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -32,3 +32,10 @@
     - pgbackrest_install is defined
     - pgbackrest_install | bool
     - inventory_hostname in groups['postgres_cluster']
+
+- name: Perform pre-checks for WAL-G
+  import_tasks: wal_g.yml
+  when:
+    - wal_g_install is defined
+    - wal_g_install | bool
+    - inventory_hostname in groups['postgres_cluster']

--- a/roles/pre-checks/tasks/pgbackrest.yml
+++ b/roles/pre-checks/tasks/pgbackrest.yml
@@ -1,0 +1,16 @@
+---
+- name: "pgBackRest | Ensure 'archive_command' is set to '{{ pgbackrest_archive_command }}'"
+  set_fact:
+    # Create a new list from postgresql_parameters, excluding 'archive_command' option if it exists
+    # Then, append a new 'archive_command' item with the value of 'pgbackrest_archive_command'
+    postgresql_parameters: >-
+      {{ postgresql_parameters | rejectattr('option', 'equalto', 'archive_command') | list
+      + [{ 'option': 'archive_command', 'value': pgbackrest_archive_command }] }}
+  vars:
+    # Find the last item in postgresql_parameters where the option is 'archive_command'
+    archive_command_item: "{{ postgresql_parameters | selectattr('option', 'equalto', 'archive_command') | list | last }}"
+  when:
+    - pgbackrest_install is defined
+    - pgbackrest_install | bool
+    # Execute the task only when 'archive_command' is undefined or its value is not equal to 'pgbackrest_archive_command'
+    - archive_command_item is undefined or archive_command_item.value != pgbackrest_archive_command

--- a/roles/pre-checks/tasks/wal_g.yml
+++ b/roles/pre-checks/tasks/wal_g.yml
@@ -1,0 +1,16 @@
+---
+- name: "WAL-G | Ensure 'archive_command' is set to '{{ wal_g_archive_command }}'"
+  set_fact:
+    # Create a new list from postgresql_parameters, excluding 'archive_command' option if it exists
+    # Then, append a new 'archive_command' item with the value of 'wal_g_archive_command'
+    postgresql_parameters: >-
+      {{ postgresql_parameters | rejectattr('option', 'equalto', 'archive_command') | list
+      + [{ 'option': 'archive_command', 'value': wal_g_archive_command }] }}
+  vars:
+    # Find the last item in postgresql_parameters where the option is 'archive_command'
+    archive_command_item: "{{ postgresql_parameters | selectattr('option', 'equalto', 'archive_command') | list | last }}"
+  when:
+    - wal_g_install is defined
+    - wal_g_install | bool
+    # Execute the task only when 'archive_command' is undefined or its value is not equal to 'wal_g_archive_command'
+    - archive_command_item is undefined or archive_command_item.value != wal_g_archive_command

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -202,7 +202,7 @@ postgresql_parameters:
   - { option: "archive_mode", value: "on" }
   - { option: "archive_timeout", value: "1800s" }
   - { option: "archive_command", value: "cd ." }  # not doing anything yet with WAL-s
-#  - { option: "archive_command", value: "wal-g wal-push %p" }  # archive WAL-s using WAL-G
+#  - { option: "archive_command", value: "{{ wal_g_archive_command }}" }  # archive WAL-s using WAL-G
 #  - { option: "archive_command", value: "{{ pgbackrest_archive_command }}" }  # archive WAL-s using pgbackrest
   - { option: "wal_level", value: "replica" }
   - { option: "wal_keep_size", value: "2GB" }
@@ -414,6 +414,7 @@ wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
 #  - { option: "AWS_REGION", value: "us-east-1" }
 #  - { option: "WALG_S3_CA_CERT_FILE", value: "/path/to/custom/ca/file" }
 #  - { option: "", value: "" }
+wal_g_archive_command: "wal-g wal-push %p"
 wal_g_patroni_cluster_bootstrap_command: "wal-g backup-fetch {{ postgresql_data_dir }} LATEST"
 
 # pgBackRest

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -203,7 +203,7 @@ postgresql_parameters:
   - { option: "archive_timeout", value: "1800s" }
   - { option: "archive_command", value: "cd ." }  # not doing anything yet with WAL-s
 #  - { option: "archive_command", value: "wal-g wal-push %p" }  # archive WAL-s using WAL-G
-#  - { option: "archive_command", value: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-push %p" }  # archive WAL-s using pgbackrest
+#  - { option: "archive_command", value: "{{ pgbackrest_archive_command }}" }  # archive WAL-s using pgbackrest
   - { option: "wal_level", value: "replica" }
   - { option: "wal_keep_size", value: "2GB" }
   - { option: "max_wal_senders", value: "10" }
@@ -467,6 +467,8 @@ pgbackrest_server_conf:
     - { option: "backup-standby", value: "y" }
 #    - { option: "", value: "" }
 # the stanza section will be generated automatically
+
+pgbackrest_archive_command: "pgbackrest --stanza={{ pgbackrest_stanza }} archive-push %p"
 
 pgbackrest_patroni_cluster_restore_command:
   '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} --delta restore'  # restore from latest backup


### PR DESCRIPTION
This PR introduces an Ansible task that automates the configuration of the 'archive_command' for pgBackRest and WAL-G.

#### pgBackRest

Ensure that 'archive_command' is set to the value of 'pgbackrest_archive_command'. This operation is performed only when 'pgbackrest_install' is defined and set to true, and 'archive_command' is undefined or its value is not equal to 'pgbackrest_archive_command' variable.

#### WAL-G

Ensure that 'archive_command' is set to the value of 'wal_g_archive_command'. This operation is performed only when 'wal_g_install' is defined and set to true, and 'archive_command' is undefined or its value is not equal to 'wal_g_archive_command' variable.

#### New variables

- pgbackrest_archive_command
- wal_g_archive_command