### PR TITLE
Consul: Add a nameserver entry poining to localhost for dnsmasq

### DIFF
--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -153,6 +153,11 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
 
+    - name: Add a nameserver entry poining to localhost for dnsmasq
+      ansible.builtin.set_fact:
+        nameservers: [127.0.0.1]
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+
   roles:
     - role: hostname
     - role: resolv_conf

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -155,8 +155,8 @@
 
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
-        nameservers: [127.0.0.1]
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+        nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
 
   roles:
     - role: hostname

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -153,10 +153,11 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
 
+    # if 'dcs_type' is 'consul'
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
         nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in (nameservers | default([])))
 
   roles:
     - role: hostname

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -108,6 +108,11 @@
       when: firewall_enabled_at_boot | bool
       tags: firewall
 
+    - name: Add a nameserver entry poining to localhost for dnsmasq
+      ansible.builtin.set_fact:
+        nameservers: [127.0.0.1]
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+
   roles:
     - role: ansible-role-firewall
       vars:

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -110,8 +110,8 @@
 
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
-        nameservers: [127.0.0.1]
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+        nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
 
   roles:
     - role: ansible-role-firewall

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -108,10 +108,11 @@
       when: firewall_enabled_at_boot | bool
       tags: firewall
 
+    # if 'dcs_type' is 'consul'
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
         nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in (nameservers | default([])))
 
   roles:
     - role: ansible-role-firewall

--- a/consul.yml
+++ b/consul.yml
@@ -117,8 +117,8 @@
 
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
-        nameservers: [127.0.0.1]
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+        nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
 
   roles:
     - role: ansible-role-firewall

--- a/consul.yml
+++ b/consul.yml
@@ -118,7 +118,7 @@
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
         nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in (nameservers | default([])))
 
   roles:
     - role: ansible-role-firewall

--- a/consul.yml
+++ b/consul.yml
@@ -115,6 +115,11 @@
       when: firewall_enabled_at_boot | bool
       tags: firewall
 
+    - name: Add a nameserver entry poining to localhost for dnsmasq
+      ansible.builtin.set_fact:
+        nameservers: [127.0.0.1]
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+
   roles:
     - role: ansible-role-firewall
       vars:
@@ -125,8 +130,6 @@
 
     - role: hostname
     - role: resolv_conf
-      vars:
-        nameservers: [127.0.0.1] # add a nameserver entry poining to localhost for dnsmasq.
     - role: etc_hosts
     - role: sysctl
     - role: timezone

--- a/consul.yml
+++ b/consul.yml
@@ -120,6 +120,11 @@
         nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
       when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in (nameservers | default([])))
 
+    - name: Redefine the consul_dnsmasq_servers variable
+      ansible.builtin.set_fact:
+        consul_dnsmasq_servers: "{{ consul_dnsmasq_servers | reject('equalto', '127.0.0.1') | list }}"
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' in (consul_dnsmasq_servers | default([])))
+
   roles:
     - role: ansible-role-firewall
       vars:

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -155,10 +155,11 @@
       when: firewall_enabled_at_boot | bool
       tags: firewall
 
+    # if 'dcs_type' is 'consul'
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
         nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in (nameservers | default([])))
 
   roles:
     - role: ansible-role-firewall

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -155,6 +155,11 @@
       when: firewall_enabled_at_boot | bool
       tags: firewall
 
+    - name: Add a nameserver entry poining to localhost for dnsmasq
+      ansible.builtin.set_fact:
+        nameservers: [127.0.0.1]
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+
   roles:
     - role: ansible-role-firewall
       environment: "{{ proxy_env | default({}) }}"

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -157,8 +157,8 @@
 
     - name: Add a nameserver entry poining to localhost for dnsmasq
       ansible.builtin.set_fact:
-        nameservers: [127.0.0.1]
-      when: dcs_type == "consul" and consul_dnsmasq_enable | bool
+        nameservers: "{{ ['127.0.0.1'] + (nameservers | default([])) }}"
+      when: dcs_type == "consul" and consul_dnsmasq_enable | bool and ('127.0.0.1' not in nameservers)
 
   roles:
     - role: ansible-role-firewall

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -105,7 +105,7 @@ consul_tls_server_key: "server.key"
 consul_recursors: []  # List of upstream DNS servers
 consul_dnsmasq_enable: true  # Enable DNS forwarding with Dnsmasq
 consul_dnsmasq_cache: 0  # dnsmasq cache-size (0 - disable caching)
-consul_dnsmasq_servers: "{{ ntp_servers }}" # Upstream DNS servers used by dnsmasq
+consul_dnsmasq_servers: "{{ nameservers }}" # Upstream DNS servers used by dnsmasq
 consul_join: []  # List of LAN servers of an existing consul cluster, to join.
 # - "10.128.64.140"
 # - "10.128.64.142"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -108,9 +108,7 @@ consul_tls_server_key: "server.key"
 consul_recursors: []  # List of upstream DNS servers
 consul_dnsmasq_enable: true  # Enable DNS forwarding with Dnsmasq
 consul_dnsmasq_cache: 0  # dnsmasq cache-size (0 - disable caching)
-consul_dnsmasq_servers:  # Upstream DNS servers used by dnsmasq
-  - "8.8.8.8"
-  - "9.9.9.9"
+consul_dnsmasq_servers: "{{ ntp_servers }}" # Upstream DNS servers used by dnsmasq
 consul_join: []  # List of LAN servers of an existing consul cluster, to join.
 # - "10.128.64.140"
 # - "10.128.64.142"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,9 +10,6 @@ proxy_env: {}  # yamllint disable rule:braces
 cluster_vip: ""  # IP address for client access to the databases in the cluster (optional).
 vip_interface: "{{ ansible_default_ipv4.interface }}"  # interface name (e.g., "ens32").
 # Note: VIP-based solutions such as keepalived or vip-manager may not function correctly in cloud environments like AWS.
-# Recommendations for cloud environments:
-# - For the "Type A" scheme: Use DNS records listing all HAProxy load balancing servers instead of relying on cluster_vip.
-# - For the "Type B" scheme: Use libpq `target_session_attrs`, ensuring read/write connections go to the primary database, as an alternative to cluster_vip.
 
 patroni_cluster_name: "postgres-cluster"  # the cluster name (must be unique for each cluster)
 patroni_install_version: "3.2.2"  # or 'latest'


### PR DESCRIPTION
This update sets `127.0.0.1` as the nameserver in `/etc/resolv.conf` when Consul is utilized as the DCS. This change ensures proper resolution of Consul service DNS names, such as `master.postgres-cluster.service.consul` and `replica.postgres-cluster.service.consul`