### PR TITLE
PgBouncer: Connect via Unix socket instead of TCP/IP

### DIFF
--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -1,9 +1,9 @@
 [databases]
 {% for pool in pgbouncer_pools %}
-{{ pool.name }} = host=127.0.0.1 port={{ postgresql_port }} dbname={{ pool.dbname }} {{ pool.pool_parameters }}
+{{ pool.name }} = host={{ postgresql_unix_socket_dir }} port={{ postgresql_port }} dbname={{ pool.dbname }} {{ pool.pool_parameters }}
 {% endfor %}
 
-* = host=127.0.0.1 port={{ postgresql_port }}
+* = host={{ postgresql_unix_socket_dir }} port={{ postgresql_port }}
 
 [pgbouncer]
 logfile = {{ pgbouncer_log_dir }}/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}.log

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -273,9 +273,9 @@ pending_restart: false
 # specify additional hosts that will be added to the pg_hba.conf
 postgresql_pg_hba:
   - { type: "local", database: "all", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
+  - { type: "local", database: "all", user: "{{ pgbouncer_auth_username }}", address: "", method: "trust" } # required for pgbouncer auth_user
   - { type: "local", database: "replication", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "all", address: "", method: "peer" }
-  - { type: "host", database: "all", user: "{{ pgbouncer_auth_username }}", address: "127.0.0.1/32", method: "trust" } # required for pgbouncer auth_user
   - { type: "host", database: "all", user: "all", address: "127.0.0.1/32", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "::1/128", method: "{{ postgresql_password_encryption_algorithm }}" }
 #  - { type: "host", database: "mydatabase", user: "mydb-user", address: "192.168.0.0/24", method: "{{ postgresql_password_encryption_algorithm }}" }


### PR DESCRIPTION
This PR introduces an improvement to the PgBouncer configuration by switching the connection method from TCP/IP to Unix socket directories. \
This change can improve performance by reducing latency, this is important for databases with a large number of high-frequency calls with a low latency requirement for queries.

Example:

|           | 127.0.0.1   | Unix socket  | Difference % |
|-----------|-------------|--------------|---------|
| latency   | 3.585 ms    | 2.007 ms     | -44.02% |
| TPS       | 27474       | 47640        | +73.40% |

Details [here](https://gitlab.com/postgres-ai/postgresql-consulting/tests-and-benchmarks/-/issues/10) and [here](https://gitlab.com/postgres-ai/postgresql-consulting/tests-and-benchmarks/-/issues/46)

