### PR TITLE
add_pgnode.yml: Fix the list of hosts to configure pgbackrest

### DIFF
--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -133,7 +133,7 @@
       changed_when: false
       tags: always
 
-- name: add_pgnode.yml | Add new PostgreSQL node to the cluster
+- name: add_pgnode.yml | Configure new PostgreSQL node
   hosts: new_replica
   become: true
   become_method: sudo
@@ -168,9 +168,10 @@
     - role: timezone
     - role: ntp
     - role: copy
+    - role: cron
 
-- name: add_pgnode.yml | Add new PostgreSQL node with pgBackRest to the cluster
-  hosts: pgbackrest:new_replica
+- name: add_pgnode.yml | Configure pgBackRest
+  hosts: pgbackrest:postgres_cluster
   become: true
   become_method: sudo
   gather_facts: true
@@ -193,7 +194,7 @@
   when: dcs_type == "consul"
   tags: consul
 
-- name: add_pgnode.yml | Configure new replica and additional roles
+- name: add_pgnode.yml | Add new PostgreSQL replica to the cluster
   hosts: new_replica
   become: true
   become_method: sudo
@@ -221,8 +222,6 @@
 
     - role: pg_probackup
       when: pg_probackup_install|bool
-
-    - role: cron
 
     - role: pgbouncer
       when: pgbouncer_install|bool


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/516

If PgBackrest is configured as dedicated repository host in SSH mode, the SSH key exchange with the nodes of the "postgres_cluster" group is required.

Previously, only the 'new_replica' group was specified, which led to an error when exchanging keys.

Fixed: 
```
TASK [pgbackrest : ssh_keys | Add database ssh keys in "~postgres/.ssh/authorized_keys" on pgbackrest server] ***************
fatal: [10.10.X.X]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'postgres_cluster_sshkey'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'postgres_cluster_sshkey'\n\nThe error appears to be in '/home/deployer/supplier_connect_dev/postgresql_cluster/roles/pgbackrest/tasks/ssh_keys.yml': line 63, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: ssh_keys | Add database ssh keys in \"~{{ pgbackrest_repo_user }}/.ssh/authorized_keys\" on pgbackrest server\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```