### PR TITLE
pgbackrest: do not perform the role of ssh_keys in check mode

### DIFF
--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -166,6 +166,7 @@
     - pgbackrest_repo_type|lower == "posix"
     - pgbackrest_repo_host is defined
     - pgbackrest_repo_host | length > 0
+    - not ansible_check_mode
   tags: pgbackrest, pgbackrest_ssh_keys
 
 - ansible.builtin.import_tasks: cron.yml


### PR DESCRIPTION
Add the ability to perform role "pgbackrest" in check mode.

ansible-playbook --check (don't make any changes; instead, try to predict some of the changes that may occur)

Fixed:

```
TASK [pgbackrest : ssh_keys | Ensure ssh key are created for "postgres" user on pgbackrest server] ***
ok: [10.128.150.35]
TASK [pgbackrest : ssh_keys | Ensure ssh key are created for "postgres" user on database servers] ***
ok: [10.128.150.247]
TASK [pgbackrest : ssh_keys | Get public ssh key from pgbackrest server] *******
ok: [10.128.150.35]
TASK [pgbackrest : ssh_keys | Get public ssh key from database servers] ********
ok: [10.128.150.247]
TASK [pgbackrest : ssh_keys | Add pgbackrest ssh key in "~postgres/.ssh/authorized_keys" on database servers] ***
ok: [10.128.150.247] => (item=10.128.150.35)
TASK [pgbackrest : ssh_keys | Add database ssh keys in "~postgres/.ssh/authorized_keys" on pgbackrest server] ***
ok: [10.128.150.35] => (item=10.128.150.247)
TASK [pgbackrest : known_hosts | add ssh public keys in "~postgres/.ssh/known_hosts" on database servers] ***
failed: [10.128.150.247] (item=None) => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
failed: [10.128.150.247] (item=None) => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
fatal: [10.128.150.247]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```

Related PR: https://github.com/vitabaks/postgresql_cluster/pull/459