### PR TITLE
Do not install PowerTools repository and postgresql devel package by default (RedHat)

### DIFF
--- a/roles/add-repository/tasks/main.yml
+++ b/roles/add-repository/tasks/main.yml
@@ -123,30 +123,33 @@
             ansible_distribution_major_version == '7')
       tags: install_scl_repo
 
-    # PowerTools repository (to install dependencies for postgresql<version>-devel package)
-    - name: Enable PowerTools repository
-      ansible.builtin.command: dnf config-manager --set-enabled "[Pp]ower[Tt]ools"
-      when:
-        - ansible_distribution_major_version is version('8', '==')
-        - ansible_distribution != "OracleLinux"
-        - ansible_distribution != 'RedHat'
-        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
+    # Add repository to install dependencies for postgresql<version>-devel package
+    - block:
+        # PowerTools repository
+        - name: Enable PowerTools repository
+          ansible.builtin.command: dnf config-manager --set-enabled "[Pp]ower[Tt]ools"
+          when:
+            - ansible_distribution_major_version is version('8', '==')
+            - ansible_distribution != "OracleLinux"
+            - ansible_distribution != 'RedHat'
 
-    # CodeReady Linux Builder (crb) repository (to install dependencies for postgresql<version>-devel package)
-    - name: Enable CodeReady Linux Builder (crb) repository
-      ansible.builtin.command: dnf config-manager --set-enabled crb
-      when:
-        - ansible_distribution_major_version is version('9', '>=')
-        - ansible_distribution != "OracleLinux"
-        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
+        # CodeReady Linux Builder (crb) repository
+        - name: Enable CodeReady Linux Builder (crb) repository
+          ansible.builtin.command: dnf config-manager --set-enabled crb
+          when:
+            - ansible_distribution_major_version is version('9', '>=')
+            - ansible_distribution != "OracleLinux"
 
-    # CodeReady Builder repository for OracleLinux (to install dependencies for postgresql<version>-devel package)
-    - name: Enable CodeReady Builder repository
-      ansible.builtin.command: dnf config-manager --enable ol{{ ansible_distribution_major_version }}_codeready_builder
+        # CodeReady Builder repository for OracleLinux
+        - name: Enable CodeReady Builder repository
+          ansible.builtin.command: dnf config-manager --enable ol{{ ansible_distribution_major_version }}_codeready_builder
+          when:
+            - ansible_distribution == "OracleLinux"
+            - ansible_distribution_major_version is version('8', '>=')
+      vars:
+        pg_devel_package: "postgresql{{ postgresql_version | replace('.', '') }}-devel"
       when:
-        - ansible_distribution == "OracleLinux"
-        - ansible_distribution_major_version is version('8', '>=')
-        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
+        - pg_devel_package in postgresql_packages
 
     # Install PostgreSQL Repository
     - name: Get pgdg-redhat-repo-latest.noarch.rpm

--- a/roles/add-repository/tasks/main.yml
+++ b/roles/add-repository/tasks/main.yml
@@ -129,6 +129,7 @@
       when:
         - ansible_distribution_major_version is version('8', '==')
         - ansible_distribution != "OracleLinux"
+        - ansible_distribution != 'RedHat'
 
     # CodeReady Linux Builder (crb) repository (to install dependencies for postgresql<version>-devel package)
     - name: Enable CodeReady Linux Builder (crb) repository

--- a/roles/add-repository/tasks/main.yml
+++ b/roles/add-repository/tasks/main.yml
@@ -130,6 +130,7 @@
         - ansible_distribution_major_version is version('8', '==')
         - ansible_distribution != "OracleLinux"
         - ansible_distribution != 'RedHat'
+        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
 
     # CodeReady Linux Builder (crb) repository (to install dependencies for postgresql<version>-devel package)
     - name: Enable CodeReady Linux Builder (crb) repository
@@ -137,6 +138,7 @@
       when:
         - ansible_distribution_major_version is version('9', '>=')
         - ansible_distribution != "OracleLinux"
+        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
 
     # CodeReady Builder repository for OracleLinux (to install dependencies for postgresql<version>-devel package)
     - name: Enable CodeReady Builder repository
@@ -144,6 +146,7 @@
       when:
         - ansible_distribution == "OracleLinux"
         - ansible_distribution_major_version is version('8', '>=')
+        - ("postgresql{{ postgresql_version | replace('.', '') }}-devel" in postgresql_packages)
 
     # Install PostgreSQL Repository
     - name: Get pgdg-redhat-repo-latest.noarch.rpm

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -68,7 +68,7 @@ system_packages:
 # for RHEL version 8 (only)
 glibc_langpack:
   - "glibc-langpack-en"
-  - "glibc-langpack-ru"  # optional
+#  - "glibc-langpack-ru"
 #  - "glibc-langpack-de"
 
 postgresql_packages:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -75,7 +75,7 @@ postgresql_packages:
   - postgresql{{ postgresql_version | replace('.', '') }}
   - postgresql{{ postgresql_version | replace('.', '') }}-server
   - postgresql{{ postgresql_version | replace('.', '') }}-contrib
-  - postgresql{{ postgresql_version | replace('.', '') }}-devel
+#  - postgresql{{ postgresql_version | replace('.', '') }}-devel
 #  - pg_repack{{ postgresql_version | replace('.', '') }}
 
 # Extra packages


### PR DESCRIPTION
issue: https://github.com/vitabaks/postgresql_cluster/issues/298

- Do not install PowerTools repository for RedHat 8
- Do not install the postgresql devel package by default
  - For compatibility with RedHat 8
  - Because you need to first execute the command "`subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms`" to install the necessary dependencies, which is only available with an active subscription on RedHat.
- Do not install the glibc-langpack-ru by default
- Do not install extra repositories if the devel package is not defined in `postgresql_packages`