### PR TITLE
pgbouncer: Ensure pgbouncer service is enabled

### DIFF
--- a/roles/pgbouncer/handlers/main.yml
+++ b/roles/pgbouncer/handlers/main.yml
@@ -2,7 +2,6 @@
 
 - name: Restart pgbouncer service
   ansible.builtin.systemd:
-    daemon_reload: true
     name: pgbouncer
     enabled: true
     state: restarted

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -48,7 +48,7 @@
     - not pgbouncer_systemd_service.stat.exists
   tags: pgbouncer_service, pgbouncer
 
-- name: Configure systemd service file
+- name: Configure pgbouncer systemd service file
   ansible.builtin.template:
     src: templates/pgbouncer.service.j2
     dest: /etc/systemd/system/pgbouncer.service
@@ -56,6 +56,13 @@
     group: postgres
     mode: "0644"
   notify: "restart pgbouncer"
+  tags: pgbouncer_service, pgbouncer
+
+- name: Ensure pgbouncer service is enabled
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: pgbouncer
+    enabled: true
   tags: pgbouncer_service, pgbouncer
 
 - block:  # workaround for pgbouncer from postgrespro repo

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -32,15 +32,23 @@
     mode: "0750"
   tags: pgbouncer_conf, pgbouncer
 
+- name: Check if pgbouncer systemd service file exists
+  ansible.builtin.stat:
+    path: /etc/systemd/system/pgbouncer.service
+  register: pgbouncer_systemd_service
+  tags: pgbouncer_service, pgbouncer
+
 - name: Stop and disable standard init script
   ansible.builtin.service:
     name: pgbouncer
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: 
+    - ansible_os_family == "Debian"
+    - not pgbouncer_systemd_service.stat.exists
   tags: pgbouncer_service, pgbouncer
 
-- name: Copy systemd service file
+- name: Configure systemd service file
   ansible.builtin.template:
     src: templates/pgbouncer.service.j2
     dest: /etc/systemd/system/pgbouncer.service

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -43,7 +43,7 @@
     name: pgbouncer
     state: stopped
     enabled: false
-  when: 
+  when:
     - ansible_os_family == "Debian"
     - not pgbouncer_systemd_service.stat.exists
   tags: pgbouncer_service, pgbouncer


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/452

- Stop and disable init script only if there is no systemd file
  - Now we first check if the pgbouncer systemd service file exists. If it does not exist, then we stop and disable the service, assuming that it is managed via init script.

- Ensure pgbouncer service is enabled