### PR TITLE
PgBackRest: automate "backup-standby" setup

### DIFF
--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -175,7 +175,7 @@
 # if 'pgbackrest_repo_host' or 'backup-standby' are specified
 - ansible.builtin.import_tasks: ssh_keys.yml
   when: (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
-        (pgbackrest_conf.global | selectattr("option", "equalto", "backup-standby") | map(attribute="value") | list | last | default('') == "y")
+        (pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y')
   tags: pgbackrest, pgbackrest_ssh_keys
 
 - ansible.builtin.import_tasks: cron.yml

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -172,7 +172,7 @@
     - pgbackrest_repo_host | length > 0
   tags: pgbackrest, pgbackrest_conf
 
-# if pgbackrest_repo_host or "backup-standby" is set
+# if 'pgbackrest_repo_host' or 'backup-standby' are specified
 - ansible.builtin.import_tasks: ssh_keys.yml
   when: (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
         (pgbackrest_conf.global | json_query("[?option=='backup-standby'].[value=='y']") | length > 0)

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -175,7 +175,7 @@
 # if 'pgbackrest_repo_host' or 'backup-standby' are specified
 - ansible.builtin.import_tasks: ssh_keys.yml
   when: (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
-        (pgbackrest_conf.global | json_query("[?option=='backup-standby'].[value=='y']") | length > 0)
+        (pgbackrest_conf.global | selectattr("option", "equalto", "backup-standby") | map(attribute="value") | list | last | default('') == "y")
   tags: pgbackrest, pgbackrest_ssh_keys
 
 - ansible.builtin.import_tasks: cron.yml

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -172,13 +172,10 @@
     - pgbackrest_repo_host | length > 0
   tags: pgbackrest, pgbackrest_conf
 
-# if pgbackrest_repo_type: "posix" and pgbackrest_repo_host is set
+# if pgbackrest_repo_host or "backup-standby" is set
 - ansible.builtin.import_tasks: ssh_keys.yml
-  when:
-    - pgbackrest_repo_type|lower == "posix"
-    - pgbackrest_repo_host is defined
-    - pgbackrest_repo_host | length > 0
-    - not ansible_check_mode
+  when: (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
+        (pgbackrest_conf.global | json_query("[?option=='backup-standby'].[value=='y']") | length > 0)
   tags: pgbackrest, pgbackrest_ssh_keys
 
 - ansible.builtin.import_tasks: cron.yml

--- a/roles/pgbackrest/tasks/ssh_keys.yml
+++ b/roles/pgbackrest/tasks/ssh_keys.yml
@@ -41,7 +41,7 @@
 - name: ssh_keys | Get public ssh key from pgbackrest server
   ansible.builtin.slurp:
     src: "~{{ pgbackrest_repo_user }}/.ssh/id_rsa.pub"
-  register: pgbackrest_sshkey
+  register: pgbackrest_server_sshkey
   changed_when: false
   when: "'pgbackrest' in group_names"
 
@@ -56,8 +56,8 @@
   ansible.posix.authorized_key:
     user: postgres
     state: present
-    key: "{{ hostvars[item].pgbackrest_sshkey['content'] | b64decode }}"
-  loop: "{{ groups['pgbackrest'] }}"
+    key: "{{ hostvars[item].pgbackrest_server_sshkey['content'] | b64decode }}"
+  loop: "{{ groups['pgbackrest'] | default([]) }}"
   when: "'postgres_cluster' in group_names"
 
 - name: ssh_keys | Add database ssh keys in "~{{ pgbackrest_repo_user }}/.ssh/authorized_keys" on pgbackrest server
@@ -67,6 +67,17 @@
     key: "{{ hostvars[item].postgres_cluster_sshkey['content'] | b64decode }}"
   loop: "{{ groups['postgres_cluster'] }}"
   when: "'pgbackrest' in group_names"
+
+# if 'backup-standby' are specified in pgbackrest_conf.global
+- name: ssh_keys | Add ssh keys in "~postgres/.ssh/authorized_keys" on database servers
+  ansible.posix.authorized_key:
+    user: postgres
+    state: present
+    key: "{{ hostvars[item].postgres_cluster_sshkey['content'] | b64decode }}"
+  loop: "{{ groups['postgres_cluster'] }}"
+  when:
+    - "'postgres_cluster' in group_names"
+    - pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y'
 
 - name: known_hosts | Get public ssh keys of hosts (ssh-keyscan)
   ansible.builtin.command: "ssh-keyscan -trsa -p {{ ansible_ssh_port | default(22) }} {{ item }}"

--- a/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -7,7 +7,13 @@
 {% for stanza in pgbackrest_conf.stanza %}
 {{ stanza.option }}={{ stanza.value }}
 {% endfor %}
-{% if any(item.option == "backup-standby" and item.value == "y" for item in pgbackrest_conf.global) %}
+{% set backup_standby_set = false %}
+{% for item in pgbackrest_conf.global %}
+  {% if item.option == "backup-standby" and item.value == "y" %}
+    {% set backup_standby_set = true %}
+  {% endif %}
+{% endfor %}
+{% if backup_standby_set %}
 {% set host_index = 2 %}
 {% for host in groups['postgres_cluster'] %}
   {% if host != ansible_hostname %}

--- a/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -8,13 +8,10 @@
 {{ stanza.option }}={{ stanza.value }}
 {% endfor %}
 {% if pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y' %}
-{% set host_index = 2 %}
-{% for host in groups['postgres_cluster'] %}
-{% if host != inventory_hostname %}
-pg{{ host_index }}-host={{ host }}
-pg{{ host_index }}-port={{ postgresql_port }}
-pg{{ host_index }}-path={{ postgresql_data_dir }}
-{% set host_index = host_index + 1 %}
-{% endif %}
+{% set pg_standby_hosts = groups['postgres_cluster'] | reject('equalto', inventory_hostname) | list %}
+{% for host in pg_standby_hosts %}
+pg{{ loop.index + 1 }}-host={{ host }}
+pg{{ loop.index + 1 }}-port={{ postgresql_port }}
+pg{{ loop.index + 1 }}-path={{ postgresql_data_dir }}
 {% endfor %}
 {% endif %}

--- a/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -7,4 +7,14 @@
 {% for stanza in pgbackrest_conf.stanza %}
 {{ stanza.option }}={{ stanza.value }}
 {% endfor %}
-
+{% if any(item.option == "backup-standby" and item.value == "y" for item in pgbackrest_conf.global) %}
+{% set host_index = 2 %}
+{% for host in groups['postgres_cluster'] %}
+  {% if host != ansible_hostname %}
+    pg{{ host_index }}-host={{ host }}
+    pg{{ host_index }}-port={{ postgresql_port }}
+    pg{{ host_index }}-path={{ postgresql_data_dir }}
+    {% set host_index = host_index + 1 %}
+  {% endif %}
+{% endfor %}
+{% endif %}

--- a/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -8,11 +8,13 @@
 {{ stanza.option }}={{ stanza.value }}
 {% endfor %}
 {% if pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y' %}
+{% set host_index = 2 %}
 {% for host in groups['postgres_cluster'] %}
 {% if host != inventory_hostname %}
-pg{{ loop.index + 1 }}-host={{ host }}
-pg{{ loop.index + 1 }}-port={{ postgresql_port }}
-pg{{ loop.index + 1 }}-path={{ postgresql_data_dir }}
+pg{{ host_index }}-host={{ host }}
+pg{{ host_index }}-port={{ postgresql_port }}
+pg{{ host_index }}-path={{ postgresql_data_dir }}
+{% set host_index = host_index + 1 %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/pgbackrest/templates/pgbackrest.conf.j2
+++ b/roles/pgbackrest/templates/pgbackrest.conf.j2
@@ -7,20 +7,12 @@
 {% for stanza in pgbackrest_conf.stanza %}
 {{ stanza.option }}={{ stanza.value }}
 {% endfor %}
-{% set backup_standby_set = false %}
-{% for item in pgbackrest_conf.global %}
-  {% if item.option == "backup-standby" and item.value == "y" %}
-    {% set backup_standby_set = true %}
-  {% endif %}
-{% endfor %}
-{% if backup_standby_set %}
-{% set host_index = 2 %}
+{% if pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y' %}
 {% for host in groups['postgres_cluster'] %}
-  {% if host != ansible_hostname %}
-    pg{{ host_index }}-host={{ host }}
-    pg{{ host_index }}-port={{ postgresql_port }}
-    pg{{ host_index }}-path={{ postgresql_data_dir }}
-    {% set host_index = host_index + 1 %}
-  {% endif %}
+{% if host != inventory_hostname %}
+pg{{ loop.index + 1 }}-host={{ host }}
+pg{{ loop.index + 1 }}-port={{ postgresql_port }}
+pg{{ loop.index + 1 }}-path={{ postgresql_data_dir }}
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -511,10 +511,10 @@ pgbackrest_conf:
     - { option: "backup-standby", value: "y" } # When set to 'y', standby servers will be automatically added to the stanza section.
 #    - { option: "", value: "" }
   stanza:  # [stanza_name] section
-    - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
-    - { option: "recovery-option", value: "recovery_target_action=promote" }
-    - { option: "log-level-console", value: "info" }
     - { option: "process-max", value: "4" }
+    - { option: "log-level-console", value: "info" }
+    - { option: "recovery-option", value: "recovery_target_action=promote" }
+    - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }
 #    - { option: "", value: "" }
 # (optional) dedicated backup server config (if "repo_host" is set)
 pgbackrest_server_conf:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -508,6 +508,7 @@ pgbackrest_conf:
     - { option: "archive-async", value: "y" } # Enables asynchronous WAL archiving (details: https://pgbackrest.org/user-guide.html#async-archiving)
     - { option: "archive-get-queue-max", value: "1GiB" }
 #    - { option: "archive-push-queue-max", value: "100GiB" }
+    - { option: "backup-standby", value: "y" } # When set to 'y', standby servers will be automatically added to the stanza section.
 #    - { option: "", value: "" }
   stanza:  # [stanza_name] section
     - { option: "pg1-path", value: "{{ postgresql_data_dir }}" }

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -508,7 +508,7 @@ pgbackrest_conf:
     - { option: "archive-async", value: "y" } # Enables asynchronous WAL archiving (details: https://pgbackrest.org/user-guide.html#async-archiving)
     - { option: "archive-get-queue-max", value: "1GiB" }
 #    - { option: "archive-push-queue-max", value: "100GiB" }
-    - { option: "backup-standby", value: "y" } # When set to 'y', standby servers will be automatically added to the stanza section.
+#    - { option: "backup-standby", value: "y" } # When set to 'y', standby servers will be automatically added to the stanza section.
 #    - { option: "", value: "" }
   stanza:  # [stanza_name] section
     - { option: "process-max", value: "4" }


### PR DESCRIPTION
Automated Inclusion of Standby Servers in PgBackRest Configuration.

This feature is triggered when the `backup-standby=y` option is added to the `pgbackrest_conf` variable. Standby servers are added sequentially, starting from `pg2-host`, `pg3-host`, and so on. In addition, SSH keys are exchanged between database servers.

This is especially true in scenarios where PgBackRest interacts directly with cloud storage, bypassing a dedicated PgBackRest server (when `pgbackrest_repo_type` has the value "`s3`", "`gcs`", or "`azure`").

> pgBackRest creates a standby backup that is identical to a backup performed on the primary. It does this by starting/stopping the backup on the pg-primary host, copying only files that are replicated from the pg-standby host, then copying the remaining few files from the pg-primary host. This means that logs and statistics from the primary database will be included in the backup.

Details about **Backup from a Standby**: https://pgbackrest.org/user-guide.html#standby-backup