### PR TITLE
WAL-G: fix command for task "Check the latest available Go version" and install make package

### DIFF
--- a/roles/wal-g/tasks/main.yml
+++ b/roles/wal-g/tasks/main.yml
@@ -103,7 +103,7 @@
     - name: Check the latest available Go version
       ansible.builtin.shell: |
         set -o pipefail;
-        curl -s https://go.dev/VERSION?m=text | tr -d 'go'
+        curl -s https://go.dev/VERSION?m=text | grep 'go' | tr -d 'go'
       args:
         executable: /bin/bash
       changed_when: false

--- a/roles/wal-g/tasks/main.yml
+++ b/roles/wal-g/tasks/main.yml
@@ -63,6 +63,7 @@
           - libbrotli-dev
           # - liblzo2-dev  # https://github.com/wal-g/wal-g/issues/1412
           - libsodium-dev
+          - make
           - cmake
           - git
         state: present
@@ -78,6 +79,7 @@
           - brotli-devel
           # - lzo-devel  # https://github.com/wal-g/wal-g/issues/1412
           - libsodium-devel
+          - make
           - cmake
           - gcc
           - git

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -420,7 +420,7 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: true  # or 'true'
+wal_g_install: false  # or 'true'
 wal_g_version: "2.0.1"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
   - { option: "AWS_ACCESS_KEY_ID", value: "{{ AWS_ACCESS_KEY_ID | default('') }}" }  # define values or pass via --extra-vars

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -420,7 +420,7 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: false  # or 'true'
+wal_g_install: true  # or 'true'
 wal_g_version: "2.0.1"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
   - { option: "AWS_ACCESS_KEY_ID", value: "{{ AWS_ACCESS_KEY_ID | default('') }}" }  # define values or pass via --extra-vars


### PR DESCRIPTION
issue: https://github.com/vitabaks/postgresql_cluster/issues/445

- Fix command for task "Check the latest available Go version"

Fixed:
```
FAILED! => {"changed": false, "dest": "/tmp/", "elapsed": 0, "gid": 0, "group": "root", "mode": "01777", "msg": "An unknown error occurred: URL can't contain control characters. '/dl/go1.21.0\\ntime 2023-08-04T20:14:06Z.linux-amd64.tar.gz' (found at least '\\n')", "owner": "root", "size": 4096, "state": "directory", "uid": 0, "url": "https://go.dev/dl/go1.21.0\ntime 2023-08-04T20:14:06Z.linux-amd64.tar.gz"}
```

- Add `make` package to lib dependencies
  - required for `community.general.make` module