### PR TITLE
upgrade: Ensure correct permissions for PgBouncer unix socket directory

### DIFF
--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -131,7 +131,8 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
   - Print tablespace location (if exists)
   - Note: If tablespaces are present they will be upgraded (step 5) on replicas using rsync
 - **Test PgBouncer access via unix socket**
-  - test access via unix socket to be able to perform 'PAUSE' command
+  - Ensure correct permissions for PgBouncer unix socket directory
+  - Test access via unix socket to be able to perform 'PAUSE' command
 - **Make sure that the cluster ip address (VIP) is running**
   - Notes: if 'cluster_vip' is defined
 

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -29,7 +29,6 @@
   loop_control:
     index_var: idx
     label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
-  when: ansible_os_family == "RedHat" # Added to prevent test failures in CI.
 
 - name: PAUSE PgBouncer pools
   become: true

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -334,7 +334,24 @@
     - tablespace_location.stdout_lines | length > 0
 
 # PgBouncer (if 'pgbouncer_pool_pause' is 'true')
-# test access via unix socket to be able to perform 'PAUSE' command
+- name: Ensure correct permissions for PgBouncer unix socket directory
+  become: true
+  become_user: root
+  ansible.builtin.file:
+    path: "/var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+  loop: "{{ range(0, (pgbouncer_processes | default(1) | int)) | list }}"
+  loop_control:
+    index_var: idx
+    label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
+  when:
+    - pgbouncer_install | bool
+    - pgbouncer_pool_pause | bool
+
+# Test access via unix socket to be able to perform 'PAUSE' command
 - name: '[Pre-Check] Test PgBouncer access via unix socket'
   ansible.builtin.command: >-
     psql -h /var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}


### PR DESCRIPTION
Similar PR https://github.com/vitabaks/postgresql_cluster/pull/534

This task checks the permissions to the PgBouncer unix socket directory before connecting to the PgBouncer via unix socket. \
The changes ensure that the directory has appropriate ownership and permissions.