### PR TITLE
update_pgcluster.yml: Reboot node if it's required, e.g. kernel or security updates

### DIFF
--- a/roles/update/handlers/main.yml
+++ b/roles/update/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Rebooting host
+  ansible.builtin.reboot:
+    reboot_timeout: 600
+    test_command: uptime
+  listen: "reboot host"

--- a/roles/update/handlers/main.yml
+++ b/roles/update/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Rebooting host
-  ansible.builtin.reboot:
-    reboot_timeout: 600
-    test_command: uptime
-  listen: "reboot host"

--- a/roles/update/tasks/system.yml
+++ b/roles/update/tasks/system.yml
@@ -34,19 +34,19 @@
 - name: Check if a reboot is required
   ansible.builtin.stat:
     path: /var/run/reboot-required
-    get_md5: no
+    get_md5: false
   register: reboot_required
   changed_when: reboot_required.stat.exists
   when: ansible_os_family == "Debian"
   notify: "reboot host"
 
-- name: Check if a reboot is required.
+- name: Check if a reboot is required
   ansible.builtin.command: needs-restarting -r
   register: reboot_required
   ignore_errors: true
   failed_when: false
-  chnaged_when: reboot_required.rc != 0
-  when: ansible_os_family == "RedHat" 
+  changed_when: reboot_required.rc != 0
+  when: ansible_os_family == "RedHat"
   notify: "reboot host"
 
 - name: Make sure handlers are flushed immediately

--- a/roles/update/tasks/system.yml
+++ b/roles/update/tasks/system.yml
@@ -30,4 +30,25 @@
   delay: 5
   retries: 3
   ignore_errors: true
+
+- name: Check if a reboot is required
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+    get_md5: no
+  register: reboot_required
+  changed_when: reboot_required.stat.exists
+  when: ansible_os_family == "Debian"
+  notify: "reboot host"
+
+- name: Check if a reboot is required.
+  ansible.builtin.command: needs-restarting -r
+  register: reboot_required
+  ignore_errors: true
+  failed_when: false
+  chnaged_when: reboot_required.rc != 0
+  when: ansible_os_family == "RedHat" 
+  notify: "reboot host"
+
+- name: Make sure handlers are flushed immediately
+  ansible.builtin.meta: flush_handlers
 ...

--- a/roles/update/tasks/system.yml
+++ b/roles/update/tasks/system.yml
@@ -34,21 +34,26 @@
 - name: Check if a reboot is required
   ansible.builtin.stat:
     path: /var/run/reboot-required
-    get_md5: false
-  register: reboot_required
-  changed_when: reboot_required.stat.exists
-  when: ansible_os_family == "Debian"
-  notify: "reboot host"
+  register: reboot_required_debian
+  changed_when: false
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_virtualization_type not in ['container', 'docker', 'lxc', 'podman']  # exclude for containers to prevent test failures in CI.
 
 - name: Check if a reboot is required
   ansible.builtin.command: needs-restarting -r
-  register: reboot_required
-  ignore_errors: true
+  register: reboot_required_rhel
   failed_when: false
-  changed_when: reboot_required.rc != 0
-  when: ansible_os_family == "RedHat"
-  notify: "reboot host"
+  changed_when: false
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_virtualization_type not in ['container', 'docker', 'lxc', 'podman']  # exclude for containers to prevent test failures in CI.
 
-- name: Make sure handlers are flushed immediately
-  ansible.builtin.meta: flush_handlers
+- name: Rebooting host
+  ansible.builtin.reboot:
+    msg: "Reboot initiated by Ansible due to required system updates"
+    reboot_timeout: 1800 # 30 minutes
+    test_command: uptime
+  when: (reboot_required_debian.stat.exists is defined and reboot_required_debian.stat.exists) or
+        (reboot_required_rhel.rc is defined and reboot_required_rhel.rc != 0)
 ...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -38,15 +38,18 @@ os_specific_packages:
     - libselinux-python
     - libsemanage-python
     - policycoreutils-python
+    - yum-utils
   RedHat-8:
     - python2
     - python3-libselinux
     - python3-libsemanage
     - python3-policycoreutils
+    - dnf-utils
   RedHat-9:
     - python3-libselinux
     - python3-libsemanage
     - python3-policycoreutils
+    - dnf-utils
 system_packages:
   - "{{ os_specific_packages[ansible_os_family ~ '-' ~ ansible_distribution_major_version] }}"
   - python3


### PR DESCRIPTION
Environments like PCIDSS require to apply kernel and security updates on a regular basis. Once those updates have been applied, a reboot of the host is needed.
This PR will reboot a host only if it's required (kernel updates, security updates etc.) when updating the PostgreSQL cluster with `ansible-playbook update_pgcluster.yml -e target=system`
