### PR TITLE
pgbouncer: Сreate the 'user_search' function in pgbouncer_auth_dbname only

### DIFF
--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -52,26 +52,33 @@
   tags: pgbouncer, pgbouncer_conf, pgbouncer_generate_userlist
 
 # if pgbouncer_auth_user is 'true'
-- name: "Create function 'user_search' for pgbouncer 'auth_query' option in all databases"
-  become: true
-  become_user: postgres
-  ansible.builtin.shell: |
-    for db in $({{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc \
-    "select datname from pg_catalog.pg_database where datname <> 'template0'"); do
-      {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d "$db" -tAXc '
-        CREATE OR REPLACE FUNCTION user_search(uname TEXT) RETURNS TABLE (usename name, passwd text) AS
+- block:
+    - name: "Check if 'user_search' function exists"
+      become: true
+      become_user: postgres
+      ansible.builtin.command: >-
+        {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d {{ pgbouncer_auth_dbname }} -tAXc
+        "select exists(select proname from pg_proc where proname='user_search')"
+      register: exists_func_user
+      when: (is_master | bool and patroni_standby_cluster.host | default('') | length < 1) # do not perform on the Standby Cluster leader
+      changed_when: false
+
+    - name: "Create 'user_search' function for pgbouncer 'auth_query' option"
+      become: true
+      become_user: postgres
+      ansible.builtin.command: >-
+        {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d {{ pgbouncer_auth_dbname }} -tAXc
+        "CREATE FUNCTION user_search(uname TEXT) RETURNS TABLE (usename name, passwd text) AS
         $$
         SELECT usename, passwd FROM pg_shadow WHERE usename=$1;
         $$
         LANGUAGE sql SECURITY DEFINER;
         REVOKE ALL ON FUNCTION user_search(uname TEXT) FROM public;
-        GRANT EXECUTE ON FUNCTION user_search(uname TEXT) TO {{ pgbouncer_auth_username }};
-      '; done
-  args:
-    executable: /bin/bash
-  when:
-    - pgbouncer_auth_user | bool
-    - (is_master | bool and patroni_standby_cluster.host | default('') | length < 1) # do not perform on the Standby Cluster leader
+        GRANT EXECUTE ON FUNCTION user_search(uname TEXT) TO {{ pgbouncer_auth_username }}"
+      when:
+        - (is_master | bool and patroni_standby_cluster.host | default('') | length < 1) # do not perform on the Standby Cluster leader
+        - exists_func_user.stdout == "f"
+  when: pgbouncer_auth_user|bool
   tags: pgbouncer, pgbouncer_conf, pgbouncer_auth_query
 
 ...


### PR DESCRIPTION
This PR is to optimize adding the user_search function to {{pgbouncer_auth_dbname }} only and only once, if the given function already exists, the playbook will not perform the function creation step, when pgbouncer_auth_user is 'true'.

When pgbouncer_auth_user is 'false' a block will be used to create a userlist file.
![pgbouncer_auth_user is 'false'](https://github.com/vitabaks/postgresql_cluster/assets/50195845/c6a7f4c3-ff04-43d8-8867-1657cd88d1a7)

When pgbouncer_auth_user is 'true', the playbook will use the block to create the user_search function in {{pgbouncer_auth_dbname }} only on the master server.
![image](https://github.com/vitabaks/postgresql_cluster/assets/50195845/09d1d190-78ed-4063-8359-8fc1be3ed4a5)

When restarting the playbook, when the user_search function is already exists in {{pgbouncer_auth_dbname }}, there will only be a stage of checking for the existence of this function, there will be no repeat stage to add the function.
![image](https://github.com/vitabaks/postgresql_cluster/assets/50195845/db9bd229-9cbf-45ca-b673-323255ecf0c7)

