### PR TITLE
custom_wal_dir: Refactoring custom WAL directory setup

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,7 +15,13 @@
         with_haproxy_load_balancing: true
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
+        postgresql_version: "15"
         cacheable: true
+
+    - name: Set variables for custom PostgreSQL data and WAL directory test
+      ansible.builtin.set_fact:
+        postgresql_data_dir: "/data/{{ postgresql_version }}/main"
+        postgresql_wal_dir: "/wal/{{ postgresql_version }}/pg_wal"
 
     - name: Set variables for TimescaleDB cluster deployment test
       ansible.builtin.set_fact:

--- a/roles/patroni/tasks/custom_wal_dir.yml
+++ b/roles/patroni/tasks/custom_wal_dir.yml
@@ -40,12 +40,21 @@
       become_user: postgres
       ansible.builtin.command: psql -tAXc "CHECKPOINT"
 
-    - name: Stop patroni service (for create symlink)
+    - name: Stop patroni service on the Replica (for create symlink)
       become: true
       become_user: root
       ansible.builtin.systemd:
         name: patroni
         state: stopped
+      when: not is_master | bool
+
+    - name: Stop patroni service on the Leader (for create symlink)
+      become: true
+      become_user: root
+      ansible.builtin.systemd:
+        name: patroni
+        state: stopped
+      when: is_master | bool
 
     - name: Make sure PostgreSQL is stopped
       become: true
@@ -77,12 +86,13 @@
         dest: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}"
         state: link
 
-    - name: Start patroni service
+    - name: Start patroni service on the Leader
       become: true
       become_user: root
       ansible.builtin.systemd:
         name: patroni
         state: started
+      when: is_master | bool
 
     - name: "Wait for port {{ patroni_restapi_port }} to become open on the host"
       ansible.builtin.wait_for:
@@ -92,8 +102,37 @@
         timeout: 120
         delay: 10
       ignore_errors: false
+      when: is_master | bool
 
-    - name: Check that the patroni is healthy
+    - name: Check that the patroni is healthy (the leader with the lock)
+      ansible.builtin.uri:
+        url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/leader"
+        status_code: 200
+      register: patroni_result
+      until: patroni_result.status == 200
+      retries: 120
+      delay: 10
+      when: is_master | bool
+
+    - name: Start patroni service on the Replica
+      become: true
+      become_user: root
+      ansible.builtin.systemd:
+        name: patroni
+        state: started
+      when: not is_master | bool
+
+    - name: "Wait for port {{ patroni_restapi_port }} to become open on the host"
+      ansible.builtin.wait_for:
+        port: "{{ patroni_restapi_port }}"
+        host: "{{ hostvars[inventory_hostname]['inventory_hostname'] }}"
+        state: started
+        timeout: 120
+        delay: 10
+      ignore_errors: false
+      when: not is_master | bool
+
+    - name: Check that the patroni is healthy on the Replica
       ansible.builtin.uri:
         url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/health"
         status_code: 200
@@ -101,15 +140,12 @@
       until: patroni_result.status == 200
       retries: 120
       delay: 10
-  when: sym.stat.exists and not sym.stat.islnk | bool
+      when: not is_master | bool
 
-# Remove the old wal directory if patroni is healthy
-- name: "Remove {{ pg_wal_dir }}_old directory"
-  ansible.builtin.file:
-    path: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}_old"
-    state: absent
-  when:
-    - patroni_result.status is defined
-    - patroni_result.status == 200
+    - name: "Remove {{ pg_wal_dir }}_old directory"
+      ansible.builtin.file:
+        path: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}_old"
+        state: absent
+  when: sym.stat.exists and not sym.stat.islnk | bool
 
 ...

--- a/roles/patroni/tasks/custom_wal_dir.yml
+++ b/roles/patroni/tasks/custom_wal_dir.yml
@@ -1,11 +1,28 @@
 ---
 
-- name: "Make sure {{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }} is symlink"
+# 🔄 Determine base pg_wal_dir name
+- name: Roles.patroni.custom_wal_dir | Set pg_wal_dir based on postgresql_version
+  ansible.builtin.set_fact:
+    pg_wal_dir: "{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}"
+
+- name: "Make sure {{ postgresql_data_dir }}/{{ pg_wal_dir }} is symlink"
   ansible.builtin.stat:
-    path: "{{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}"
+    path: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}"
   register: sym
 
-- block:  # synchronize WAL`s if wal dir exist (and is not symlink)
+# Synchronize WAL`s (if wal dir is not symlink)
+- block:
+    - name: Make sure the custom WAL directory "{{ postgresql_wal_dir }}" exists and is empty
+      ansible.builtin.file:
+        path: "{{ postgresql_wal_dir }}"
+        state: "{{ item }}"
+        owner: postgres
+        group: postgres
+        mode: "0700"
+      loop:
+        - absent
+        - directory
+
     - name: Make sure rsync is installed (for synchronize wal dir)
       ansible.builtin.package:
         name:
@@ -18,11 +35,17 @@
       retries: 3
       environment: "{{ proxy_env | default({}) }}"
 
+    - name: Execute CHECKPOINT before stopping PostgreSQL
+      become: true
+      become_user: postgres
+      ansible.builtin.command: psql -tAXc "CHECKPOINT"
+
     - name: Stop patroni service (for create symlink)
+      become: true
+      become_user: root
       ansible.builtin.systemd:
         name: patroni
         state: stopped
-      register: patroni_stop_result
 
     - name: Make sure PostgreSQL is stopped
       become: true
@@ -35,35 +58,28 @@
       retries: 100
       delay: 6
 
-    - name: "Synchronize {{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }} to {{ postgresql_wal_dir }}"
+    - name: "Synchronize {{ postgresql_data_dir }}/{{ pg_wal_dir }} to {{ postgresql_wal_dir }}"
       become: true
       become_user: postgres
       ansible.posix.synchronize:
-        src: "{{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}/"
+        src: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}/"
         dest: "{{ postgresql_wal_dir }}/"
       delegate_to: "{{ inventory_hostname }}"
 
-    # 🔄 Determine base pg_wal_dir name
-    - name: Roles.patroni.custom_wal_dir | Set pg_wal_dir based on postgresql_version
-      ansible.builtin.set_fact:
-        pg_wal_dir: "{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}"
-
     - name: "Rename {{ pg_wal_dir }} to {{ pg_wal_dir }}_old"
       ansible.builtin.command: mv {{ postgresql_data_dir }}/{{ pg_wal_dir }} {{ postgresql_data_dir }}/{{ pg_wal_dir }}_old
-      register: mv_result
-  when: sym.stat.exists and not sym.stat.islnk|bool
 
-- name: "Create symlink {{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }} -> {{ postgresql_wal_dir }}"
-  become: true
-  become_user: postgres
-  ansible.builtin.file:
-    src: "{{ postgresql_wal_dir }}"
-    dest: "{{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}"
-    state: link
-  when: sym.stat.islnk is not defined or not sym.stat.islnk|bool
+    - name: "Create symlink {{ postgresql_data_dir }}/{{ pg_wal_dir }} -> {{ postgresql_wal_dir }}"
+      become: true
+      become_user: postgres
+      ansible.builtin.file:
+        src: "{{ postgresql_wal_dir }}"
+        dest: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}"
+        state: link
 
-- block:  # start patroni
     - name: Start patroni service
+      become: true
+      become_user: root
       ansible.builtin.systemd:
         name: patroni
         state: started
@@ -81,18 +97,19 @@
       ansible.builtin.uri:
         url: "http://{{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}/health"
         status_code: 200
-      register: replica_result
-      until: replica_result.status == 200
+      register: patroni_result
+      until: patroni_result.status == 200
       retries: 120
       delay: 10
-  when: patroni_stop_result is changed
+  when: sym.stat.exists and not sym.stat.islnk | bool
 
-- name: "Remove {{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}_old directory"
+# Remove the old wal directory if patroni is healthy
+- name: "Remove {{ pg_wal_dir }}_old directory"
   ansible.builtin.file:
-    path: "{{ postgresql_data_dir }}/{{ 'pg_wal' if postgresql_version is version('10', '>=') else 'pg_xlog' }}_old"
+    path: "{{ postgresql_data_dir }}/{{ pg_wal_dir }}_old"
     state: absent
   when:
-    - replica_result.status is defined
-    - replica_result.status == 200
+    - patroni_result.status is defined
+    - patroni_result.status == 200
 
 ...

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -990,7 +990,7 @@
 # create symlink pg_xlog/pg_wal to custom WAL dir
 - ansible.builtin.import_tasks: custom_wal_dir.yml
   when: postgresql_wal_dir is defined and postgresql_wal_dir | length > 0
-  tags: patroni, custom_wal_dir
+  tags: patroni, custom_wal_dir, point_in_time_recovery
 
 # disable postgresql from autostart
 - block:  # "Debian"

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -181,9 +181,6 @@ postgresql:
     {% for item in basebackup %}
     {{ item.option }}: '{{ item.value }}'
     {% endfor %}
-    {% if postgresql_version is version('10', '>=') and postgresql_wal_dir is defined and postgresql_wal_dir | length > 0 %}
-    waldir: {{ postgresql_wal_dir }}
-    {% endif %}
   {% endif %}
   {% if 'pg_probackup' in patroni_create_replica_methods %}
   pg_probackup:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -384,6 +384,7 @@ wal_g:
 basebackup:
   - { option: "max-rate", value: "100M" }
   - { option: "checkpoint", value: "fast" }
+#  - { option: "waldir", value: "{{ postgresql_wal_dir }}" }
 pg_probackup:
   - { option: "command", value: "{{ pg_probackup_restore_command }}" }
   - { option: "no_params", value: "true" }


### PR DESCRIPTION
This PR includes a refactoring of the Ansible playbook that manages PostgreSQL's WAL directory, as well as an update to the Patroni configuration template.

Main Changes:

1. **Refactoring the Ansible playbook for managing Postgresql WAL**:
- Defined the name of the base WAL directory at the start of the script. This improves readability and simplifies the handling of the variable later in the script.
- Updated the WAL synchronization block. Now, it first ensures the custom WAL directory exists and is empty. Execute CHECKPOINT before stopping PostgreSQL.
- Modified the order of certain actions to enhance script reliability.
2. **Updating the Patroni configuration template**:
- Removed the PostgreSQL version check and the condition for defining waldir in the template.
- Added a new option In 'basebackup' variable which allows users to specify 'waldir' setting. By default, this option is disabled.
3. **Additional tag added for point-in-time recovery operations**:
- An extra tag `point_in_time_recovery` has been introduced for tasks in `custom_wall_dir.yml`. This tag allows the execution of these tasks specifically after restore from backup to ensure that a symlink to a separate WAL directory set up after the recovery. 
4. **Added molecule test for custom PostgreSQL data and WAL directory**.
-  It makes sense when custom paths are set in the variables `postgresql_data_dir` and `postgresql_wal_dir`
- This test verifies that our setup can accommodate non-standard directory paths and supports relocating the WAL directory to a separate disk (using a symlink).

These changes will make the playbook more robust and user-friendly for configuration and maintenance.