### PR TITLE
vip-manager: do not install in check mode

### DIFF
--- a/roles/vip-manager/tasks/main.yml
+++ b/roles/vip-manager/tasks/main.yml
@@ -32,7 +32,11 @@
       delay: 5
       retries: 3
       when: ansible_os_family == "RedHat"
-  when: installation_method == "repo" and vip_manager_package_repo | length > 0
+  when:
+    - installation_method == "repo"
+    - vip_manager_package_repo | length > 0
+    - not ansible_check_mode
+    - not postgresql_cluster_maintenance | default(false) | bool
   tags: vip, vip_manager, vip_manager_install
 
 - block:  # install vip-manager package from file
@@ -62,7 +66,11 @@
       delay: 5
       retries: 3
       when: ansible_os_family == "RedHat"
-  when: installation_method == "file" and vip_manager_package_file | length > 0
+  when:
+    - installation_method == "file"
+    - vip_manager_package_file | length > 0
+    - not ansible_check_mode
+    - not postgresql_cluster_maintenance | default(false) | bool
   tags: vip, vip_manager, vip_manager_install
 
 - name: Make sure the conf directory "{{ vip_manager_conf | dirname }}" exist


### PR DESCRIPTION
- do not install vip-manager in check mode
- do not install vip-manager in maintenance mode (config_pgcluster.yml)

Fixed:

```
TASK [vip-manager : Get vip-manager package] ***********************************
changed: [192.168.12.216] => (item=https://github.com/cybertec-postgresql/vip-manager/releases/download/v2.1.0/vip-manager_2.1.0_Linux_x86_64.deb)
changed: [192.168.12.215] => (item=https://github.com/cybertec-postgresql/vip-manager/releases/download/v2.1.0/vip-manager_2.1.0_Linux_x86_64.deb)
changed: [192.168.12.217] => (item=https://github.com/cybertec-postgresql/vip-manager/releases/download/v2.1.0/vip-manager_2.1.0_Linux_x86_64.deb)
FAILED - RETRYING: [192.168.12.216]: Install vip-manager (3 retries left).
FAILED - RETRYING: [192.168.12.217]: Install vip-manager (3 retries left).
FAILED - RETRYING: [192.168.12.215]: Install vip-manager (3 retries left).
FAILED - RETRYING: [192.168.12.216]: Install vip-manager (2 retries left).
FAILED - RETRYING: [192.168.12.217]: Install vip-manager (2 retries left).
FAILED - RETRYING: [192.168.12.215]: Install vip-manager (2 retries left).
FAILED - RETRYING: [192.168.12.216]: Install vip-manager (1 retries left).
FAILED - RETRYING: [192.168.12.217]: Install vip-manager (1 retries left).
FAILED - RETRYING: [192.168.12.215]: Install vip-manager (1 retries left).
TASK [vip-manager : Install vip-manager] ***************************************
fatal: [192.168.12.216]: FAILED! => {"attempts": 3, "changed": false, "msg": "Unable to install package: E:Could not open file /tmp/vip-manager_2.1.0_Linux_x86_64.deb - open (2: No such file or directory)"}
fatal: [192.168.12.217]: FAILED! => {"attempts": 3, "changed": false, "msg": "Unable to install package: E:Could not open file /tmp/vip-manager_2.1.0_Linux_x86_64.deb - open (2: No such file or directory)"}
fatal: [192.168.12.215]: FAILED! => {"attempts": 3, "changed": false, "msg": "Unable to install package: E:Could not open file /tmp/vip-manager_2.1.0_Linux_x86_64.deb - open (2: No such file or directory)"}
```

Related PR: https://github.com/vitabaks/postgresql_cluster/pull/459