### PR TITLE
pgpass: do not output the contents to the log

### DIFF
--- a/roles/pgpass/tasks/main.yml
+++ b/roles/pgpass/tasks/main.yml
@@ -12,6 +12,7 @@
     owner: postgres
     group: postgres
     mode: "0600"
+  no_log: true
   when:
     - postgresql_pgpass is defined
     - postgresql_pgpass | length > 0


### PR DESCRIPTION
do not output the contents (passwords) to the ansible log for task "Configure a password"

To hide the contents in diff when using the ansible `ansible.builtin.copy`, set the `no_log` parameter to `true`. 

Fixed:

```
TASK [pgpass : Configure a password file (/var/lib/postgresql/.pgpass)] ********
--- before
+++ after: /root/.ansible/tmp/ansible-local-30xva_jds2/tmpbi95bhut
@@ -0,0 +1,2 @@
+localhost:5432:*:postgres:SECRET-PASSWORD
+192.168.12.216:5432:*:postgres:SECRET-PASSWORD2
changed: [192.168.12.216]
```