### PR TITLE
Adding variable and corresponding code for diverting percentage of requests which coming to a slave towards the master

### DIFF
--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -25,13 +25,7 @@ listen stats
     stats enable
     stats uri /
 
-listen master
-{% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
-{% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
-{% endif %}
-    maxconn {{ haproxy_maxconn.master }}
+backend master_backend
     option tcplog
     option httpchk OPTIONS /primary
     http-check expect status 200
@@ -45,14 +39,16 @@ listen master
 {{end}}{% endraw %}
 {% endif %}
 
-
-listen replicas
+listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
 {% endif %}
-    maxconn {{ haproxy_maxconn.replica }}
+    maxconn {{ haproxy_maxconn.master }}
+    default_backend master_backend
+
+backend replicas_backend
     option tcplog
     option httpchk OPTIONS /replica
     balance roundrobin
@@ -67,14 +63,22 @@ listen replicas
 {{end}}{% endraw %}
 {% endif %}
 
-
-listen replicas_sync
+listen replicas
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
+
+backend replicas_sync_backend
     option tcplog
     option httpchk OPTIONS /sync
     balance roundrobin
@@ -89,14 +93,22 @@ listen replicas_sync
 {{end}}{% endraw %}
 {% endif %}
 
-
-listen replicas_async
+listen replicas_sync
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_sync_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
+
+backend replicas_async_backend
     option tcplog
     option httpchk OPTIONS /async
     balance roundrobin
@@ -109,5 +121,20 @@ listen replicas_async
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
+{% endif %}
+
+listen replicas_async
+{% if cluster_vip is defined and cluster_vip | length > 0 %}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
+{% else %}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
+{% endif %}
+    maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_async_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
 {% endif %}
 

--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -25,6 +25,15 @@ listen stats
     stats enable
     stats uri /
 
+listen master
+{% if cluster_vip is defined and cluster_vip | length > 0 %}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
+{% else %}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
+{% endif %}
+    maxconn {{ haproxy_maxconn.master }}
+    default_backend master_backend
+
 backend master_backend
     option tcplog
     option httpchk OPTIONS /primary
@@ -39,14 +48,21 @@ backend master_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen master
+
+listen replicas
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
-    maxconn {{ haproxy_maxconn.master }}
-    default_backend master_backend
+    maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
 
 backend replicas_backend
     option tcplog
@@ -63,17 +79,18 @@ backend replicas_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen replicas
+
+listen replicas_sync
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
 {% endif %}
-    default_backend replicas_backend
+    default_backend replicas_sync_backend
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
 {% endif %}
@@ -93,17 +110,18 @@ backend replicas_sync_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen replicas_sync
+
+listen replicas_async
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
 {% endif %}
-    default_backend replicas_sync_backend
+    default_backend replicas_async_backend
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
 {% endif %}
@@ -121,20 +139,5 @@ backend replicas_async_backend
 {% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
-{% endif %}
-
-listen replicas_async
-{% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
-{% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
-{% endif %}
-    maxconn {{ haproxy_maxconn.replica }}
-{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
-    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
-{% endif %}
-    default_backend replicas_async_backend
-{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
-    use_backend master_backend if divert_to_master
 {% endif %}
 

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -25,6 +25,22 @@ listen stats
     stats enable
     stats uri /
 
+backend master_backend
+    option tcplog
+    option httpchk OPTIONS /primary
+    http-check expect status 200
+    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
+{% if pgbouncer_install|bool %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
+{% endif %}
+{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
+{% endif %}
+
 listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
     bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
@@ -32,10 +48,14 @@ listen master
     bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
+    default_backend master_backend
+
+backend replicas_backend
     option tcplog
-    option httpchk OPTIONS /primary
+    option httpchk OPTIONS /replica
+    balance roundrobin
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -54,8 +74,17 @@ listen replicas
     bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
+
+backend replicas_sync_backend
     option tcplog
-    option httpchk OPTIONS /replica
+    option httpchk OPTIONS /sync
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -77,8 +106,17 @@ listen replicas_sync
     bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_sync_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
+
+backend replicas_async_backend
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /async
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -100,19 +138,10 @@ listen replicas_async
     bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
-    option httpchk OPTIONS /async
-    balance roundrobin
-    http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
-{% if pgbouncer_install|bool %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
 {% endif %}
-{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
+    default_backend replicas_async_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
 {% endif %}
-

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -25,22 +25,6 @@ listen stats
     stats enable
     stats uri /
 
-backend master_backend
-    option tcplog
-    option httpchk OPTIONS /primary
-    http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
-{% if pgbouncer_install|bool %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
-{% endif %}
-{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
-{% endif %}
-
 listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
     bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
@@ -50,12 +34,11 @@ listen master
     maxconn {{ haproxy_maxconn.master }}
     default_backend master_backend
 
-backend replicas_backend
+backend master_backend
     option tcplog
-    option httpchk OPTIONS /replica
-    balance roundrobin
+    option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -82,9 +65,9 @@ listen replicas
     use_backend master_backend if divert_to_master
 {% endif %}
 
-backend replicas_sync_backend
+backend replicas_backend
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /replica
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -114,9 +97,9 @@ listen replicas_sync
     use_backend master_backend if divert_to_master
 {% endif %}
 
-backend replicas_async_backend
+backend replicas_sync_backend
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /sync
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -145,3 +128,21 @@ listen replicas_async
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
 {% endif %}
+
+backend replicas_async_backend
+    option tcplog
+    option httpchk OPTIONS /async
+    balance roundrobin
+    http-check expect status 200
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+{% if pgbouncer_install|bool %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
+{% endif %}
+{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
+{% endif %}
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -41,7 +41,7 @@ haproxy_maxconn:
 haproxy_timeout:
   client: "60m"
   server: "60m"
-haproxy_divert_to_master: 0 # diverting percentage (from 1 to 99) of requests which coming to a slave towards the master
+haproxy_divert_to_master: 0 # diverting percentage (from 0 to 99) of requests which coming to a slave towards the master
 
 # keepalived (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'true')
 keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last octet of 'cluster_vip' IP address is used by default.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -41,6 +41,7 @@ haproxy_maxconn:
 haproxy_timeout:
   client: "60m"
   server: "60m"
+haproxy_divert_to_master: 0 # diverting percentage (from 1 to 99) of requests which coming to a slave towards the master
 
 # keepalived (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'true')
 keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last octet of 'cluster_vip' IP address is used by default.


### PR DESCRIPTION
The pull request adding variable and corresponding code for diverting specified percentage of requests which coming into HAProxy to a slave port towards the master.

Necessity of the feature is questionable and discussionable. AFAIK there's no any direct profit to use routing of a part of reading queries to master instead of a slave.

**Changes**

* added `haproxy_divert_to_master` var into `vars/main.yml`

* setting `haproxy_divert_to_master` to 0 to avoid changes in ansible deployment result with default configuration (which disabling any diverting of connections to master instead of slave)

* added corresponding code into `haproxy.cfg.j2` template

* added corresponding code into `haproxy.tmpl.j2` template