### PR TITLE
upgrade: Fix PgBouncer socket dir permissions on RHEL

### DIFF
--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -16,7 +16,7 @@
 #
 # Finally, the script checks whether all servers have been successfully paused by comparing the number of successful PAUSE executions to the total number of pgbouncer servers.
 
-- name: Check the permissions to the PgBouncer unix socket directory
+- name: Ensure correct permissions for PgBouncer unix socket directory
   become: true
   become_user: root
   ansible.builtin.file:

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -18,6 +18,8 @@
 
 - name: Check the permissions to the PgBouncer unix socket directory
   ansible.builtin.file:
+    become: true
+    become_user: root
     path: "/var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}"
     state: directory
     owner: postgres

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -15,6 +15,20 @@
 # the timeout command will interrupt the execution of 'pgb_resume_command' and execute the pgb_resume_query command to remove the pause and ensure atomicity.
 #
 # Finally, the script checks whether all servers have been successfully paused by comparing the number of successful PAUSE executions to the total number of pgbouncer servers.
+
+- name: Check the permissions to the PgBouncer unix socket directory
+  ansible.builtin.file:
+    path: "/var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+  loop: "{{ range(0, (pgbouncer_processes | default(1) | int)) | list }}"
+  loop_control:
+    index_var: idx
+    label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
+  when: ansible_os_family == "RedHat" # Added to prevent test failures in CI.
+
 - name: PAUSE PgBouncer pools
   become: true
   become_user: postgres

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -17,9 +17,9 @@
 # Finally, the script checks whether all servers have been successfully paused by comparing the number of successful PAUSE executions to the total number of pgbouncer servers.
 
 - name: Check the permissions to the PgBouncer unix socket directory
+  become: true
+  become_user: root
   ansible.builtin.file:
-    become: true
-    become_user: root
     path: "/var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}"
     state: directory
     owner: postgres


### PR DESCRIPTION
**Problem:**
There was a discovered issue in Red Hat Enterprise Linux (RHEL) environments where the PgBouncer socket directory had incorrect permissions. This problem specifically affected the operation of PAUSE pools in PgBouncer before pg_upgrade.

**Solution:**
This commit fixes the access rights issue by checking the access rights to the PgBouncer socket directory files before pausing pools. The changes ensure that the directory has appropriate ownership and permissions.

Fixed:

```
  TASK [upgrade : Perform PAUSE on all pgbouncers servers] ***********************
  included: /home/runner/work/postgresql_cluster/postgresql_cluster/roles/upgrade/tasks/pgbouncer_pause.yml for 10.172.2.20, 10.172.2.21, 10.172.2.22
  fatal: [10.172.2.20]: FAILED! => {"changed": true, "cmd": "set -o pipefail;\n\npg_servers=\"10.172.2.20\\n10.172.2.21\\n10.172.2.22\"\npg_servers_count=\"3\"\npg_slow_active_count_query=\"select count(*) from pg_stat_activity where pid <> pg_backend_pid() and state <> 'idle' and query_start < clock_timestamp() - interval '1000 ms' and backend_type = 'client backend'\"\npg_slow_active_terminate_query=\"select\n  clock_timestamp(),\n  pg_terminate_backend(pid),\n  clock_timestamp() - query_start as query_age,\n  left(regexp_replace(query, E'[ \\\\t\\\\n\\\\r]+', ' ', 'g'),150) as query\nfrom pg_stat_activity where pid <> pg_backend_pid() and state <> 'idle' and query_start < clock_timestamp() - interval '100 ms' and backend_type = 'client backend'\"\n# it is assumed that pgbouncer is installed on database servers\npgb_servers=\"$pg_servers\"\npgb_servers_count=\"$pg_servers_count\"\npgb_count=\"12\"\npgb_pause_command=\"printf '%s\\n' /var/run/pgbouncer /var/run/pgbouncer-2 /var/run/pgbouncer-3 /var/run/pgbouncer-4 | xargs -I {} -P 4 -n 1 psql -h {} -p 6432 -U postgres -d pgbouncer -tAXc 'PAUSE'\"\npgb_resume_command='kill -SIGUSR2 $(pidof pgbouncer)'\n\nstart_time=$(date +%s)\nwhile true; do\n  current_time=$(date +%s)\n  # initialize pgb_paused_count to 0 (we assume that all pgbouncers are not paused)\n  pgb_paused_count=0\n\n  # wait for the active queries to complete on pg_servers\n  IFS=$'\\n' pg_slow_active_counts=($(echo -e \"$pg_servers\" | xargs -I {} -P \"$pg_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"psql -p 5432 -U postgres -d postgres -tAXc \\\"$pg_slow_active_count_query\\\"\"))\n\n  # sum up all the values in the array\n  total_pg_slow_active_count=0\n  for count in \"${pg_slow_active_counts[@]}\"; do\n    total_pg_slow_active_count=$((total_pg_slow_active_count + count))\n  done\n\n  echo \"$(date): total pg_slow_active_count: $total_pg_slow_active_count\"\n\n  if [[ \"$total_pg_slow_active_count\" == 0 ]]; then\n    # pause pgbouncer on all pgb_servers. We send via ssh to all pgbouncers in parallel and collect results from all (maximum wait time 2 seconds)\n    IFS=$'\\n' pause_results=($(echo -e \"$pgb_servers\" | xargs -I {} -P \"$pgb_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"timeout 2 $pgb_pause_command 2>&1 || true\"))\n    echo \"${pause_results[*]}\"\n    # analyze the pause_results array to count the number of paused pgbouncers\n    pgb_paused_count=$(echo \"${pause_results[*]}\" | grep -o -e \"PAUSE\" -e \"already suspended/paused\" | wc -l)\n    echo \"$(date): pgb_count: $pgb_count, pgb_paused: $pgb_paused_count\"\n  fi\n\n  # make sure that the pause is performed on all pgbouncer servers, to ensure atomicity\n  if [[ \"$pgb_paused_count\" -eq \"$pgb_count\" ]]; then\n    break # pause is performed on all pgb_servers, exit from the loop\n  elif [[ \"$pgb_paused_count\" -gt 0 && \"$pgb_paused_count\" -ne \"$pgb_count\" ]]; then\n    # pause is not performed on all pgb_servers, perform resume (we do not use timeout because we mast to resume all pgbouncers)\n    IFS=$'\\n' resume_results=($(echo -e \"$pgb_servers\" | xargs -I {} -P \"$pgb_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"$pgb_resume_command 2>&1 || true\"))\n    echo \"${resume_results[*]}\"\n  fi\n\n  # after 30 seconds of waiting, terminate active sessions on pg_servers and try pausing again\n  if (( current_time - start_time >= 30 )); then\n    echo \"$(date): terminate active queries\"\n    echo -e \"$pg_servers\" | xargs -I {} -P \"$pg_servers_count\" -n 1 ssh -o StrictHostKeyChecking=no {} \"psql -p 5432 -U postgres -d postgres -tAXc \\\"$pg_slow_active_terminate_query\\\"\"\n  fi\n\n  # if it was not possible to pause for 60 seconds, exit with an error\n  if (( current_time - start_time >= 60 )); then\n    echo \"$(date): it was not possible to pause (exit by timeout)\"\n    exit 1\n  fi\ndone > /tmp/pgbouncer_pool_pause_2023-12-16.log\n", "delta": "0:01:00.255280", "end": "2023-12-16 00:32:03.849474", "msg": "non-zero return code", "rc": 1, "start": "2023-12-16 00:31:03.594194", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```