### PR TITLE
Patroni: switch to Patroni REST API endpoint '/primary'

### DIFF
--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -33,7 +33,7 @@ listen master
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
     option tcplog
-    option httpchk OPTIONS /master
+    option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -33,7 +33,7 @@ listen master
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
     option tcplog
-    option httpchk OPTIONS /master
+    option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -101,10 +101,10 @@ consul_join: []  # List of LAN servers of an existing consul cluster, to join.
 consul_services:
   - name: "{{ patroni_cluster_name }}"
     id: "{{ patroni_cluster_name }}-master"
-    tags: ['master']
+    tags: ['master', 'primary']
     port: "{{ pgbouncer_listen_port }}"  # or "{{ postgresql_port }}" if pgbouncer_install: false
     checks:
-      - { http: "http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/master", interval: "2s" }
+      - { http: "http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/primary", interval: "2s" }
       - { args: ["systemctl", "status", "pgbouncer"], interval: "5s" }  # comment out this check if pgbouncer_install: false
   - name: "{{ patroni_cluster_name }}"
     id: "{{ patroni_cluster_name }}-replica"


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/381

Starting with Patroni version 3.0.0, endpoint '/master' was removed from the documentation. Although backward compatibility is still working, but in future versions endpoint '/master' may be completely removed, so we switch to Patroni REST API endpoint '/primary'.

Details here: https://github.com/zalando/patroni/pull/2541