### PR TITLE
Automate the configuration of WAL-G cron jobs

### DIFF
--- a/roles/wal-g/tasks/cron.yml
+++ b/roles/wal-g/tasks/cron.yml
@@ -1,0 +1,16 @@
+---
+- name: Add WAL-G cron jobs
+  cron:
+    cron_file: "{{ item.file | default('') }}"
+    user: "{{ item.user | default('postgres')  }}"
+    minute: "{{ item.minute | default('*') }}"
+    hour: "{{ item.hour | default('*') }}"
+    day: "{{ item.day | default('*') }}"
+    month: "{{ item.month | default('*') }}"
+    weekday: "{{ item.weekday | default('*') }}"
+    name: "{{ item.name }}"
+    disabled: "{{ item.disabled | default(False) }}"
+    state: "{{ item.state | default('present') }}"
+    job: "{{ item.job }}"
+  loop: "{{ wal_g_cron_jobs }}"
+  tags: wal_g_cron

--- a/roles/wal-g/tasks/main.yml
+++ b/roles/wal-g/tasks/main.yml
@@ -259,4 +259,10 @@
     mode: "0644"
   tags: wal-g, wal_g, wal_g_conf
 
+- import_tasks: cron.yml
+  when:
+    - wal_g_cron_jobs is defined
+    - wal_g_cron_jobs | length > 0
+  tags: wal-g, wal_g, wal_g_cron
+
 ...

--- a/tags.md
+++ b/tags.md
@@ -89,12 +89,14 @@
 - wal_g
 - - wal_g_install
 - - wal_g_conf
+- - wal_g_cron
 - pgbackrest
 - - pgbackrest_repo
 - - pgbackrest_install
 - - pgbackrest_conf
 - - pgbackrest_ssh_keys
 - - pgbackrest_stanza_create
+- - pgbackrest_cron
 - pg_probackup
 - - pg_probackup_repo
 - - pg_probackup_install

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -403,19 +403,37 @@ pg_probackup_patroni_cluster_bootstrap_command: "pg_probackup-{{ pg_probackup_ve
 wal_g_install: false  # or 'true'
 wal_g_version: "2.0.1"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
-  - { option: "AWS_ACCESS_KEY_ID", value: "minio" }
-  - { option: "AWS_SECRET_ACCESS_KEY", value: "miniosecret" }
-  - { option: "AWS_ENDPOINT", value: "http://172.26.9.200:9000" }
-  - { option: "WALG_S3_PREFIX", value: "s3://bucket" }
-  - { option: "AWS_S3_FORCE_PATH_STYLE", value: "true" }
-  - { option: "WALG_COMPRESSION_METHOD", value: "brotli" }
+  - { option: "AWS_ACCESS_KEY_ID", value: "{{ AWS_ACCESS_KEY_ID | default('') }}" }  # define values or pass via --extra-vars
+  - { option: "AWS_SECRET_ACCESS_KEY", value: "{{ AWS_SECRET_ACCESS_KEY | default('') }}" }  # define values or pass via --extra-vars
+  - { option: "WALG_S3_PREFIX", value: "{{ WALG_S3_PREFIX | default('') }}" } # define values or pass via --extra-vars
+  - { option: "WALG_COMPRESSION_METHOD", value: "brotli" }  # or "lz4", "lzma", "zstd"
   - { option: "PGDATA", value: "{{ postgresql_data_dir }}" }
   - { option: "PGHOST", value: "{{ postgresql_unix_socket_dir }}" }
-#  - { option: "AWS_REGION", value: "us-east-1" }
-#  - { option: "WALG_S3_CA_CERT_FILE", value: "/path/to/custom/ca/file" }
+#  - { option: "AWS_S3_FORCE_PATH_STYLE", value: "true" }  # to use Minio.io S3-compatible storage
+#  - { option: "AWS_ENDPOINT", value: "http://minio:9000" }  # to use Minio.io S3-compatible storage
 #  - { option: "", value: "" }
 wal_g_archive_command: "wal-g wal-push %p"
 wal_g_patroni_cluster_bootstrap_command: "wal-g backup-fetch {{ postgresql_data_dir }} LATEST"
+
+wal_g_cron_jobs:
+  - name: "WAL-G: Create daily backup"
+    user: "postgres"
+    file: /etc/cron.d/walg
+    minute: "30"
+    hour: "3"
+    day: "*"
+    month: "*"
+    weekday: "*"
+    job: "[ $(curl -s -o /dev/null -w '%{http_code}' http://{{ inventory_hostname }}:{{ patroni_restapi_port }}) = '200' ] && wal-g backup-push"
+  - name: "WAL-G: Delete old backups" # older than 30 days (by default). Change according to your company's backup retention policy.
+    user: "postgres"
+    file: /etc/cron.d/walg
+    minute: "30"
+    hour: "6"
+    day: "*"
+    month: "*"
+    weekday: "*"
+    job: "[ $(curl -s -o /dev/null -w '%{http_code}' http://{{ inventory_hostname }}:{{ patroni_restapi_port }}) = '200' ] && wal-g delete before FIND_FULL $(date -d '-30 days' '+%FT%TZ') --confirm"
 
 # pgBackRest
 pgbackrest_install: false  # or 'true'
@@ -499,17 +517,6 @@ pgbackrest_cron_jobs:
     job: "pgbackrest --type=diff --stanza={{ pgbackrest_stanza }} backup"
     # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --type=diff --stanza={{ pgbackrest_stanza }} backup; fi"
 
-cron_jobs: []
-# Example for walg
-#  - name: "WAL-G: Create daily backup"
-#    user: "postgres"
-#    file: /etc/cron.d/walg
-#    minute: "30"
-#    hour: "6"
-#    day: "*"
-#    month: "*"
-#    weekday: "*"
-#    job: "[ $(curl -s -o /dev/null -w '%{http_code}' http://{{ inventory_hostname }}:{{ patroni_restapi_port }}) = '200' ] && wal-g backup-push"
 
 # PITR mode (if patroni_cluster_bootstrap_method: "pgbackrest" or "wal-g"):
 # 1) The database cluster directory will be cleaned (for "wal-g") or overwritten (for "pgbackrest" --delta restore).

--- a/vars/system.yml
+++ b/vars/system.yml
@@ -188,4 +188,25 @@ copy_files_to_all_server: []
 #  - { src: "files/ssl-cert-snakeoil.key", dest: "/etc/ssl/private/ssl-cert-snakeoil.key", owner: "postgres", group: "postgres", mode: "0600" }
 #  - { src: "files/myfile", dest: "/path/to/myfile", owner: "postgres", group: "postgres", mode: "0640" }
 
+# System cron jobs
+cron_jobs: []
+#  - name: "Example Job one"
+#    user: "postgres"
+#    file: /etc/cron.d/example_job_one
+#    minute: "00"
+#    hour: "1"
+#    day: "*"
+#    month: "*"
+#    weekday: "*"
+#    job: "echo 'example job one command'"
+#  - name: "Example Job two"
+#    user: "postgres"
+#    file: /etc/cron.d/example_job_two
+#    minute: "00"
+#    hour: "2"
+#    day: "*"
+#    month: "*"
+#    weekday: "*"
+#    job: "echo 'example job two command'"
+
 ...


### PR DESCRIPTION
1. If wal_g_install: true, setting up cron jobs for WAl-G.
2. Change the WAL-G config example to use with AWS S3
3. Move "cron_jobs" variable to vars/system.yml

New variable "wal_g_cron_jobs"