### PR TITLE
confd requires an additional 'basic_auth' flag for etcd authorization

### DIFF
--- a/roles/confd/templates/confd.toml.j2
+++ b/roles/confd/templates/confd.toml.j2
@@ -15,9 +15,8 @@ nodes = [
 ]
 {% if dcs_exists|bool and dcs_type == 'etcd' %}
 {% if patroni_etcd_username | default('') | length > 0 %}
+basic_auth = true
 username = "{{ patroni_etcd_username | default('') }}"
-{% endif %}
-{% if patroni_etcd_password | default('') | length > 0 %}
-password = "{{ patroni_etcd_password }}"
+password = "{{ patroni_etcd_password | default('') }}"
 {% endif %}
 {% endif %}


### PR DESCRIPTION
During detailed testing, it was found that the 'username' and 'password' parameters alone are insufficient for the proper operation of confd with etcd authentication. It is necessary to add the 'basic-auth' flag.