### PR TITLE
PgBouncer: Use the RuntimeDirectory option in the systemd unit file.

### DIFF
--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -34,6 +34,15 @@
     mode: "0750"
   tags: pgbouncer_conf, pgbouncer
 
+- name: Ensure log directory "{{ pgbouncer_log_dir }}" exist
+  ansible.builtin.file:
+    path: "{{ pgbouncer_log_dir }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0750"
+  tags: pgbouncer_conf, pgbouncer
+
 - name: Check if pgbouncer systemd service file exists
   ansible.builtin.stat:
     path: /etc/systemd/system/pgbouncer.service

--- a/roles/pgbouncer/templates/pgbouncer.service.j2
+++ b/roles/pgbouncer/templates/pgbouncer.service.j2
@@ -8,9 +8,9 @@ Type=forking
 User=postgres
 Group=postgres
 
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir -p /run/pgbouncer /var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }} {{ pgbouncer_log_dir }}
-ExecStartPre=/bin/chown -R postgres:postgres /run/pgbouncer /var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }} {{ pgbouncer_log_dir }}
+RuntimeDirectory=pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}
+RuntimeDirectoryMode=0755
+
 {% if ansible_os_family == "Debian" %}
 ExecStart=/usr/sbin/pgbouncer -d {{ pgbouncer_conf_dir }}/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}.ini
 {% endif %}


### PR DESCRIPTION
In this update, we have transitioned from using `PermissionsStartOnly` and `ExecStartPre` to `RuntimeDirectory` and `RuntimeDirectoryMode` in the systemd unit files for the pgBouncer service. This change aims to improve the management of service runtime directories and ensure a more robust and modern configuration.

Details of the Changes:

**1. Deprecation of PermissionsStartOnly:**

- The PermissionsStartOnly directive was deprecated in newer versions of systemd, necessitating a reevaluation of how temporary directories and files for pgBouncer are created and managed.

**2. Implementation of RuntimeDirectory:**

- Utilizing RuntimeDirectory allows systemd to automatically create and manage temporary directories for services. This simplifies configuration and reduces the likelihood of errors.
- RuntimeDirectory ensures that necessary directories are created before the service starts and removed after it stops.

**3. Setting RuntimeDirectoryMode:**

- By setting RuntimeDirectoryMode, we explicitly define the access permissions for the created temporary directories, enhancing security and predictability.

**4. Improved Reliability and Compatibility:**

- These changes bring the systemd configuration in line with the latest standards and practices, improving compatibility across various system environments.

Conclusion:

The shift to using `RuntimeDirectory` and `RuntimeDirectoryMode` in systemd unit files for pgBouncer provides a more reliable, secure, and contemporary configuration. This simplifies the management of the service's resources and enhances its stability in operational environments.