### PR TITLE
PgBackRest: Enable asynchronous WAL archiving

### DIFF
--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -106,6 +106,19 @@
   tags: pgbackrest, pgbackrest_install
 
 - block:
+    - name: Ensure spool directory exist
+      ansible.builtin.file:
+        path: "{{ item.value }}"
+        state: directory
+        owner: postgres
+        group: postgres
+        mode: "0750"
+      loop: "{{ pgbackrest_conf.global }}"
+      when: 
+        - item.option == 'spool-path'
+      loop_control:
+        label: "{{ item.option }}"
+
     - name: Ensure config directory exist
       ansible.builtin.file:
         path: "{{ pgbackrest_conf_file | dirname }}"

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -114,8 +114,7 @@
         group: postgres
         mode: "0750"
       loop: "{{ pgbackrest_conf.global }}"
-      when: 
-        - item.option == 'spool-path'
+      when: item.option == 'spool-path'
       loop_control:
         label: "{{ item.option }}"
 

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -116,7 +116,7 @@
       loop: "{{ pgbackrest_conf.global }}"
       when: item.option == 'spool-path'
       loop_control:
-        label: "{{ item.option }}"
+        label: "{{ item.value }}"
 
     - name: Ensure config directory exist
       ansible.builtin.file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -485,7 +485,7 @@ pgbackrest_repo_type: "posix"  # or "s3", "gcs", "azure"
 pgbackrest_repo_host: ""  # dedicated repository host (optional)
 pgbackrest_repo_user: "postgres"
 pgbackrest_conf_file: "/etc/pgbackrest/pgbackrest.conf"
-# see more options https://pgbackrest.org/configuration.html
+# config https://pgbackrest.org/configuration.html
 pgbackrest_conf:
   global:  # [global] section
     - { option: "log-level-file", value: "detail" }
@@ -500,6 +500,10 @@ pgbackrest_conf:
     - { option: "stop-auto", value: "y" }
     - { option: "resume", value: "n" }
     - { option: "link-all", value: "y" }
+    - { option: "spool-path", value: "/var/spool/pgbackrest" }
+    - { option: "archive-async", value: "y" } # Enables asynchronous WAL archiving (details: https://pgbackrest.org/user-guide.html#async-archiving)
+    - { option: "archive-get-queue-max", value: "1GiB" }
+#    - { option: "archive-push-queue-max", value: "100GiB" }
 #    - { option: "", value: "" }
   stanza:  # [stanza_name] section
     - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }


### PR DESCRIPTION
Asynchronous archiving is enabled with the archive-async option. This option enables asynchronous operation for both the archive-push and archive-get commands.

Asynchronous operation is most useful in environments that generate a lot of WAL or have a high latency connection to the repository storage (i.e., S3 or other object stores). 

Details: https://pgbackrest.org/user-guide.html#async-archiving

#### Example:

default
![2023-11-21_12-02-38](https://github.com/vitabaks/postgresql_cluster/assets/37010174/e591282e-6840-428d-b32b-cb33adbda32c)

with "archive-async"
![2023-11-21_11-58-22](https://github.com/vitabaks/postgresql_cluster/assets/37010174/c60c418f-1cf7-4a01-b68a-cac1e17fec96)
