### PR TITLE
pgbackrest: Create a unique cron file name

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -533,7 +533,7 @@ pgbackrest_patroni_cluster_restore_command:
 # If 'repo_host' is defined, the cron jobs will be created on the pgbackrest server.
 pgbackrest_cron_jobs:
   - name: "pgBackRest: Full Backup"
-    file: /etc/cron.d/pgbackrest
+    file: "/etc/cron.d/pgbackrest-{{ patroni_cluster_name }}"
     user: "postgres"
     minute: "30"
     hour: "6"
@@ -543,7 +543,7 @@ pgbackrest_cron_jobs:
     job: "pgbackrest --type=full --stanza={{ pgbackrest_stanza }} backup"
     # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --type=full --stanza={{ pgbackrest_stanza }} backup; fi"
   - name: "pgBackRest: Diff Backup"
-    file: /etc/cron.d/pgbackrest
+    file: "/etc/cron.d/pgbackrest-{{ patroni_cluster_name }}"
     user: "postgres"
     minute: "30"
     hour: "6"


### PR DESCRIPTION
Create a cron filename that includes the cluster name. 

To working with a dedicated pgbackrest server that caters to multiple PostgreSQL clusters, it's vital to include the cluster name in the filename. Without this distinction, another cluster using the same pgbackrest server might inadvertently overwrite the cron job file.