### PR TITLE
Fix: perform tasks of the "copy" role with root privilege

### DIFF
--- a/roles/copy/tasks/main.yml
+++ b/roles/copy/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: Fetch files from the master
+  become: true
+  become_user: root
   run_once: true
   ansible.builtin.fetch:
     src: "{{ item.src }}"
@@ -15,6 +17,8 @@
   tags: fetch_files
 
 - name: Copy files to all servers
+  become: true
+  become_user: root
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"


### PR DESCRIPTION
When pg_upgrade is executed, tasks are run from under the postgres user and in some cases these privileges are not enough.

Fixed:

```
TASK [copy : Copy files to all servers] ****************************************
failed: [10.128.67.9] (item={'src': 'files/numbers.syn', 'dest': '/usr/share/postgresql/15/tsearch_data/numbers.syn', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "2eac4d89c90cd673d3c37035a62972b548b53120", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/numbers.syn", "group": "root", "mode": "0644", "owner": "root", "src": "files/numbers.syn"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.8] (item={'src': 'files/numbers.syn', 'dest': '/usr/share/postgresql/15/tsearch_data/numbers.syn', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "2eac4d89c90cd673d3c37035a62972b548b53120", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/numbers.syn", "group": "root", "mode": "0644", "owner": "root", "src": "files/numbers.syn"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.9] (item={'src': 'files/part_of_speech_russian.stop', 'dest': '/usr/share/postgresql/15/tsearch_data/part_of_speech_russian.stop', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "ee14179a64f09f9b14bf3bebe9cbac2d31eee513", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/part_of_speech_russian.stop", "group": "root", "mode": "0644", "owner": "root", "src": "files/part_of_speech_russian.stop"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.8] (item={'src': 'files/part_of_speech_russian.stop', 'dest': '/usr/share/postgresql/15/tsearch_data/part_of_speech_russian.stop', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "ee14179a64f09f9b14bf3bebe9cbac2d31eee513", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/part_of_speech_russian.stop", "group": "root", "mode": "0644", "owner": "root", "src": "files/part_of_speech_russian.stop"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.9] (item={'src': 'files/ru_ru.affix', 'dest': '/usr/share/postgresql/15/tsearch_data/ru_ru.affix', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "6c9a3a9f414963f49fc466fda3eff30b12879c71", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/ru_ru.affix", "group": "root", "mode": "0644", "owner": "root", "src": "files/ru_ru.affix"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.8] (item={'src': 'files/ru_ru.affix', 'dest': '/usr/share/postgresql/15/tsearch_data/ru_ru.affix', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "6c9a3a9f414963f49fc466fda3eff30b12879c71", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/ru_ru.affix", "group": "root", "mode": "0644", "owner": "root", "src": "files/ru_ru.affix"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.9] (item={'src': 'files/ru_ru.dict', 'dest': '/usr/share/postgresql/15/tsearch_data/ru_ru.dict', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "2a079128f334ec1a359e8e33393f8fe12f75f746", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/ru_ru.dict", "group": "root", "mode": "0644", "owner": "root", "src": "files/ru_ru.dict"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
failed: [10.128.67.8] (item={'src': 'files/ru_ru.dict', 'dest': '/usr/share/postgresql/15/tsearch_data/ru_ru.dict', 'owner': 'root', 'group': 'root', 'mode': '0644'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "2a079128f334ec1a359e8e33393f8fe12f75f746", "item": {"dest": "/usr/share/postgresql/15/tsearch_data/ru_ru.dict", "group": "root", "mode": "0644", "owner": "root", "src": "files/ru_ru.dict"}, "msg": "Destination /usr/share/postgresql/15/tsearch_data not writable"}
```