### PR TITLE
Add PIP_BREAK_SYSTEM_PACKAGES to the pip module

### DIFF
--- a/consul.yml
+++ b/consul.yml
@@ -43,6 +43,8 @@
         name: netaddr
         executable: pip3
       become: false
+      environment:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
 
 - name: consul.yml | Configure Consul instances
   hosts: consul_instances

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -24,5 +24,7 @@
       ansible.builtin.pip:
         name: netaddr
       become: false
+      environment:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
 
 ...

--- a/molecule/pg_upgrade/prepare.yml
+++ b/molecule/pg_upgrade/prepare.yml
@@ -24,5 +24,7 @@
       ansible.builtin.pip:
         name: netaddr
       become: false
+      environment:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
 
 ...

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -27,6 +27,7 @@
         umask: "0022"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_requirements_repo | length < 1
 
     - name: Install requirements
@@ -37,6 +38,7 @@
         umask: "0022"
       environment:
         PATH: "{{ ansible_env.PATH }}:{{ postgresql_bin_dir }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_requirements_repo | length < 1
 
     - name: Install patroni
@@ -48,6 +50,7 @@
         umask: "0022"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length < 1 and patroni_install_version == "latest"
 
     - name: "Install patroni {{ patroni_install_version }}"
@@ -58,6 +61,7 @@
         umask: "0022"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length < 1 and patroni_install_version != "latest"
   when: installation_method == "repo" and patroni_installation_method == "pip"
   environment: "{{ proxy_env | default({}) }}"
@@ -93,6 +97,7 @@
       loop: "{{ patroni_pip_requirements_repo | map('basename') | list }}"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_requirements_repo | length > 0
 
     - name: Install patroni
@@ -104,6 +109,7 @@
       loop: "{{ patroni_pip_package_repo | map('basename') | list }}"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length > 0
   when: installation_method == "repo" and patroni_installation_method == "pip"
   vars:
@@ -134,6 +140,7 @@
       loop: "{{ patroni_pip_requirements_file | map('basename') | list }}"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_requirements_file | length > 0
 
     - name: Install patroni
@@ -145,6 +152,7 @@
       loop: "{{ patroni_pip_package_file | map('basename') | list }}"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_file | length > 0
   when: installation_method == "file" and patroni_installation_method == "pip"
   vars:
@@ -617,6 +625,7 @@
         - ruamel.yaml
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       vars:
         ansible_python_interpreter: /usr/bin/python3
   # Run PITR

--- a/roles/update/tasks/patroni.yml
+++ b/roles/update/tasks/patroni.yml
@@ -10,6 +10,7 @@
         umask: "0022"
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
   when: installation_method == "repo" and patroni_installation_method == "pip"
   environment: "{{ proxy_env | default({}) }}"
   vars:

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -32,6 +32,7 @@
     - pexpect
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
+    PIP_BREAK_SYSTEM_PACKAGES: "1"
   vars:
     ansible_python_interpreter: /usr/bin/python3
 


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/447

Python 3.11 introduces [PEP 668](https://peps.python.org/pep-0668/), which marks Python base environments as “externally managed”. \
Consequently, on Debian 12, installations using pip3 may encounter the externally-managed-environment error as shown below:

```
fatal: [xxxxx]: FAILED! => {"changed": false, "cmd": ["/usr/bin/pip3", "install", "-U", "--trusted-host=pypi.python.org", "--trusted-host=pypi.org", "--trusted-host=files.pythonhosted.org", "setuptools<66.0.0"], "msg": "\n:stderr: error: externally-managed-environment\n\n× This environment is externally managed\n╰─> To install Python packages system-wide, try apt install\n    python3-xyz, where xyz is the package you are trying to\n    install.\n    \n    If you wish to install a non-Debian-packaged Python package,\n    create a virtual environment using python3 -m venv path/to/venv.\n    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make\n    sure you have python3-full installed.\n    \n    If you wish to install a non-Debian packaged Python application,\n    it may be easiest to use pipx install xyz, which will manage a\n    virtual environment for you. Make sure you have pipx installed.\n    \n    See /usr/share/doc/python3.11/README.venv for more information.\n\nnote: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.\nhint: See PEP 668 for the detailed specification.\n"}
```

To address this, this PR introduces the environment variable `PIP_BREAK_SYSTEM_PACKAGES=1`. This ensures that `pip3` can install packages without being restricted by the externally managed environment constraints set by PEP 668.