### PR TITLE
Fix: Do not use a proxy when accessing the Patroni API

### DIFF
--- a/roles/patroni/config/tasks/main.yml
+++ b/roles/patroni/config/tasks/main.yml
@@ -57,6 +57,8 @@
         body_format: json
       loop: "{{ postgresql_parameters }}"
       when: item.value == "null"
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when: is_master | bool
   tags: patroni, patroni_conf
 


### PR DESCRIPTION
Do not use a proxy server when accessing the Patroni REST API, endpoint `/config`

Role: `patroni/config`

Fixed:

```
TASK [patroni/config : Update postgresql parameters in DCS] ********************
failed: [10.129.50.31] (item={'option': 'max_connections', 'value': '500'}) => {"ansible_loop_var": "item", "changed": false, "connection": "close", "content_language": "en", "content_length": "3643", "content_type": "text/html;charset=utf-8", "date": "Thu, 07 Sep 2023 10:50:00 GMT", "elapsed": 0, "item": {"option": "max_connections", "value": "500"}, "mime_version": "1.0", "msg": "Status code was 403 and not [200]: HTTP Error 403: Forbidden", "redirected": false, "server": "squid/4.4", "status": 403, "url": "http://10.129.50.31:8008/config", "vary": "Accept-Language", "via": "1.1 ftpserver (squid/4.4)", "x_cache": "MISS from ftpserver", "x_cache_lookup": "NONE from ftpserver:3128", "x_squid_error": "ERR_ACCESS_DENIED 0"}
```