### PR TITLE
Add the Molecule tests for the Type C schema (Consul)

### DIFF
--- a/add_balancer.yml
+++ b/add_balancer.yml
@@ -1,15 +1,19 @@
 ---
-- name: add_balancer.yml | Add haproxy balancer node (to the cluster "{{ patroni_cluster_name }}")
+- name: add_balancer.yml | Add HAProxy balancer node
   hosts: balancers
   become: true
   become_method: sudo
   any_errors_fatal: true
   gather_facts: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
-
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -122,13 +126,18 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   vars:
     add_balancer: true
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -1,5 +1,5 @@
 ---
-- name: add_pgnode.yml | PostgreSQL High-Availability Cluster Scaling (add a replica node to the cluster "{{ patroni_cluster_name }}")
+- name: add_pgnode.yml | PostgreSQL HA Cluster Scaling (add a replica node)
   hosts: postgres_cluster
   become: true
   become_method: sudo
@@ -7,11 +7,16 @@
   gather_facts: true
   handlers:
     - ansible.builtin.import_tasks: roles/patroni/handlers/main.yml
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -134,11 +139,16 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -165,9 +175,11 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -187,13 +199,18 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   vars:
     existing_pgcluster: true
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always

--- a/balancers.yml
+++ b/balancers.yml
@@ -1,17 +1,22 @@
 ---
-- name: balancers.yml | Configure load balancers
+- name: balancers.yml | Configure HAProxy load balancers
   hosts: balancers
   become: true
   become_method: sudo
   any_errors_fatal: true
   gather_facts: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   vars:
     vip_manager_disable: false # or 'true' for disable vip-manager service (if installed)
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -1,11 +1,14 @@
 ---
-- name: config_pgcluster.yml | Configuration PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
+- name: config_pgcluster.yml | Configuration PostgreSQL HA Cluster (based on "Patroni")
   hosts: postgres_cluster
   gather_facts: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
 
@@ -76,10 +79,15 @@
   handlers:
     - ansible.builtin.import_tasks: roles/patroni/handlers/main.yml
     - ansible.builtin.import_tasks: roles/pgbouncer/handlers/main.yml
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -155,9 +163,11 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -172,9 +182,11 @@
   become: true
   become_method: sudo
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -221,9 +233,11 @@
   become_method: sudo
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -277,9 +291,14 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
   roles:
     # finish (info)
     - role: deploy-finish

--- a/consul.yml
+++ b/consul.yml
@@ -1,22 +1,40 @@
 ---
-- name: consul.yml | Consul Playbook
-  hosts: localhost
+- name: consul.yml | Configure Consul instances
+  hosts: consul_instances
+  become: true
+  become_method: sudo
   any_errors_fatal: true
-  gather_facts: false
-  vars_files:
-    - vars/main.yml
-  tasks:
+  gather_facts: true
+  environment: "{{ proxy_env | default({}) }}"
+
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
+    - name: Include OS-specific variables
+      ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
+      tags: always
+
     - name: Check if the consul role requirements (ansible.utils) are installed
       ansible.builtin.command: ansible-galaxy collection list ansible.utils
       changed_when: false
       failed_when: false
       register: ansible_utils_result
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Consul role requirements
       ansible.builtin.fail:
         msg:
           - "Please install consul role requirements (ansible.utils)"
           - "ansible-galaxy install -r roles/consul/requirements.yml"
+      delegate_to: localhost
+      run_once: true # noqa run-once
       when:
         - ansible_utils_result.stderr is search("unable to find")
 
@@ -28,6 +46,8 @@
       until: package_status is success
       delay: 5
       retries: 3
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Make sure the python3-pip package are present on the control host
       ansible.builtin.package:
@@ -37,6 +57,8 @@
       until: package_status is success
       delay: 5
       retries: 3
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Install netaddr dependency on the control host
       ansible.builtin.pip:
@@ -45,22 +67,8 @@
       become: false
       environment:
         PIP_BREAK_SYSTEM_PACKAGES: "1"
-
-- name: consul.yml | Configure Consul instances
-  hosts: consul_instances
-  become: true
-  become_method: sudo
-  any_errors_fatal: true
-  gather_facts: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
-  environment: "{{ proxy_env | default({}) }}"
-
-  pre_tasks:
-    - name: Include OS-specific variables
-      ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
-      tags: always
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Update apt cache
       ansible.builtin.apt:

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -1,18 +1,23 @@
 ---
 
-- name: Deploy PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
+- name: Deploy PostgreSQL HA Cluster (based on "Patroni")
   hosts: all
   become: true
   become_method: sudo
   gather_facts: true
   tags: always
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -122,11 +127,16 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -182,9 +192,12 @@
   become_method: sudo
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
+
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
@@ -201,11 +214,16 @@
   any_errors_fatal: true
   handlers:
     - ansible.builtin.import_tasks: roles/pgbouncer/handlers/main.yml
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always

--- a/etcd_cluster.yml
+++ b/etcd_cluster.yml
@@ -1,15 +1,20 @@
 ---
-- name: Configure etcd Cluster and System Settings
+- name: etcd_cluster.yml | Deploy etcd Cluster
   hosts: etcd_cluster
   become: true
   become_method: sudo
   any_errors_fatal: true
   gather_facts: true
-  vars_files:
-    - vars/main.yml
-    - vars/system.yml
 
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
+
+    - name: Include system variables
+      ansible.builtin.include_vars: "vars/system.yml"
+      tags: always
+
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -1,0 +1,10 @@
+---
+- name: Molecule.default.cleanup
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Delete dcs_type.yml file
+      ansible.builtin.file:
+        path: "../../vars/dcs_type.yml"
+        state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,11 +13,14 @@
         nameservers: ["8.8.8.8", "9.9.9.9"]
         timezone: "Etc/UTC"
         with_haproxy_load_balancing: true
+        dcs_type: "{{ ['etcd', 'consul'] | random }}" # Set 'dcs_type' to either 'etcd' or 'consul' randomly
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
         postgresql_version: "15" # to test custom WAL dir
         pgbouncer_processes: 2 # Test multiple pgbouncer processes (so_reuseport)
         cacheable: true
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Set variables for custom PostgreSQL data and WAL directory test
       ansible.builtin.set_fact:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -91,8 +91,8 @@
 - name: Deploy PostgreSQL Cluster test
   ansible.builtin.import_playbook: ../../deploy_pgcluster.yml
 
-# - name: Config PostgreSQL Cluster test
-#  ansible.builtin.import_playbook: ../../config_pgcluster.yml
+- name: Config PostgreSQL Cluster test
+  ansible.builtin.import_playbook: ../../config_pgcluster.yml
 
-# - name: Update PostgreSQL Cluster test
-#  ansible.builtin.import_playbook: ../../update_pgcluster.yml
+- name: Update PostgreSQL Cluster test
+  ansible.builtin.import_playbook: ../../update_pgcluster.yml

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -22,6 +22,15 @@
       delegate_to: localhost
       run_once: true # noqa run-once
 
+    - name: Write dcs_type.yml file (for Molecule verify)
+      ansible.builtin.copy:
+        content: |
+          ---
+          dcs_type: "{{ dcs_type }}"
+        dest: "../../vars/dcs_type.yml"
+      delegate_to: localhost
+      run_once: true # noqa run-once
+
     - name: Set variables for custom PostgreSQL data and WAL directory test
       ansible.builtin.set_fact:
         postgresql_data_dir: "/pgdata/{{ postgresql_version }}/main"
@@ -82,8 +91,8 @@
 - name: Deploy PostgreSQL Cluster test
   ansible.builtin.import_playbook: ../../deploy_pgcluster.yml
 
-- name: Config PostgreSQL Cluster test
-  ansible.builtin.import_playbook: ../../config_pgcluster.yml
+# - name: Config PostgreSQL Cluster test
+#  ansible.builtin.import_playbook: ../../config_pgcluster.yml
 
-- name: Update PostgreSQL Cluster test
-  ansible.builtin.import_playbook: ../../update_pgcluster.yml
+# - name: Update PostgreSQL Cluster test
+#  ansible.builtin.import_playbook: ../../update_pgcluster.yml

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -13,6 +13,11 @@
       ansible.builtin.include_vars:
         file: ../../vars/main.yml
 
+    # Including the dcs_type variable redefined in converge.yml
+    - name: Molecule.default.verify | Include dcs_type Variable
+      ansible.builtin.include_vars:
+        file: ../../vars/dcs_type.yml
+
     # 🔄 Including OS-specific variables
     # These variables are specific to the operating system on which the playbook is running
     - name: Molecule.default.verify | Include OS-Specific Variables

--- a/molecule/pg_upgrade/converge.yml
+++ b/molecule/pg_upgrade/converge.yml
@@ -13,11 +13,14 @@
         nameservers: ["8.8.8.8", "9.9.9.9"]
         timezone: "Etc/UTC"
         with_haproxy_load_balancing: true
+        dcs_type: "{{ ['etcd', 'consul'] | random }}" # Set 'dcs_type' to either 'etcd' or 'consul' randomly
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
         postgresql_version: "14" # redefine the version to install for the upgrade test
         pgbouncer_processes: 4 # Test multiple pgbouncer processes (so_reuseport)
         cacheable: true
+      delegate_to: localhost
+      run_once: true # noqa run-once
 
     - name: Set variables for custom PostgreSQL data and WAL directory test
       ansible.builtin.set_fact:

--- a/pg_upgrade.yml
+++ b/pg_upgrade.yml
@@ -1,16 +1,19 @@
 ---
 # TODO:
 # - Citus support
-- name: "Upgrade PostgreSQL {{ pg_old_version }} to version {{ pg_new_version }} (PostgreSQL HA Cluster: {{ patroni_cluster_name }})"
+- name: "pg_upgrade.yml | Upgrade PostgreSQL {{ pg_old_version }} to the new version {{ pg_new_version }}"
   hosts: postgres_cluster
   gather_facts: true
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/upgrade.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+
+    - name: Include upgrade variables
+      ansible.builtin.include_vars: "vars/upgrade.yml"
+
     - name: '[Prepare] Get Patroni Cluster Leader Node'
       ansible.builtin.uri:
         url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/leader
@@ -58,9 +61,9 @@
   become_user: postgres
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -81,9 +84,9 @@
   become_user: root
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -104,9 +107,9 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -144,9 +147,9 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -166,9 +169,9 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -229,9 +232,9 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables
@@ -258,9 +261,9 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
     - name: Include upgrade variables

--- a/pg_upgrade_rollback.yml
+++ b/pg_upgrade_rollback.yml
@@ -5,13 +5,15 @@
 # The playbook first checks the health of the current cluster, verifies the version of PostgreSQL, and ensures the new PostgreSQL is not running.
 # If these checks pass, the playbook switches back to the old PostgreSQL paths and restarts the Patroni service.
 
-- name: "Rollback PostgreSQL {{ pg_new_version }} to version {{ pg_old_version }} (PostgreSQL HA Cluster: {{ patroni_cluster_name }})"
+- name: "pg_upgrade_rollback.yml | Rollback the PostgreSQL upgrade"
   hosts: postgres_cluster
   gather_facts: true
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
-    - vars/upgrade.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+    - name: Include upgrade variables
+      ansible.builtin.include_vars: "vars/upgrade.yml"
   tasks:
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'
       ansible.builtin.add_host:
@@ -37,15 +39,13 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
-      tags: always
     - name: Include upgrade variables
       ansible.builtin.include_vars: "vars/upgrade.yml"
-      tags: always
   tasks:
     - name: Running rollback.yml
       ansible.builtin.include_role:

--- a/remove_cluster.yml
+++ b/remove_cluster.yml
@@ -1,10 +1,12 @@
 ---
-- name: remove_cluster.yml | PostgreSQL Cluster Play
+- name: remove_cluster.yml | Remove PostgreSQL HA Cluster
   hosts: postgres_cluster
   become: true
-  vars_files:
-    - vars/main.yml
-    - vars/{{ ansible_os_family }}.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+    - name: Include OS-specific variables
+      ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
   tasks:
     - block:
         - name: Stop Patroni service
@@ -34,8 +36,9 @@
 - name: remove_cluster.yml | Consul Cluster Play
   hosts: consul_instances
   become: true
-  vars_files:
-    - vars/main.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
   tasks:
     - block:
         - name: Stop Consul service
@@ -57,8 +60,9 @@
 - name: remove_cluster.yml | Etcd Cluster Play
   hosts: etcd_cluster
   become: true
-  vars_files:
-    - vars/main.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
   tasks:
     - block:
         - name: Stop Etcd service

--- a/roles/upgrade/tasks/maintenance_enable.yml
+++ b/roles/upgrade/tasks/maintenance_enable.yml
@@ -22,6 +22,7 @@
       ansible.builtin.service:
         name: confd
         state: stopped
+      when: dcs_type == "etcd"
 
     - name: Update haproxy conf file (disable http-checks)
       ansible.builtin.template:

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -1,12 +1,14 @@
 ---
-- name: Update PostgreSQL HA Cluster (based on "Patroni" and "{{ dcs_type }}")
+- name: update_pgcluster.yml | Update PostgreSQL HA Cluster (based on "Patroni")
   hosts: postgres_cluster
   gather_facts: true
   become: true
   become_method: sudo
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
+      tags: always
   tasks:
     - name: "[Prepare] Get Patroni Cluster Leader Node"
       ansible.builtin.uri:
@@ -49,11 +51,12 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   vars:
     max_replication_lag_bytes: 10485760 # 10 MiB
     max_transaction_sec: 15 # seconds
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
   tasks:
     - name: Running Pre-Checks
       ansible.builtin.include_role:
@@ -71,14 +74,13 @@
   become_method: sudo
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
-  vars_files:
-    - vars/main.yml
   vars:
     target: postgres # or 'patroni', 'system'
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
-      tags: always
 
   tasks:
     - name: Stop read-only traffic
@@ -130,15 +132,13 @@
   become_method: sudo
   any_errors_fatal: true
   environment: "{{ proxy_env | default({}) }}"
-  vars_files:
-    - vars/main.yml
   vars:
     target: postgres # or 'patroni', 'system'
   pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
-      tags: always
-
   tasks:
     - name: "Switchover Patroni leader role"
       ansible.builtin.include_role:
@@ -193,10 +193,11 @@
   become: true
   become_user: postgres
   any_errors_fatal: true
-  vars_files:
-    - vars/main.yml
   vars:
     update_extensions: true # or 'false', to avoid updating extensions
+  pre_tasks:
+    - name: Include main variables
+      ansible.builtin.include_vars: "vars/main.yml"
   tasks:
     - name: Update extensions
       ansible.builtin.include_role:


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/375

- Replace "`vars_files`" to "`include_vars`" to be able to override variables using `set_fact`
- Add the Molecule tests for the Type C schema (Consul)
  - Set 'dcs_type' to either 'etcd' or 'consul' randomly in the converge.yml for tests