### PR TITLE
Molecule: exclude ubuntu 18.04 from pg_upgrade tests

### DIFF
--- a/.github/workflows/molecule_pg_upgrade.yml
+++ b/.github/workflows/molecule_pg_upgrade.yml
@@ -27,9 +27,6 @@ jobs:
           - distro: ubuntu2004
             tag: latest
             namespace: geerlingguy
-          - distro: ubuntu1804
-            tag: latest
-            namespace: geerlingguy
           - distro: rockylinux8
             tag: latest
             namespace: geerlingguy


### PR DESCRIPTION
No postgresql 16  packages for Ubuntu 18.04