### PR TITLE
Add patroni_maximum_lag_on_replica variable

### DIFF
--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -69,7 +69,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -91,7 +91,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -145,7 +145,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -167,7 +167,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -72,7 +72,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -96,7 +96,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -154,7 +154,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -178,7 +178,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -339,8 +339,9 @@ patroni_restapi_port: 8008
 patroni_ttl: 30
 patroni_loop_wait: 10
 patroni_retry_timeout: 10
-patroni_maximum_lag_on_failover: 1048576
 patroni_master_start_timeout: 300
+patroni_maximum_lag_on_failover: 1048576 # (1MB) the maximum bytes a follower may lag to be able to participate in leader election.
+patroni_maximum_lag_on_replica: "100MB" # the maximum of lag that replica can be in order to be available for read-only queries.
 
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callbacks#dynamic-configuration-settings
 patroni_callbacks: []


### PR DESCRIPTION
Issue: https://github.com/zalando/patroni/issues/1249

Introduce a new configuration variable, `patroni_maximum_lag_on_replica`, with a default value of "100MB". This parameter allows defining a threshold for the maximum acceptable lag for replicas. When a replica's lag surpasses this limit, it will no longer be considered for read-only traffic. 

The implementation involves appending an optional `?lag=<max-lag>` parameter to the health check for `replica` and `async` endpoints. By doing so, it enables excluding those replicas from load balancing whose lag exceeds the specified maximum, as determined by the `patroni_maximum_lag_on_replica` setting.

**Documentation**: [Patroni Health Check Endpoints](https://patroni.readthedocs.io/en/latest/rest_api.html#health-check-endpoints)

This update ensures that only replicas capable of providing timely, consistent read-only access are considered, enhancing the reliability and accuracy of load-balanced read operations in distributed database environments managed by Patroni.


Note: If you have more strict requirements for a lag of replica, reduce the value of the 'patroni_maximum_lag_on_replica' variable or consider using synchronous replication. Conversely, if the lag doesn't matter much to your application, increase the value of the variable.