### PR TITLE
Fix add_pgnode.yml: Clear the data directory for the new node for bootstrapping

### DIFF
--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -456,7 +456,7 @@
             not postgresql_conf_file.stat.exists
 
     # When performing PITR, we do not clear the directory if pgbackrest is used
-    # to be able to use the '--delta restore' option. 
+    # to be able to use the '--delta restore' option.
     - name: Prepare PostgreSQL | make sure the data directory "{{ postgresql_data_dir }}" is empty
       ansible.builtin.file:
         path: "{{ postgresql_data_dir }}"

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -455,6 +455,8 @@
             postgresql_packages|join(" ") is not search("postgrespro")) and
             not postgresql_conf_file.stat.exists
 
+    # When performing PITR, we do not clear the directory if pgbackrest is used
+    # to be able to use the '--delta restore' option. 
     - name: Prepare PostgreSQL | make sure the data directory "{{ postgresql_data_dir }}" is empty
       ansible.builtin.file:
         path: "{{ postgresql_data_dir }}"
@@ -466,7 +468,7 @@
         - absent
         - directory
       when: (is_master | bool and patroni_cluster_bootstrap_method != "pgbackrest")
-            or (not is_master | bool and 'pgbackrest' not in patroni_create_replica_methods)  # --delta restore
+            or (not is_master | bool and ('pgbackrest' not in patroni_create_replica_methods or new_node | default(false) | bool))
 
     - name: Prepare PostgreSQL | make sure the custom WAL directory "{{ postgresql_wal_dir }}" is empty
       ansible.builtin.file:
@@ -480,7 +482,7 @@
         - directory
       when: (postgresql_wal_dir is defined and postgresql_wal_dir | length > 0) and
             ((is_master | bool and patroni_cluster_bootstrap_method != "pgbackrest")
-              or (not is_master | bool and 'pgbackrest' not in patroni_create_replica_methods))  # --delta restore
+              or (not is_master | bool and ('pgbackrest' not in patroni_create_replica_methods or new_node | default(false) | bool)))
   when: not postgresql_exists | bool or patroni_cluster_bootstrap_method != "initdb"
   tags: patroni, point_in_time_recovery
 


### PR DESCRIPTION
This Pull Request introduces an important update to the conditions used for clearing the PostgreSQL data and custom WAL directories in our Ansible deployment scripts. The adjustment ensures that the directories are properly prepared not only for master nodes but also for replica nodes, specifically addressing scenarios where pgbackrest is used or when deploying new nodes.

#### Changes
- Modified the conditional logic in the tasks responsible for clearing the PostgreSQL data directory (`postgresql_data_dir`) and the custom WAL directory (`postgresql_wal_dir`).
- The updated conditions now accurately check:
  - If the node is a master and `patroni_cluster_bootstrap_method` does not use `pgbackrest`.
  - If the node is not a master, the directory clearance happens either when `pgbackrest` is not part of the `patroni_create_replica_methods`, or it is a new node (indicated by the `new_node` variable).

Note: When performing PITR, we do not clear the directory if pgbackrest is used to be able to use the '--delta' restore option.

#### Fixed:

```
Dec 11 12:02:57 mds-pgnode04 patroni[405558]: 2023-12-11 12:02:57,446 CRITICAL: system ID mismatch, node mds-pgnode04 belongs to a different cluster: 7174171621869448735 != 7311>
Dec 11 12:02:57 mds-pgnode04 systemd[1]: patroni.service: Main process exited, code=exited, status=1/FAILURE
Dec 11 12:02:57 mds-pgnode04 systemd[1]: patroni.service: Failed with result 'exit-code'.
Dec 11 12:02:57 mds-pgnode04 systemd[1]: patroni.service: Scheduled restart job, restart counter is at 1.
Dec 11 12:02:57 mds-pgnode04 systemd[1]: Stopped Runners to orchestrate a high-availability PostgreSQL - Patroni.
```