### PR TITLE
add-repository: Do not delete the 'epel-release' package if it is installed (RHEL)

### DIFF
--- a/roles/add-repository/tasks/main.yml
+++ b/roles/add-repository/tasks/main.yml
@@ -35,17 +35,6 @@
       when: yum_repository | length > 0
 
     # Install Epel Repository
-    - name: Remove epel-release package (if exists)
-      ansible.builtin.package:
-        name: epel-release
-        state: absent
-      register: package_status
-      until: package_status is success
-      delay: 5
-      retries: 3
-      when: install_epel_repo|bool
-      tags: install_epel_repo
-
     - name: Get epel-release-latest rpm package
       ansible.builtin.get_url:
         url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"


### PR DESCRIPTION
There is no need to delete the `epel-relase` package, as this violates the idempotency of the task every time the playbook `config_pgcluster.yml` is launched.