### PR TITLE
pgbouncer: Add auth_dbname option

### DIFF
--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -14,6 +14,7 @@ unix_socket_dir = /var/run/postgresql
 auth_type = {{ pgbouncer_auth_type }}
 {% if pgbouncer_auth_user | bool %}
 auth_user = {{ pgbouncer_auth_username }}
+auth_dbname = {{ pgbouncer_auth_dbname }}
 auth_query = SELECT usename, passwd FROM user_search($1)
 {% else %} 
 auth_file = {{ pgbouncer_conf_dir }}/userlist.txt

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -295,13 +295,14 @@ pgbouncer_max_db_connections: 1000
 pgbouncer_default_pool_size: 20
 pgbouncer_query_wait_timeout: 120
 pgbouncer_default_pool_mode: "session"
-pgbouncer_admin_users: "postgres"  # comma-separated list of users, who are allowed to change settings
-pgbouncer_stats_users: "postgres"  # comma-separated list of users who are just allowed to use SHOW command
+pgbouncer_admin_users: "{{ patroni_superuser_username }}"  # comma-separated list of users, who are allowed to change settings
+pgbouncer_stats_users: "{{ patroni_superuser_username }}"  # comma-separated list of users who are just allowed to use SHOW command
 pgbouncer_ignore_startup_parameters: "extra_float_digits,geqo,search_path"
 pgbouncer_auth_type: "{{ postgresql_password_encryption_algorithm }}"
 pgbouncer_auth_user: true # or 'false' if you want to manage the list of users for authentication in the database via userlist.txt
 pgbouncer_auth_username: pgbouncer # user who can query the database via the user_search function
 pgbouncer_auth_password: "pgbouncer-pass" # please change password
+pgbouncer_auth_dbname: "postgres"
 
 pgbouncer_pools:
   - { name: "postgres", dbname: "postgres", pool_parameters: "" }


### PR DESCRIPTION
The database name “pgbouncer” is reserved for the admin console.

Related MR: https://github.com/vitabaks/postgresql_cluster/pull/401

Fixed:

```
postgres@pgnode02:~$ psql -h 127.0.0.1 -p 6432 -U postgres -d pgbouncer
psql: error: connection to server at "127.0.0.1", port 6432 failed: FATAL:  bouncer config error
```
pgbouncer.log
```
2023-08-03 12:46:22.405 UTC [15102] ERROR C-0x562de93bce50: (nodb)/(nouser)@127.0.0.1:55328 cannot use the reserved "pgbouncer" database as an auth_dbname
2023-08-03 12:46:22.405 UTC [15102] WARNING C-0x562de93bce50: (nodb)/(nouser)@127.0.0.1:55328 pooler error: bouncer config error
2023-08-03 12:46:24.158 UTC [15102] LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us, wait 0 us
```