### PR TITLE
etcd: compatibility with check mode

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -44,7 +44,10 @@
       loop:
         - etcd
         - etcdctl
-  when: installation_method == "repo" and etcd_package_repo | length > 0
+  when:
+    - installation_method == "repo"
+    - etcd_package_repo | length > 0
+    - not ansible_check_mode
   tags: etcd, etcd_install
 
 - block:  # install etcd package from file
@@ -64,7 +67,10 @@
       loop:
         - etcd
         - etcdctl
-  when: installation_method == "file" and etcd_package_file | length > 0
+  when:
+    - installation_method == "file"
+    - etcd_package_file | length > 0
+    - not ansible_check_mode
   tags: etcd, etcd_install
 
 - name: Add etcd user

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -133,7 +133,7 @@
         ETCDCTL_API: "3"
       register: etcd_health_result
       until: >
-        'is healthy' in etcd_health_result.stdout or 
+        'is healthy' in etcd_health_result.stdout or
         'is healthy' in etcd_health_result.stderr
       retries: 10
       delay: 10

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -129,6 +129,8 @@
       ansible.builtin.command: >
         /usr/local/bin/etcdctl endpoint health
         --endpoints=http://{{ inventory_hostname }}:2379
+      environment:
+        ETCDCTL_API: "3"
       register: etcd_health_result
       until: "'is healthy' in etcd_health_result.stdout"
       retries: 10

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -132,7 +132,9 @@
       environment:
         ETCDCTL_API: "3"
       register: etcd_health_result
-      until: "'is healthy' in etcd_health_result.stdout"
+      until: >
+        'is healthy' in etcd_health_result.stdout or 
+        'is healthy' in etcd_health_result.stderr
       retries: 10
       delay: 10
       changed_when: false
@@ -140,7 +142,10 @@
 
     - name: cluster health
       ansible.builtin.debug:
-        msg: "{{ etcd_health_result.stdout }}"
+        msg: >
+          {{ etcd_health_result.stdout
+          if etcd_health_result.stdout | length > 0
+          else etcd_health_result.stderr }}
   when: not ansible_check_mode
   tags: etcd, etcd_start, etcd_status
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -135,11 +135,11 @@
       delay: 10
       changed_when: false
       ignore_errors: false
-      check_mode: false
 
     - name: cluster health
       ansible.builtin.debug:
         msg: "{{ etcd_health_result.stdout }}"
+  when: not ansible_check_mode
   tags: etcd, etcd_start, etcd_status
 
 ...


### PR DESCRIPTION
do not install etcd in check mode

ansible-playbook --check (don't make any changes; instead, try to predict some of the changes that may occur)

Fixed:

```
TASK [etcd : Download "etcd" package] ******************************************
failed: [10.129.50.35] (item=https://github.com/etcd-io/etcd/releases/download/vv3.3.27/etcd-v3.3.27-linux-amd64.tar.gz) => {"ansible_loop_var": "item", "changed": false, "dest": "/tmp/", "elapsed": 0, "gid": 0, "group": "root", "item": "https://github.com/etcd-io/etcd/releases/download/v3.3.27/etcd-v3.3.27-linux-amd64.tar.gz", "mode": "01777", "msg": "Request failed", "owner": "root", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 0, "url": "https://github.com/etcd-io/etcd/releases/download/v3.3.27/etcd-vv3.3.27-linux-amd64.tar.gz"}
```

Related PR: https://github.com/vitabaks/postgresql_cluster/pull/459

Additionally:
- Add ETCDCTL_API: "3" to environment
- expect 'is healthy' status in stdout or in stderr
    - In certain scenarios (for example the old etcd version), even when a command executes without errors (.rc=0), the output may reside in stderr instead of stdout. Now we accommodate for 'is healthy' in either output stream.