### PR TITLE
Molecule (fix): Add repository GPG key for AlmaLinux 8

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -47,6 +47,10 @@
       ansible.builtin.set_fact:
         target: system # includes updates to Postgres, Patroni, and all system packages
 
+   - name: Add repository GPG key
+      ansible.builtin.command: "rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{{ ansible_distribution_major_version }}"
+      when: ansible_distribution == "AlmaLinux"
+
     - name: Clean yum cache (molecule containers)
       ansible.builtin.command: yum clean all
       when:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -47,7 +47,7 @@
       ansible.builtin.set_fact:
         target: system # includes updates to Postgres, Patroni, and all system packages
 
-   - name: Add repository GPG key
+    - name: Add repository GPG key
       ansible.builtin.command: "rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{{ ansible_distribution_major_version }}"
       when: ansible_distribution == "AlmaLinux"
 

--- a/molecule/pg_upgrade/converge.yml
+++ b/molecule/pg_upgrade/converge.yml
@@ -39,6 +39,10 @@
         pg_old_version: "14"
         pg_new_version: "16"
 
+    - name: Add repository GPG key
+      ansible.builtin.command: "rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{{ ansible_distribution_major_version }}"
+      when: ansible_distribution == "AlmaLinux"
+
     - name: Clean yum cache (molecule containers)
       ansible.builtin.command: yum clean all
       when:


### PR DESCRIPTION
Fixed:

```
  TASK [Install openssh-server package (molecule containers)] ********************
 fatal: [10.172.0.20]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for openssh-8.0p1-19.el8_9.2.x86_64: Public key for openssh-8.0p1-19.el8_9.2.x86_64.rpm is not installed"}
  fatal: [10.172.0.21]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for openssh-8.0p1-19.el8_9.2.x86_64: Public key for openssh-8.0p1-19.el8_9.2.x86_64.rpm is not installed"}
  fatal: [10.172.0.22]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for openssh-8.0p1-19.el8_9.2.x86_64: Public key for openssh-8.0p1-19.el8_9.2.x86_64.rpm is not installed"}
```