### PR TITLE
feat: adds variables to enable client tls on pgbouncer

### DIFF
--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -36,6 +36,10 @@ listen_backlog = 4096
 max_prepared_statements = {{ pgbouncer_max_prepared_statements }}
 so_reuseport = 1
 
+client_tls_sslmode = {{ pgbouncer_client_tls_sslmode }}
+client_tls_key_file = {{ pgbouncer_client_tls_key_file }}
+client_tls_cert_file = {{ pgbouncer_client_tls_cert_file }}
+
 log_connections = 0
 log_disconnections = 0
 

--- a/roles/pgbouncer/templates/pgbouncer.ini.j2
+++ b/roles/pgbouncer/templates/pgbouncer.ini.j2
@@ -35,11 +35,11 @@ pkt_buf = 8192
 listen_backlog = 4096
 max_prepared_statements = {{ pgbouncer_max_prepared_statements }}
 so_reuseport = 1
-
+{% if pgbouncer_client_tls_sslmode != 'disable' %}
 client_tls_sslmode = {{ pgbouncer_client_tls_sslmode }}
 client_tls_key_file = {{ pgbouncer_client_tls_key_file }}
 client_tls_cert_file = {{ pgbouncer_client_tls_cert_file }}
-
+{% endif %}
 log_connections = 0
 log_disconnections = 0
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -321,6 +321,9 @@ pgbouncer_auth_user: true # or 'false' if you want to manage the list of users f
 pgbouncer_auth_username: pgbouncer # user who can query the database via the user_search function
 pgbouncer_auth_password: "pgbouncer-pass" # please change password
 pgbouncer_auth_dbname: "postgres"
+pgbouncer_client_tls_sslmode: "disable"
+pgbouncer_client_tls_key_file: ""
+pgbouncer_client_tls_cert_file: ""
 
 pgbouncer_pools:
   - { name: "postgres", dbname: "postgres", pool_parameters: "" }


### PR DESCRIPTION
This PR is related to #582.

Although this is a trivial change, I think that quite a few people could incur in the requirement of having to enable TLS at least between clients and pgbouncer.

This has been tried on a deployment of type "A". Without these configurations, trying to connect to the cluster `vip` using TLS fails:

```bash
❯ PGSSLMODE=require psql --host pgdebian2.domain.lan --port 5000 --user testuser --db test --password
psql: error: connection to server at "pgdebian2.domain.lan" (192.168.99.99), port 5000 failed: server does not support SSL, but SSL was required
```

To allow encrypted connections, one could add to `/etc/pgbouncer/pgbouncer.ini` on each node:

```
# using the self-signed example certs
client_tls_sslmode = allow
client_tls_key_file = /etc/ssl/private/ssl-cert-snakeoil.key 
client_tls_cert_file = /etc/ssl/certs/ssl-cert-snakeoil.pem
```

After restarting the `pgbouncer` service, encrypted connections are allowed on the cluster virtual ip.

```bash
❯ PGSSLMODE=require psql --host pgdebian2.domain.lan --port 5000 --user testuser --db test --password
psql (16.1, server 16.2 (Debian 16.2-1.pgdg120+2))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
```

Let me know if you want me to add some tests.

Thanks!