### PR TITLE
Specify Patroni version to 3.1.0 (don't use 'latest' by default)

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,7 +15,7 @@ vip_interface: "{{ ansible_default_ipv4.interface }}"  # interface name (e.g., "
 # - For the "Type B" scheme: Use libpq `target_session_attrs`, ensuring read/write connections go to the primary database, as an alternative to cluster_vip.
 
 patroni_cluster_name: "postgres-cluster"  # the cluster name (must be unique for each cluster)
-patroni_install_version: "latest"  # or specific version (example 1.5.6)
+patroni_install_version: "3.1.0"  # or 'latest'
 
 patroni_superuser_username: "postgres"
 patroni_superuser_password: "postgres-pass"  # please change password


### PR DESCRIPTION
In this pull request, the default value for the `patroni_install_version` has been updated from 'latest' to '`3.1.0`'. This change ensures that a specific version of Patroni is used during the installation, which can help prevent potential issues or unexpected behaviors that might arise when automatically using the latest version. 

It also makes the deployment process more predictable and manageable, especially in environments where exact version control is crucial.

Related issues:
- https://github.com/zalando/patroni/issues/2882
- https://github.com/zalando/patroni/issues/2879