### PR TITLE
Do not use a proxy when accessing the Patroni API

### DIFF
--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -24,6 +24,8 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
 
     # Stop, if Patroni is unavailable
     - name: The Patroni cluster is unhealthy

--- a/pg_upgrade.yml
+++ b/pg_upgrade.yml
@@ -21,6 +21,8 @@
       register: patroni_leader_result
       changed_when: false
       failed_when: false
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
 
     # Stop, if Patroni is unavailable
     - name: The Patroni cluster is unhealthy

--- a/roles/patroni/tasks/custom_wal_dir.yml
+++ b/roles/patroni/tasks/custom_wal_dir.yml
@@ -113,6 +113,8 @@
       until: patroni_result.status == 200
       retries: 120
       delay: 10
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
       when: is_master | bool and not ansible_check_mode
 
     - name: Start patroni service on the Replica
@@ -141,6 +143,8 @@
       until: patroni_result.status == 200
       retries: 120
       delay: 10
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
       when: not is_master | bool and not ansible_check_mode
 
     - name: "Remove {{ pg_wal_dir }}_old directory"

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -852,6 +852,8 @@
       until: result.status == 200
       retries: 10
       delay: 2
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
       when:
         - (patroni_standby_cluster.host is not defined or patroni_standby_cluster.host | length < 1)
         - not ansible_check_mode
@@ -1000,6 +1002,8 @@
       until: replica_result.status == 200
       retries: 1200  # timeout 10 hours
       delay: 30
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
       when: not ansible_check_mode
   when: not is_master | bool
   tags: patroni, patroni_start_replica, point_in_time_recovery

--- a/roles/update/tasks/extensions.yml
+++ b/roles/update/tasks/extensions.yml
@@ -6,6 +6,8 @@
   register: patroni_leader_result
   changed_when: false
   failed_when: false
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
 
 - name: Get a list of databases
   ansible.builtin.command: >-

--- a/roles/update/tasks/pre_checks.yml
+++ b/roles/update/tasks/pre_checks.yml
@@ -1,6 +1,6 @@
 ---
 - name: '[Pre-Check] (ALL) Test PostgreSQL DB Access'
-  ansible.builtin.command: >
+  ansible.builtin.command: >-
     psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc 'select 1'
   changed_when: false
 

--- a/roles/update/tasks/start_services.yml
+++ b/roles/update/tasks/start_services.yml
@@ -22,6 +22,8 @@
   until: patroni_replica_result.status == 200
   retries: 300
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
 
 - name: Check PostgreSQL is started and accepting connections
   become: true

--- a/roles/update/tasks/start_traffic.yml
+++ b/roles/update/tasks/start_traffic.yml
@@ -26,4 +26,6 @@
   until: patroni_replica_result.status == 200
   retries: 30
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
 ...

--- a/roles/update/tasks/stop_traffic.yml
+++ b/roles/update/tasks/stop_traffic.yml
@@ -26,6 +26,8 @@
   until: patroni_replica_result.status == 503
   retries: 30
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
 
 - name: Wait for active transactions to complete
   become: true

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -23,4 +23,6 @@
   until: patroni_replica_result.status == 200
   retries: 300
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
 ...

--- a/roles/upgrade/tasks/rollback.yml
+++ b/roles/upgrade/tasks/rollback.yml
@@ -20,6 +20,8 @@
   register: patroni_cluster_result
   failed_when: false
   changed_when: false
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when:
     - inventory_hostname in groups['primary']
 
@@ -133,6 +135,8 @@
   until: patroni_leader_result.status == 200
   retries: "{{ (pg_start_stop_timeout | int) // 2 }}"
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when:
     - inventory_hostname in groups['primary']
 
@@ -163,6 +167,8 @@
   until: patroni_replica_result.status == 200
   retries: "{{ (pg_start_stop_timeout | int) // 2 }}"
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when:
     - inventory_hostname in groups['secondary']
 

--- a/roles/upgrade/tasks/start_services.yml
+++ b/roles/upgrade/tasks/start_services.yml
@@ -27,6 +27,8 @@
   until: patroni_leader_result.status == 200
   retries: "{{ (pg_start_stop_timeout | int) // 2 }}"
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when:
     - inventory_hostname in groups['primary']
 
@@ -65,6 +67,8 @@
   until: patroni_replica_result.status == 200
   retries: "{{ (pg_start_stop_timeout | int) // 2 }}"
   delay: 2
+  environment:
+    no_proxy: "{{ inventory_hostname }}"
   when:
     - inventory_hostname in groups['secondary']
 

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -17,6 +17,8 @@
       register: patroni_leader_result
       changed_when: false
       failed_when: false
+      environment:
+        no_proxy: "{{ inventory_hostname }}"
       tags: always
 
     - name: '[Prepare] Add host to group "primary" (in-memory inventory)'


### PR DESCRIPTION
Do not use a proxy server when accessing the Patroni REST API.

Fixed:

```
PLAY [(2/4) UPDATE: Secondary] *************************************************
TASK [Include OS-specific variables] *******************************************
ok: [10.128.67.12]
TASK [Stop read-only traffic] **************************************************
TASK [update : Edit patroni.yml | enable noloadbalance, nosync, nofailover] ****
changed: [10.128.67.12] => (item=noloadbalance: true)
changed: [10.128.67.12] => (item=nosync: true)
changed: [10.128.67.12] => (item=nofailover: true)
TASK [update : Reload patroni service] *****************************************
changed: [10.128.67.12]
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (30 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (29 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (28 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (27 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (26 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (25 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (24 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (23 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (22 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (21 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (20 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (19 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (18 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (17 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (16 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (15 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (14 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (13 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (12 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (11 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (10 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (9 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (8 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (7 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (6 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (5 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (4 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (3 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (2 retries left).
FAILED - RETRYING: [10.128.67.12]: Make sure replica endpoint is unavailable (1 retries left).
TASK [update : Make sure replica endpoint is unavailable] **********************
fatal: [10.128.67.12]: FAILED! => {"attempts": 30, "changed": false, "connection": "close", "content_language": "en", "content_length": "3574", "content_type": "text/html;charset=utf-8", "date": "Mon, 04 Dec 2023 11:38:01 GMT", "elapsed": 0, "mime_version": "1.0", "msg": "Status code was 403 and not [503]: HTTP Error 403: Forbidden", "redirected": false, "server": "squid/5.7", "status": 403, "url": "http://10.128.67.12:8008/replica", "vary": "Accept-Language", "via": "1.1 ftpserver (squid/5.7)", "x_cache": "MISS from ftpserver", "x_cache_lookup": "NONE from ftpserver:3128", "x_squid_error": "ERR_ACCESS_DENIED 0"}
NO MORE HOSTS LEFT *************************************************************
PLAY RECAP *********************************************************************
10.128.67.11               : ok=9    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
10.128.67.12               : ok=7    changed=2    unreachable=0    failed=1    skipped=8    rescued=0    ignored=0   
```