### PR TITLE
Patroni: Replace md5 with postgresql_password_encryption_algorithm in pg_hba.conf section

### DIFF
--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -106,8 +106,8 @@ bootstrap:
 {% endif %}
 
   pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
-    - host replication {{ patroni_replication_username }} 127.0.0.1/32 md5
-    - host all all 0.0.0.0/0 md5
+    - host replication {{ patroni_replication_username }} 127.0.0.1/32 {{ postgresql_password_encryption_algorithm }}
+    - host all all 0.0.0.0/0 {{ postgresql_password_encryption_algorithm }}
 
 
 postgresql:


### PR DESCRIPTION
This PR updates the pg_hba.conf file during the initdb process. The modification involves replacing the `md5` password encryption algorithm with a dynamic, `{{ postgresql_password_encryption_algorithm }}`, which allows for flexible and secure password encryption.

Note that this configuration change applies only to the initdb process and further pg_hba.conf is managed using Ansible.

Issue https://github.com/vitabaks/postgresql_cluster/issues/389