### PR TITLE
Haproxy stats to vip

### DIFF
--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Restart haproxy service
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
     name: haproxy
     enabled: true
@@ -9,9 +9,9 @@
   listen: "restart haproxy"
 
 - name: Check HAProxy is started and accepting connections
-  wait_for:
+  ansible.builtin.wait_for:
     port: "{{ haproxy_listen_port.stats }}"
-    host: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}"
+    host: "{{ cluster_vip | default(hostvars[inventory_hostname]['inventory_hostname'], true) }}"
     state: started
     timeout: 120
     delay: 10

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -21,11 +21,14 @@ defaults
 
 listen stats
     mode http
+{% if cluster_vip is defined and cluster_vip | length > 0 %}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.stats }}
+{% else %}
     bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.stats }}
+{% endif %}
     stats enable
     stats uri /
 
-listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
     bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
 {% else %}

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -29,6 +29,7 @@ listen stats
     stats enable
     stats uri /
 
+listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
     bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
 {% else %}


### PR DESCRIPTION
This PR binds the `cluster_vip` IP to the haproxy stats endpoint if exists. 
It will align with the other exposed endpoints like master, replicas etc.
Please review.

Thanks

