### PR TITLE
Move OS checking tasks to the pre-checks role

### DIFF
--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -42,16 +42,6 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
 
-    - name: Checking Linux distribution
-      ansible.builtin.fail:
-        msg: "{{ ansible_distribution }} is not supported"
-      when: ansible_distribution not in os_valid_distributions
-
-    - name: Checking version of OS Linux
-      ansible.builtin.fail:
-        msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
-      when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
-
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -131,16 +131,6 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
 
-    - name: Checking Linux distribution
-      ansible.builtin.fail:
-        msg: "{{ ansible_distribution }} is not supported"
-      when: ansible_distribution not in os_valid_distributions
-
-    - name: Checking version of OS Linux
-      ansible.builtin.fail:
-        msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
-      when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
-
     - name: Build a firewall_ports_dynamic_var
       ansible.builtin.set_fact:
         firewall_ports_dynamic_var: "{{ firewall_ports_dynamic_var | default([]) + (firewall_allowed_tcp_ports_for[item] | default([])) }}"

--- a/roles/pre-checks/tasks/main.yml
+++ b/roles/pre-checks/tasks/main.yml
@@ -7,6 +7,16 @@
   when:
     - ansible_version.full is version(minimal_ansible_version, '<')
 
+- name: Checking Linux distribution
+  ansible.builtin.fail:
+    msg: "{{ ansible_distribution }} is not supported"
+  when: ansible_distribution not in os_valid_distributions
+
+- name: Checking version of OS Linux
+  ansible.builtin.fail:
+    msg: "{{ ansible_distribution_version }} of {{ ansible_distribution }} is not supported"
+  when: ansible_distribution_version is version_compare(os_minimum_versions[ansible_distribution], '<')
+
 - name: Perform pre-checks for timescaledb
   ansible.builtin.import_tasks: timescaledb.yml
   when:


### PR DESCRIPTION
this is necessary to check the supported versions of Linux distributions at an early stage of the playbook execution. Previously, this check was performed only after the DCS cluster was deployed.