### PR TITLE
Change to avoid the error "AnsibleUndefinedVariable: 'ansible_hostname'"

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -5,6 +5,7 @@
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups['postgres_cluster'] }}"
+  when: hostvars[groups['postgres_cluster'][0]].ansible_hostname is not defined
 
 # Install HAProxy from rpm/deb packages
 # from repo

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Gather facts for hosts postres_cluster
+  ansible.builtin.setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['postgres_cluster'] }}"
+
 # Install HAProxy from rpm/deb packages
 # from repo
 - block:


### PR DESCRIPTION
This commit fixes the error "AnsibleUndefinedVariable: 'ansible_hostname'". This error only occurs when the playbook `balancers.yml` is executed directly using the command
```
ansible-playbook balancers.yml
```
Host `postgres_cluster` is not part of this playbook, but their facts are needed in the template haproxy.cfg.j2