### PR TITLE
pg_upgrade: Use 50% CPU cores for vacuumdb (analyze)

### DIFF
--- a/vars/upgrade.yml
+++ b/vars/upgrade.yml
@@ -62,9 +62,10 @@ schema_compatibility_check: true  # If 'true', a compatibility check of the data
 schema_compatibility_check_port: "{{ (postgresql_port | int) + 1 }}"  # Port used to run a temporary PostgreSQL instance for schema compatibility checking.
 schema_compatibility_check_timeout: 3600  # Maximum duration (in seconds) for the compatibility check (using pg_dumpall --schema-only).
 
-vacuumdb_parallel_jobs: "{{ ansible_processor_vcpus }}"  # use all CPU cores
-vacuumdb_analyze_timeout: 3600  # seconds. The maximum duration of analyze command (soft limit, exceeding won't halt playbook)
 update_extensions: true  # if 'true', try to update extensions automatically
+
+vacuumdb_parallel_jobs: "{{ [ansible_processor_vcpus | int // 2, 1] | max }}"  # use 50% CPU cores
+vacuumdb_analyze_timeout: 3600  # seconds. The maximum duration of analyze command (soft limit, exceeding won't halt playbook)
 
 # Do not perform an upgrade if
 max_replication_lag_bytes: 10485760  # 10 MiB - Maximum allowed replication lag in bytes


### PR DESCRIPTION
Use 50% CPU cores for vacuumdb (analyze) to minimize the utilization of server resources at the time of statistics collection, since the database can already handle the load from the application.

If necessary, you can change the value of the `vacuumdb_parallel_jobs` variable.