### PR TITLE
Parameters for patroni etcd username, password and namespace

### DIFF
--- a/roles/confd/templates/confd.toml.j2
+++ b/roles/confd/templates/confd.toml.j2
@@ -9,7 +9,15 @@ nodes = [
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
   {% for etcd_hosts in patroni_etcd_hosts %}
-  "http://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
+  "{{ patroni_etcd_protocol | default('http') }}://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
   {% endfor %}
 {% endif %}
 ]
+{% if dcs_exists|bool and dcs_type == 'etcd' %}
+{% if patroni_etcd_username | default("") | length > 0 %}
+username: {{ patroni_etcd_username | default("") }}
+{% endif %}
+{% if patroni_etcd_password | default("") | length > 0 %}
+password: {{ patroni_etcd_password }}
+{% endif %}
+{% endif %}

--- a/roles/confd/templates/confd.toml.j2
+++ b/roles/confd/templates/confd.toml.j2
@@ -9,15 +9,15 @@ nodes = [
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
   {% for etcd_hosts in patroni_etcd_hosts %}
-  "{{ patroni_etcd_protocol | default('') or 'http' }}://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
+  "{{ patroni_etcd_protocol | default('http', true) }}://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
   {% endfor %}
 {% endif %}
 ]
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
-{% if patroni_etcd_username | default("") | length > 0 %}
-username = "{{ patroni_etcd_username | default("") }}"
+{% if patroni_etcd_username | default('') | length > 0 %}
+username = "{{ patroni_etcd_username | default('') }}"
 {% endif %}
-{% if patroni_etcd_password | default("") | length > 0 %}
+{% if patroni_etcd_password | default('') | length > 0 %}
 password = "{{ patroni_etcd_password }}"
 {% endif %}
 {% endif %}

--- a/roles/confd/templates/confd.toml.j2
+++ b/roles/confd/templates/confd.toml.j2
@@ -9,15 +9,15 @@ nodes = [
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
   {% for etcd_hosts in patroni_etcd_hosts %}
-  "{{ patroni_etcd_protocol | default('http') }}://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
+  "{{ patroni_etcd_protocol | default('') or 'http' }}://{{etcd_hosts.host}}:{{etcd_hosts.port}}",
   {% endfor %}
 {% endif %}
 ]
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 {% if patroni_etcd_username | default("") | length > 0 %}
-username: {{ patroni_etcd_username | default("") }}
+username = "{{ patroni_etcd_username | default("") }}"
 {% endif %}
 {% if patroni_etcd_password | default("") | length > 0 %}
-password: {{ patroni_etcd_password }}
+password = "{{ patroni_etcd_password }}"
 {% endif %}
 {% endif %}

--- a/roles/confd/templates/haproxy.toml.j2
+++ b/roles/confd/templates/haproxy.toml.j2
@@ -1,5 +1,5 @@
 [template]
-prefix = "/{{ patroni_etcd_namespace | default("service") }}/{{ patroni_cluster_name }}"
+prefix = "/{{ patroni_etcd_namespace | default('service') }}/{{ patroni_cluster_name }}"
 src = "haproxy.tmpl"
 dest = "/etc/haproxy/haproxy.cfg"
 {% if haproxy_installation_method == "src" %}

--- a/roles/confd/templates/haproxy.toml.j2
+++ b/roles/confd/templates/haproxy.toml.j2
@@ -1,5 +1,5 @@
 [template]
-prefix = "/service/{{ patroni_cluster_name }}"
+prefix = "/{{ patroni_etcd_namespace | default("service") }}/{{ patroni_cluster_name }}"
 src = "haproxy.tmpl"
 dest = "/etc/haproxy/haproxy.cfg"
 {% if haproxy_installation_method == "src" %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -3,7 +3,7 @@
 
 scope: {{ patroni_cluster_name }}
 name: {{ ansible_hostname }}
-namespace: {{ patroni_etcd_namespace | default("service") }}
+namespace: /{{ patroni_etcd_namespace | default("service") }}
 
 {% if patroni_log_destination == 'logfile' %}
 log:

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -35,14 +35,14 @@ etcd3:
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 etcd3:
-  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor +%}
-  {% if patroni_etcd_username %}
+  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor %}
+  {% if patroni_etcd_username | default("") | length > 0 %}
   username: {{ patroni_etcd_username | default("") }}
   {% endif %}
-  {% if patroni_etcd_password | default("") %}
+  {% if patroni_etcd_password | default("") | length > 0 %}
   password: {{ patroni_etcd_password }}
   {% endif %}
-  {% if patroni_etcd_protocol | default("") %}
+  {% if patroni_etcd_protocol | default("") | length > 0 %}
   protocol: {{ patroni_etcd_protocol }}
   {% endif %}
 {% endif %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -3,7 +3,7 @@
 
 scope: {{ patroni_cluster_name }}
 name: {{ ansible_hostname }}
-namespace: /{{ patroni_etcd_namespace | default("service") }}
+namespace: /{{ patroni_etcd_namespace | default('service') }}
 
 {% if patroni_log_destination == 'logfile' %}
 log:
@@ -36,13 +36,13 @@ etcd3:
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 etcd3:
   hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor +%}
-  {% if patroni_etcd_username | default("") | length > 0 %}
-  username: {{ patroni_etcd_username | default("") }}
+  {% if patroni_etcd_username | default('') | length > 0 %}
+  username: {{ patroni_etcd_username | default('') }}
   {% endif %}
-  {% if patroni_etcd_password | default("") | length > 0 %}
+  {% if patroni_etcd_password | default('') | length > 0 %}
   password: {{ patroni_etcd_password }}
   {% endif %}
-  {% if patroni_etcd_protocol | default("") | length > 0 %}
+  {% if patroni_etcd_protocol | default('') | length > 0 %}
   protocol: {{ patroni_etcd_protocol }}
   {% endif %}
 {% endif %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -3,7 +3,7 @@
 
 scope: {{ patroni_cluster_name }}
 name: {{ ansible_hostname }}
-namespace: {{ patroni_etcd_namespace | default("/service/") }}
+namespace: {{ patroni_etcd_namespace | default("service") }}
 
 {% if patroni_log_destination == 'logfile' %}
 log:

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -3,7 +3,7 @@
 
 scope: {{ patroni_cluster_name }}
 name: {{ ansible_hostname }}
-namespace: /service/
+namespace: {{ patroni_etcd_namespace | default("/service/") }}
 
 {% if patroni_log_destination == 'logfile' %}
 log:
@@ -35,7 +35,16 @@ etcd3:
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 etcd3:
-  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor %}
+  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor +%}
+  {% if patroni_etcd_username %}
+  username: {{ patroni_etcd_username | default("") }}
+  {% endif %}
+  {% if patroni_etcd_password | default("") %}
+  password: {{ patroni_etcd_password }}
+  {% endif %}
+  {% if patroni_etcd_protocol | default("") %}
+  protocol: {{ patroni_etcd_protocol }}
+  {% endif %}
 {% endif %}
 
 {% if dcs_type == 'consul' %}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -35,7 +35,7 @@ etcd3:
 {% endif %}
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 etcd3:
-  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor %}
+  hosts: {% for etcd_hosts in patroni_etcd_hosts %}{{etcd_hosts.host}}:{{etcd_hosts.port}}{% if not loop.last %},{% endif %}{% endfor +%}
   {% if patroni_etcd_username | default("") | length > 0 %}
   username: {{ patroni_etcd_username | default("") }}
   {% endif %}

--- a/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/roles/vip-manager/templates/vip-manager.yml.j2
@@ -26,7 +26,7 @@ dcs-endpoints:
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 dcs-endpoints:
 {% for etcd_hosts in patroni_etcd_hosts %}
-  - {{ patroni_etcd_protocol | default('http') }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
+  - {{ patroni_etcd_protocol | default('') or 'http' }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
 {% endfor %}
 
 {% if patroni_etcd_username | default("") | length > 0 %}

--- a/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/roles/vip-manager/templates/vip-manager.yml.j2
@@ -4,7 +4,7 @@
 interval: {{ vip_manager_interval }}
 
 # the etcd or consul key which vip-manager will regularly poll.
-trigger-key: "/service/{{ patroni_cluster_name }}/leader"
+trigger-key: "/{{ patroni_etcd_namespace | default("service") }}/{{ patroni_cluster_name }}/leader"
 # if the value of the above key matches the trigger-value (often the hostname of this host), vip-manager will try to add the virtual ip address to the interface specified in Iface
 trigger-value: "{{ ansible_hostname }}"
 
@@ -26,8 +26,15 @@ dcs-endpoints:
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 dcs-endpoints:
 {% for etcd_hosts in patroni_etcd_hosts %}
-  - http://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
+  - {{ patroni_etcd_protocol | default('http') }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
 {% endfor %}
+
+{% if patroni_etcd_username | default("") | length > 0 %}
+etcd-user: {{ patroni_etcd_username | default("") }}
+{% endif %}
+{% if patroni_etcd_password | default("") | length > 0 %}
+etcd-password: {{ patroni_etcd_password }}
+{% endif %}
 {% endif %}
 
   # consul will always only use the first entry from this list.

--- a/roles/vip-manager/templates/vip-manager.yml.j2
+++ b/roles/vip-manager/templates/vip-manager.yml.j2
@@ -4,7 +4,7 @@
 interval: {{ vip_manager_interval }}
 
 # the etcd or consul key which vip-manager will regularly poll.
-trigger-key: "/{{ patroni_etcd_namespace | default("service") }}/{{ patroni_cluster_name }}/leader"
+trigger-key: "/{{ patroni_etcd_namespace | default('service') }}/{{ patroni_cluster_name }}/leader"
 # if the value of the above key matches the trigger-value (often the hostname of this host), vip-manager will try to add the virtual ip address to the interface specified in Iface
 trigger-value: "{{ ansible_hostname }}"
 
@@ -26,7 +26,7 @@ dcs-endpoints:
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 dcs-endpoints:
 {% for etcd_hosts in patroni_etcd_hosts %}
-  - {{ patroni_etcd_protocol | default('') or 'http' }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
+  - {{ patroni_etcd_protocol | default('http', true) }}://{{ etcd_hosts.host }}:{{ etcd_hosts.port }}
 {% endfor %}
 
 {% if patroni_etcd_username | default("") | length > 0 %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -66,9 +66,9 @@ patroni_etcd_hosts: []  # list of servers of an existing etcd cluster
 #  - { host: "10.128.64.142", port: "2379" }
 #  - { host: "10.128.64.143", port: "2379" }
 patroni_etcd_namespace: "/service/"  # (optional) etcd namespace for patroni cluster
-patroni_etcd_username:  "" # (optional) username for etcd authentication
-patroni_etcd_password:  "" # (optional) password for etcd authentication
-patroni_etcd_protocol:  "" # (optional) http or https, if not specified http is used
+patroni_etcd_username: "" # (optional) username for etcd authentication
+patroni_etcd_password: "" # (optional) password for etcd authentication
+patroni_etcd_protocol: "" # (optional) http or https, if not specified http is used
 
 # more options you can specify in the roles/patroni/templates/patroni.yml.j2
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,7 +65,7 @@ patroni_etcd_hosts: []  # list of servers of an existing etcd cluster
 #  - { host: "10.128.64.140", port: "2379" }
 #  - { host: "10.128.64.142", port: "2379" }
 #  - { host: "10.128.64.143", port: "2379" }
-patroni_etcd_namespace: "service"  # (optional) etcd namespace (prefix); patroni cluster, confd and vip-manager will store keys in  /{{ patroni_etcd_namespace }}/{{ patroni_cluster_name }}
+patroni_etcd_namespace: "service"  # (optional) etcd namespace (prefix)
 patroni_etcd_username: "" # (optional) username for etcd authentication
 patroni_etcd_password: "" # (optional) password for etcd authentication
 patroni_etcd_protocol: "" # (optional) http or https, if not specified http is used

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -66,9 +66,9 @@ patroni_etcd_hosts: []  # list of servers of an existing etcd cluster
 #  - { host: "10.128.64.142", port: "2379" }
 #  - { host: "10.128.64.143", port: "2379" }
 patroni_etcd_namespace: "/service/"  # (optional) etcd namespace for patroni cluster
-patroni_etcd_username:  # (optional) username for etcd authentication
-patroni_etcd_password:  # (optional) password for etcd authentication
-patroni_etcd_protocol:  # (optional) http or https, if not specified http is used
+patroni_etcd_username:  "" # (optional) username for etcd authentication
+patroni_etcd_password:  "" # (optional) password for etcd authentication
+patroni_etcd_protocol:  "" # (optional) http or https, if not specified http is used
 
 # more options you can specify in the roles/patroni/templates/patroni.yml.j2
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,6 +65,10 @@ patroni_etcd_hosts: []  # list of servers of an existing etcd cluster
 #  - { host: "10.128.64.140", port: "2379" }
 #  - { host: "10.128.64.142", port: "2379" }
 #  - { host: "10.128.64.143", port: "2379" }
+patroni_etcd_namespace: "/service/"  # (optional) etcd namespace for patroni cluster
+patroni_etcd_username:  # (optional) username for etcd authentication
+patroni_etcd_password:  # (optional) password for etcd authentication
+patroni_etcd_protocol:  # (optional) http or https, if not specified http is used
 
 # more options you can specify in the roles/patroni/templates/patroni.yml.j2
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,7 +65,7 @@ patroni_etcd_hosts: []  # list of servers of an existing etcd cluster
 #  - { host: "10.128.64.140", port: "2379" }
 #  - { host: "10.128.64.142", port: "2379" }
 #  - { host: "10.128.64.143", port: "2379" }
-patroni_etcd_namespace: "/service/"  # (optional) etcd namespace for patroni cluster
+patroni_etcd_namespace: "service"  # (optional) etcd namespace (prefix); patroni cluster, confd and vip-manager will store keys in  /{{ patroni_etcd_namespace }}/{{ patroni_cluster_name }}
 patroni_etcd_username: "" # (optional) username for etcd authentication
 patroni_etcd_password: "" # (optional) password for etcd authentication
 patroni_etcd_protocol: "" # (optional) http or https, if not specified http is used


### PR DESCRIPTION
When using a shared etcd cluster, it is necessary to have the ability to configure additional parameters in the patroini config: namespace, login, password, and protocol