### PR TITLE
config_pgcluster.yml: Add compatibility with check mode

### DIFF
--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -20,6 +20,7 @@
       register: patroni_leader_result
       changed_when: false
       failed_when: false
+      check_mode: false
 
     # Stop, if Patroni is unavailable
     - name: The Patroni cluster is unhealthy
@@ -37,6 +38,7 @@
       when: hostvars[item]['patroni_leader_result']['status'] == 200
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
+      check_mode: false
 
     - name: '[Prepare] Add hosts to group "secondary" (in-memory inventory)'
       ansible.builtin.add_host:
@@ -47,6 +49,7 @@
       when: hostvars[item]['patroni_leader_result']['status'] != 200
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
+      check_mode: false
 
     - name: "Print Patroni Cluster info"
       ansible.builtin.debug:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -129,6 +129,7 @@
       delay: 10
       changed_when: false
       ignore_errors: false
+      check_mode: false
 
     - name: cluster health
       ansible.builtin.debug:

--- a/roles/patroni/tasks/custom_wal_dir.yml
+++ b/roles/patroni/tasks/custom_wal_dir.yml
@@ -112,7 +112,7 @@
       until: patroni_result.status == 200
       retries: 120
       delay: 10
-      when: is_master | bool
+      when: is_master | bool and not ansible_check_mode
 
     - name: Start patroni service on the Replica
       become: true
@@ -140,7 +140,7 @@
       until: patroni_result.status == 200
       retries: 120
       delay: 10
-      when: not is_master | bool
+      when: not is_master | bool and not ansible_check_mode
 
     - name: "Remove {{ pg_wal_dir }}_old directory"
       ansible.builtin.file:

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -840,7 +840,9 @@
       until: result.status == 200
       retries: 10
       delay: 2
-      when: patroni_standby_cluster.host is not defined or patroni_standby_cluster.host | length < 1
+      when:
+        - (patroni_standby_cluster.host is not defined or patroni_standby_cluster.host | length < 1)
+        - not ansible_check_mode
   when: is_master | bool
   tags: patroni, patroni_start_master, point_in_time_recovery
 
@@ -984,6 +986,7 @@
       until: replica_result.status == 200
       retries: 1200  # timeout 10 hours
       delay: 30
+      when: not ansible_check_mode
   when: not is_master | bool
   tags: patroni, patroni_start_replica, point_in_time_recovery
 

--- a/roles/ssh-keys/tasks/main.yml
+++ b/roles/ssh-keys/tasks/main.yml
@@ -46,8 +46,10 @@
       no_log: true
       loop: "{{ ssh_known_host_results.results }}"
   ignore_errors: true
-  when: enable_ssh_key_based_authentication is defined and
-        enable_ssh_key_based_authentication|bool
+  when:
+    - anable_ssh_key_based_authentication is defined
+    - enable_ssh_key_based_authentication | bool
+    - not ansible_check_mode
   tags: ssh_keys
 
 ...

--- a/roles/transparent_huge_pages/handlers/main.yml
+++ b/roles/transparent_huge_pages/handlers/main.yml
@@ -7,5 +7,6 @@
     state: restarted
     enabled: true
   listen: "restart disable-thp"
+  when: not ansible_check_mode
 
 ...


### PR DESCRIPTION
Add the ability to perform playbook config_pgcluster.yml in check mode.

ansible-playbook --check  (don't make any changes; instead, try to predict some of the changes that may occur)