### PR TITLE
Add external loadbalancer support

### DIFF
--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -132,6 +132,10 @@ postgresql:
 {% else %}
   listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }},127.0.0.1:{{ postgresql_port }}
 {% endif %}
+  connect_address: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ postgresql_port }}
+{% if patroni_superuser_username == 'postgres' %}
+  use_unix_socket: true
+{% endif %}
   data_dir: {{ postgresql_data_dir }}
   bin_dir: {{ postgresql_bin_dir }}
   config_dir: {{ postgresql_conf_dir }}

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -21,7 +21,11 @@ log:
 {% endif %}
 
 restapi:
+  {% if with_external_load_balancing|bool -%}
+  listen: 0.0.0.0:{{ patroni_restapi_port }}
+  {% else -%}
   listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}
+  {% endif -%} 
   connect_address: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ patroni_restapi_port }}
 #  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
 #  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
@@ -123,12 +127,10 @@ bootstrap:
 postgresql:
 {% if not with_haproxy_load_balancing|bool and not pgbouncer_install|bool and (cluster_vip is defined and cluster_vip | length > 0) %}
   listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }},{{ cluster_vip }},127.0.0.1:{{ postgresql_port }}
+{% elif with_external_load_balancing|bool and load_balancer_ips %}
+  listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }},127.0.0.1,{{ load_balancer_ips | join(',') }}:{{ postgresql_port }}
 {% else %}
   listen: {{ hostvars[inventory_hostname]['inventory_hostname'] }},127.0.0.1:{{ postgresql_port }}
-{% endif %}
-  connect_address: {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ postgresql_port }}
-{% if patroni_superuser_username == 'postgres' %}
-  use_unix_socket: true
 {% endif %}
   data_dir: {{ postgresql_data_dir }}
   bin_dir: {{ postgresql_bin_dir }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,6 +46,10 @@ haproxy_timeout:
   client: "60m"
   server: "60m"
 
+# With external Load Balancing
+with_external_load_balancing: false # 'true' if you want to use an external load balancer or 'false' if you want to use the built-in load balancer (HAProxy)
+load_balancer_ips: [] # list of IP addresses of the load balancer(s). Ex: [10.0.0.1, 10.0.0.2]
+
 # keepalived (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'true')
 keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last octet of 'cluster_vip' IP address is used by default.
 # virtual_router_id - must be unique in the network (available values are 0..255).


### PR DESCRIPTION
When running PostgreSQL clusters created with this tool in Google Cloud Project's Google Compute Engine, using VIP is not an option. Because of this, external Load Balancers like GCP's offering are needed. The networking behavior of GCP's load balancers creates a separate route on each VM the LB is applied to. 

Because of this, the listen addresses for Patroni and PostgreSQL need to be updated to have the applications listen to the newly added routes. I had some trouble adding multiple IPs for Patroni's rest api service, so that is set to 0.0.0.0:{{ patroni_restapi_port }}. But I am able to specify each IP needed for the PostgreSQL config. 

Additionally, there are two variables added in vars/main.yml. 

- with_external_load_balancing | bool that can be set if the user wants to use external LBs or not
- load_balancer_ips | map that the user can add in the IPs for their load balancer(s).

I have been running this changes on a fork with success. These updates help with management. If I need to make an update to pg_hba.conf and run the update_config playbook, my patroni/postgresql listen address changes get re-written.

Best,
Jon