### PR TITLE
Fix: Disable privilege escalation for temp file deletion tasks

### DIFF
--- a/roles/confd/tasks/main.yml
+++ b/roles/confd/tasks/main.yml
@@ -83,6 +83,7 @@
       notify: "restart confd"
 
     - name: Remove confd.toml, haproxy.toml, haproxy.tmpl files from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: "files/{{ item }}"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -419,6 +419,7 @@
       notify: "restart haproxy"
 
     - name: Remove haproxy.cfg file from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: files/haproxy.cfg

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -67,6 +67,7 @@
       notify: "restart keepalived"
 
     - name: Remove keepalived.conf file from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: files/keepalived.conf

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -309,6 +309,7 @@
         mode: "0640"
 
     - name: Remove patroni.yml conf files from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: files/patroni.yml

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -145,6 +145,7 @@
       when: not pgbouncer_auth_user|bool
 
     - name: Remove pgbouncer.ini file from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: files/pgbouncer.ini
@@ -152,6 +153,7 @@
       delegate_to: localhost
 
     - name: Remove userlist.txt conf file from localhost
+      become: false
       run_once: true
       ansible.builtin.file:
         path: files/userlist.txt


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/414

Previously, tasks involving the deletion of temporary files, where delegation to localhost was employed, were unnecessarily requiring sudo privileges. This was causing issues during execution, as the tasks were prompting for a sudo password and failing if not provided.

To address this, we've added `become: false` to these tasks. This disables privilege escalation for these specific tasks, allowing them to execute without needing sudo permissions. It's important to note that this change doesn't affect the security or functionality of our playbook. Instead, it streamlines execution by eliminating unnecessary privilege requests.

This fix has been applied to all tasks involving the deletion of temporary files where `delegate_to: localhost` is used. 

With this update, we expect smoother and more efficient playbook runs, improving our automation capabilities.