### PR TITLE
Optimize PostgreSQL parameters for SSD storage

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -202,8 +202,8 @@ postgresql_parameters:
   - { option: "wal_buffers", value: "32MB" }
   - { option: "default_statistics_target", value: "1000" }
   - { option: "seq_page_cost", value: "1" }
-  - { option: "random_page_cost", value: "4" }  # "1.1" for SSD storage. Also, if your databases fits in shared_buffers
-  - { option: "effective_io_concurrency", value: "2" }  # "200" for SSD storage
+  - { option: "random_page_cost", value: "1.1" }  # or "4" for HDDs with slower random access
+  - { option: "effective_io_concurrency", value: "200" }  # or "2" for traditional HDDs with lower I/O parallelism
   - { option: "synchronous_commit", value: "on" }  # or 'off' if you can you lose single transactions in case of a crash
   - { option: "autovacuum", value: "on" }  # never turn off the autovacuum!
   - { option: "autovacuum_max_workers", value: "5" }


### PR DESCRIPTION
### Purpose
This PR introduces several adjustments to the PostgreSQL configuration to optimize performance for environments using SSD storage. 

### Key Changes
- `random_page_cost` is set to `1.1`, down from the default suited for HDDs, to leverage the faster random read capabilities of SSDs.
- `effective_io_concurrency` is increased to `200` to take advantage of SSD's higher parallel I/O capabilities. This is a significant change from the default setting, which is optimized for traditional HDDs.

These changes are aimed at harnessing the full potential of SSDs, ensuring better performance of the database system, especially in high I/O demand environments.