### PR TITLE
PgBouncer: Add max_prepared_statements option

### DIFF
--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -33,7 +33,7 @@ reserve_pool_timeout = 1
 max_db_connections = {{ pgbouncer_max_db_connections }}
 pkt_buf = 8192
 listen_backlog = 4096
-
+max_prepared_statements = {{ pgbouncer_max_prepared_statements }}
 so_reuseport = 1
 
 log_connections = 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -303,6 +303,7 @@ pgbouncer_listen_addr: "0.0.0.0"
 pgbouncer_listen_port: 6432
 pgbouncer_max_client_conn: 10000
 pgbouncer_max_db_connections: 1000
+pgbouncer_max_prepared_statements: 1024
 pgbouncer_default_pool_size: 20
 pgbouncer_query_wait_timeout: 120
 pgbouncer_default_pool_mode: "session"


### PR DESCRIPTION
Version 1.21 of [PgBouncer](https://github.com/pgbouncer/pgbouncer), the Postgres connection pooler, has added a long awaited feature: support for prepared statements inside of transaction mode. Prior to this, one had to choose between using prepared statements (a performance win), and using PgBouncer's transaction mode (also a large performance win). Now, we can have our cake and eat it too 🎂 🎉.

Details:
- https://www.pgbouncer.org/config.html#max_prepared_statements
- https://www.crunchydata.com/blog/prepared-statements-in-transaction-mode-for-pgbouncer