### PR TITLE
Fix: Set the dependency versions for the "yedit" module.

### DIFF
--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -36,8 +36,8 @@ python-dateutil==2.8.2
 python-slugify==8.0.1
 requests==2.31.0
 rich==13.3.5
-ruamel.yaml==0.17.26
-ruamel.yaml.clib==0.2.7
+ruamel.yaml==0.17.40
+ruamel.yaml.clib==0.2.8
 selinux==0.3.0
 six==1.16.0
 subprocess-tee==0.4.1

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -11,5 +11,6 @@ python-dateutil
 pysyncobj>=0.3.8
 psutil>=2.0.0
 ydiff>=1.2.0
-pexpect>=4.8.0
-ruamel.yaml>=0.16.10
+pexpect==4.9.0
+ruamel.yaml==0.17.40
+ruamel.yaml.clib==0.2.8

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -623,8 +623,8 @@
         extra_args: "--trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"
         umask: "0022"
       loop:
-        - pexpect
-        - ruamel.yaml
+        - pexpect==4.9.0
+        - ruamel.yaml==0.17.40
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/496

New versions of `ruamel.yaml` (0.18.x) are incompatible with the current version of the "[yedit](https://github.com/kwoodson/ansible-role-yedit)" module, which may lead to a PITR error during an attempt to edit the `patroni.yml` or `patroni.dynamic.json` parameter files.

We set the dependencies version on earlier versions to avoid errors.

Fixed:

```
TASK [patroni : Edit patroni.dynamic.json | disable archive_command (if enabled)] ***************************************************************************************************************An exception occurred during task execution. To see the full traceback, use -vvv. The error was: instead of file "/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py", line 495
fatal: [192.168.62.186]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1085, in load\n    error_deprecation('load', 'load', arg=_error_dep_arg, comment=_error_dep_comment)\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"load()\" has been removed, use\n\n  yaml = YAML(typ='rt')\n  yaml.load(...)\n\nand register any classes that you use, or check the tag attribute on the loaded data,\ninstead of file \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493\n\n\n\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 47, in invoke_module\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 967, in <module>\n  File \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 959, in main\n  File \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 812, in run_ansible\n  File \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1105, in safe_load\n    error_deprecation('safe_load', 'load', arg=\"typ='safe', pure=True\")\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"safe_load()\" has been removed, use\n\n  yaml = YAML(typ='safe', pure=True)\n  yaml.load(...)\n\ninstead of file \"/tmp/ansible_yedit_payload_btl6ylm1/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495\n\n\n\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: instead of file "/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py", line 495
fatal: [192.168.62.187]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1085, in load\n    error_deprecation('load', 'load', arg=_error_dep_arg, comment=_error_dep_comment)\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"load()\" has been removed, use\n\n  yaml = YAML(typ='rt')\n  yaml.load(...)\n\nand register any classes that you use, or check the tag attribute on the loaded data,\ninstead of file \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493\n\n\n\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 47, in invoke_module\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 967, in <module>\n  File \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 959, in main\n  File \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 812, in run_ansible\n  File \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1105, in safe_load\n    error_deprecation('safe_load', 'load', arg=\"typ='safe', pure=True\")\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"safe_load()\" has been removed, use\n\n  yaml = YAML(typ='safe', pure=True)\n  yaml.load(...)\n\ninstead of file \"/tmp/ansible_yedit_payload_upjtbw38/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495\n\n\n\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: instead of file "/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py", line 495
fatal: [192.168.62.185]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1085, in load\n    error_deprecation('load', 'load', arg=_error_dep_arg, comment=_error_dep_comment)\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"load()\" has been removed, use\n\n  yaml = YAML(typ='rt')\n  yaml.load(...)\n\nand register any classes that you use, or check the tag attribute on the loaded data,\ninstead of file \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 493\n\n\n\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 47, in invoke_module\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 967, in <module>\n  File \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 959, in main\n  File \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 812, in run_ansible\n  File \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495, in load\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1105, in safe_load\n    error_deprecation('safe_load', 'load', arg=\"typ='safe', pure=True\")\n  File \"/usr/local/lib/python3.9/dist-packages/ruamel/yaml/main.py\", line 1037, in error_deprecation\n    raise AttributeError(s)\nAttributeError: \n\"safe_load()\" has been removed, use\n\n  yaml = YAML(typ='safe', pure=True)\n  yaml.load(...)\n\ninstead of file \"/tmp/ansible_yedit_payload_feblw7on/ansible_yedit_payload.zip/ansible/modules/yedit.py\", line 495\n\n\n\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

We will monitor the progress of [fixing](https://github.com/kwoodson/ansible-role-yedit/issues/101) compatibility with more recent versions on the yedit project. If the module is no longer maintained, then perhaps in subsequent releases of postgresql_cluster we will abandon its use.