### PR TITLE
README.md + info in vars/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,23 @@ In our configuration keepalived checks the status of the HAProxy service and in 
 
 This is simple scheme without load balancing `Used by default`
 
-To provide a single entry point (VIP) for database access is used "vip-manager". If the variable `cluster_vip` is specified (optional).
+To provide a single entry point (VIP) for database access are used "vip-manager" or "keepalived" ("vip-manager" choose by default). If the variable `cluster_vip` is specified (optional).
 
 [**vip-manager**](https://github.com/cybertec-postgresql/vip-manager) is a service that gets started on all cluster nodes and connects to the DCS. If the local node owns the leader-key, vip-manager starts the configured VIP. In case of a failover, vip-manager removes the VIP on the old leader and the corresponding service on the new leader starts it there. \
 Written in Go. Cybertec Schönig & Schönig GmbH https://www.cybertec-postgresql.com
 
+[**keepalived**](https://github.com/acassen/keepalived) is a service that gets started on all cluster nodes too as it does vip-manager. High-availability is achieved by the Virtual Router Redundancy Protocol (VRRP). \
+Written in C. https://www.keepalived.org/
+
+To deploy keepalived instead of vip-manager:
+
+1. Make sure `cluster_vip` is set
+
+2. Set `vip_manager_disable: true`
+
+3. Set `with_haproxy_load_balancing: true`
+
+> Good to know: you can reconfigure your cluster from vip-manager to keepalived and via playbook `balancers.yml` if needed.
 
 ### [Type C] PostgreSQL High-Availability with Consul Service Discovery (DNS)
 ![TypeC](images/TypeC.png)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -49,7 +49,12 @@ vip_manager_interval: "1000"  # time (in milliseconds) after which vip-manager w
 vip_manager_iface: "{{ vip_interface }}"  # interface to which the virtual ip will be added
 vip_manager_ip: "{{ cluster_vip }}"  # the virtual ip address to manage
 vip_manager_mask: "24"  # netmask for the virtual ip
+vip_manager_disable: false # set to true for keepalived deployment
 
+# keepalived is deployed when:
+# 1. if cluster_vip is specified
+# 2. vip_manager_disable set to "true"
+# 3. with_haproxy_load_balancing set to "true"
 
 # DCS (Distributed Consensus Store)
 dcs_exists: false  # or 'true' if you don't want to deploy a new etcd cluster


### PR DESCRIPTION
Доброго времени дня, Виталий. Спасибо вам за вашу большую работу в этом репозитории.
В REDAME.md и vars/main.yml не было никакой информации о том как правильно развернуть кластер с использованием keepalived. В моем случае vip-manager не взлетел, а keepalived взлетел отлично. Пытаюсь восполнить пробел, для тех, кто так же пожелает воспользоваться этим вариантом.

In README.md and vars/main.yml I didn't find any information about properly deployment of cluster using keepalived. In my case, the vip-manager did not worked, but keepalived works perfectly. I'm trying to fill in the gap, for those who also wish to use this option.

