### PR TITLE
PgBouncer: Fix "local" pg_hba rule

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -275,7 +275,7 @@ postgresql_pg_hba:
   - { type: "local", database: "all", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
   - { type: "local", database: "all", user: "{{ pgbouncer_auth_username }}", address: "", method: "trust" } # required for pgbouncer auth_user
   - { type: "local", database: "replication", user: "{{ patroni_superuser_username }}", address: "", method: "trust" }
-  - { type: "local", database: "all", user: "all", address: "", method: "peer" }
+  - { type: "local", database: "all", user: "all", address: "", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "127.0.0.1/32", method: "{{ postgresql_password_encryption_algorithm }}" }
   - { type: "host", database: "all", user: "all", address: "::1/128", method: "{{ postgresql_password_encryption_algorithm }}" }
 #  - { type: "host", database: "mydatabase", user: "mydb-user", address: "192.168.0.0/24", method: "{{ postgresql_password_encryption_algorithm }}" }


### PR DESCRIPTION
When [switching to Unix socket](https://github.com/vitabaks/postgresql_cluster/pull/498) for PgBouncer connections, they missed updating the pg_hba rules for "local", which is why new database users could not connect.

Issue: https://github.com/vitabaks/postgresql_cluster/issues/507

Fixed:

```
psql -U test -h 192.168.100.78 -p 5000 -d test
Password for user test:
psql: error: connection to server at "192.168.100.78", port 5000 failed: FATAL:  Peer authentication failed for user "test"
```