### PR TITLE
Disable 'pgdg' repo during system packages installation (RHEL)

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -35,13 +35,17 @@
   tags: install_packages_from_file
 
 - block:  # RedHat (update cache)
-    - name: Clean yum cache
-      ansible.builtin.command: yum clean all
+    - name: Update yum cache
+      ansible.builtin.shell: yum clean all && yum -y makecache
+      args:
+        executable: /bin/bash
       when: ansible_distribution_major_version == '7'
 
-    - name: Clean dnf cache
-      ansible.builtin.command: dnf clean all
-      when: ansible_distribution_major_version is version('8', '>=')
+    - name: Update dnf cache
+      ansible.builtin.shell: dnf clean all && dnf -y makecache
+      args:
+        executable: /bin/bash
+      when: ansible_distribution_major_version >= '8'
   environment: "{{ proxy_env | default({}) }}"
   when: ansible_os_family == "RedHat" and installation_method == "repo"
   tags: install_packages, install_postgres
@@ -49,16 +53,37 @@
 # Install packages from repository
 # RedHat
 - name: Install system packages
-  ansible.builtin.package:
+  ansible.builtin.yum:
     name: "{{ item }}"
     state: present
+    disablerepo: 'pgdg*'
   loop: "{{ system_packages }}"
   register: package_status
   until: package_status is success
   delay: 5
   retries: 3
   environment: "{{ proxy_env | default({}) }}"
-  when: ansible_os_family == "RedHat" and installation_method == "repo"
+  when:
+    - installation_method == "repo"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == '7'
+  tags: install_packages
+
+- name: Install system packages
+  ansible.builtin.dnf:
+    name: "{{ item }}"
+    state: present
+    disablerepo: 'pgdg*'
+  loop: "{{ system_packages }}"
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
+  environment: "{{ proxy_env | default({}) }}"
+  when:
+    - installation_method == "repo"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version >= '8'
   tags: install_packages
 
 # Debian
@@ -100,7 +125,7 @@
   when: installation_method == "repo" and ansible_os_family == "Debian"
   tags: install_postgres
 
-# PostgreSQL prepare for install (for RHEL 8)
+# PostgreSQL prepare for install (for RHEL)
 - block:
     - name: PostgreSQL | check if appstream module is enabled
       ansible.builtin.command: 'dnf -y -C module list postgresql'

--- a/roles/update/tasks/postgres.yml
+++ b/roles/update/tasks/postgres.yml
@@ -1,15 +1,19 @@
 ---
-- name: Clean yum cache
-  ansible.builtin.command: yum clean all
+- name: Update yum cache
+  ansible.builtin.shell: yum clean all && yum -y makecache
+  args:
+    executable: /bin/bash
   when:
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == '7'
 
-- name: Clean dnf cache
-  ansible.builtin.command: dnf clean all
+- name: Update dnf cache
+  ansible.builtin.shell: dnf clean all && dnf -y makecache
+  args:
+    executable: /bin/bash
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version is version('8', '>=')
+    - ansible_distribution_major_version >= '8'
 
 - name: Update apt cache
   ansible.builtin.apt:

--- a/roles/update/tasks/system.yml
+++ b/roles/update/tasks/system.yml
@@ -1,15 +1,19 @@
 ---
-- name: Clean yum cache
-  ansible.builtin.command: yum clean all
+- name: Update yum cache
+  ansible.builtin.shell: yum clean all && yum -y makecache
+  args:
+    executable: /bin/bash
   when:
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == '7'
 
-- name: Clean dnf cache
-  ansible.builtin.command: dnf clean all
+- name: Update dnf cache
+  ansible.builtin.shell: dnf clean all && dnf -y makecache
+  args:
+    executable: /bin/bash
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version is version('8', '>=')
+    - ansible_distribution_major_version >= '8'
 
 - name: Update apt cache
   ansible.builtin.apt:
@@ -30,6 +34,33 @@
   delay: 5
   retries: 3
   ignore_errors: true
+  when: ansible_os_family == "Debian"
+
+- name: Update all system packages
+  ansible.builtin.yum:
+    name: '*'
+    state: latest
+    disablerepo: 'pgdg*'
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == '7'
+
+- name: Update all system packages
+  ansible.builtin.dnf:
+    name: '*'
+    state: latest
+    disablerepo: 'pgdg*'
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version >= '8'
 
 - name: Check if a reboot is required
   ansible.builtin.stat:

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -99,16 +99,15 @@
       ansible.builtin.include_role:
         name: update
         tasks_from: postgres
-      when: target | lower == 'postgres'
+      when: target | lower == 'postgres' or target | lower == 'system'
 
     - name: Update Patroni
       ansible.builtin.include_role:
         name: update
         tasks_from: patroni
-      when: target | lower == 'patroni' or
-        (target | lower == 'system' and patroni_installation_method == "pip")
+      when: target | lower == 'patroni' or target | lower == 'system'
 
-    - name: Update all system packages (includes PostgreSQL and Patroni)
+    - name: Update all system packages
       ansible.builtin.include_role:
         name: update
         tasks_from: system
@@ -161,16 +160,15 @@
       ansible.builtin.include_role:
         name: update
         tasks_from: postgres
-      when: target | lower == 'postgres'
+      when: target | lower == 'postgres' or target | lower == 'system'
 
     - name: Update Patroni
       ansible.builtin.include_role:
         name: update
         tasks_from: patroni
-      when: target | lower == 'patroni' or
-        (target | lower == 'system' and patroni_installation_method == "pip")
+      when: target | lower == 'patroni' or target | lower == 'system'
 
-    - name: Update all system packages (includes PostgreSQL and Patroni)
+    - name: Update all system packages
       ansible.builtin.include_role:
         name: update
         tasks_from: system


### PR DESCRIPTION
We encountered an issue where the python3-psycopg2 package, installed from the pgdg-common repository (published on 23-Jan-2024), caused compatibility problems with Patroni on RHEL 8 distributions due to version 2.9.9 of the package.

<img src="https://github.com/vitabaks/postgresql_cluster/assets/37010174/51014a82-6cec-4986-a73a-c88e35f3589e" width="55%">

Patroni log:

```
Jan 24 09:23:33 pgnode01 systemd[1]: Started Runners to orchestrate a high-availability PostgreSQL - Patroni.
Jan 24 09:23:33 pgnode01 patroni[10661]: FATAL: Patroni requires psycopg2>=2.5.4, psycopg2-binary, or psycopg>=3.0.0
```

To solve this problem, we now exclude pgdg repositories during the installation of system packages in order to install system packages (including python3-psycopg2) from system repositories, and not from pgdg.

Before:
```
[root@pgnode01 /]# yum list installed | grep psycopg
python3-psycopg2.x86_64                   2.9.9-2PGDG.rhel8                                @pgdg-common     
```

After:
```
[root@pgnode01 /]# yum list installed | grep psycopg
python3-psycopg2.x86_64            2.7.5-7.el8                                      @appstream   
```

Additionally:

- Updated tasks for updating the yum/dnf cache

