### PR TITLE
upgrade: Add pgbackrest_stanza_upgrade variable

### DIFF
--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -86,6 +86,7 @@ If these checks pass, the playbook switches back to the old PostgreSQL paths and
 | `pgbouncer_pool_pause_stop_after` | Time in seconds after which the script exits with an error if unable to pause all pgbouncer pools. | `60` |
 | `pg_slow_active_query_treshold` | Time in milliseconds to wait for active queries before trying to pause the pool. | `1000` |
 | `pg_slow_active_query_treshold_to_terminate` | Time in milliseconds after reaching "pgbouncer_pool_pause_terminate_after" before the script terminates active queries. | `100` |
+| `pgbackrest_stanza_upgrade` | Perform the "stanza-upgrade" command after the upgrade (if 'pgbackrest_install' is 'true'). | `true` |
 
 Note: For variables marked as "Derived value", the default value is determined based on other variables. \
 Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)

--- a/roles/upgrade/tasks/post_upgrade.yml
+++ b/roles/upgrade/tasks/post_upgrade.yml
@@ -91,7 +91,7 @@
 
     - name: pgbackrest | Upgrade stanza "{{ pgbackrest_stanza }}"
       ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-upgrade"
-      when: pg_path_count.stdout | length > 0
+      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
   become: true
   become_user: postgres
   ignore_errors: true
@@ -125,7 +125,7 @@
       delegate_to: "{{ groups['pgbackrest'][0] }}"
       run_once: true
       ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-upgrade"
-      when: pg_path_count.stdout | length > 0
+      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
   ignore_errors: true

--- a/vars/upgrade.yml
+++ b/vars/upgrade.yml
@@ -90,4 +90,7 @@ pg_slow_active_query_treshold: 1000
 # terminate active queries that longer than the specified time (in milliseconds) after reaching "pgbouncer_pool_pause_terminate_after" before trying to pause the pool.
 pg_slow_active_query_treshold_to_terminate: 100  # (0 = terminate all active backends)
 
+# if 'pgbackrest_install' is 'true'
+pgbackrest_stanza_upgrade: true  # perform the "stanza-upgrade" command after the upgrade.
+
 ...


### PR DESCRIPTION
In certain situations, such as when a cluster is created from a backup copy of another cluster, executing the `stanza-upgrade` command can be redundant or even potentially problematic. To accommodate such scenarios, we need the ability to control the execution of this command.

### Changes

- **New Variable**: `pgbackrest_stanza_upgrade` (default value: `true`).
- When set to `false`, the execution of the `stanza-upgrade` command will be skipped. This allows for more controlled management of stanza upgrades in specialized deployment scenarios.
