### PR TITLE
update_pgcluster.yml: Use Patroni REST API instead of patronictl command to switchover

### DIFF
--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -5,6 +5,10 @@
     method: POST
     body: '{"leader":"{{ ansible_hostname }}"}'
     body_format: json
+  register: patronictl_switchover_result
+  until: patronictl_switchover_result.status == 200
+  retries: 300
+  delay: 2
   environment:
     no_proxy: "{{ inventory_hostname }}"
 

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -5,8 +5,8 @@
     method: POST
     body: '{"leader":"{{ ansible_hostname }}"}'
     body_format: json
-  register: switchover_result
-  until: switchover_result.status == 200
+  register: patroni_switchover_result
+  until: patroni_switchover_result.status == 200
   retries: 300
   delay: 2
   environment:

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -1,6 +1,5 @@
 ---
 - name: Perform switchover of the leader for the Patroni cluster "{{ patroni_cluster_name }}"
-  become: true
   ansible.builtin.uri:
     url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/switchover
     method: POST

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -5,8 +5,8 @@
     method: POST
     body: '{"leader":"{{ ansible_hostname }}"}'
     body_format: json
-  register: patronictl_switchover_result
-  until: patronictl_switchover_result.status == 200
+  register: switchover_result
+  until: switchover_result.status == 200
   retries: 300
   delay: 2
   environment:

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -1,19 +1,14 @@
 ---
 - name: Perform switchover of the leader for the Patroni cluster "{{ patroni_cluster_name }}"
   become: true
-  become_user: postgres
-  ansible.builtin.expect:
-    command: "patronictl -c /etc/patroni/patroni.yml switchover {{ patroni_cluster_name }}"
-    responses:
-      (.*)Primary(.*): "{{ hostvars[groups['primary'][0]]['ansible_hostname'] }}"
-      (.*)Candidate(.*): "{{ hostvars[groups['secondary'][0]]['ansible_hostname'] }}"
-      (.*)When should the switchover take place(.*): "now"
-      (.*)Are you sure you want to switchover cluster(.*): "y"
+  ansible.builtin.uri:
+    url: http://{{ inventory_hostname }}:{{ patroni_restapi_port }}/switchover
+    method: POST
+    body: '{"leader":"{{ ansible_hostname }}"}'
+    body_format: json
   register: patronictl_switchover_result
   environment:
-    PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
+    no_proxy: "{{ inventory_hostname }}"
 
 - name: Make sure that the Patroni is healthy and is a replica
   ansible.builtin.uri:

--- a/roles/update/tasks/switchover.yml
+++ b/roles/update/tasks/switchover.yml
@@ -6,7 +6,6 @@
     method: POST
     body: '{"leader":"{{ ansible_hostname }}"}'
     body_format: json
-  register: patronictl_switchover_result
   environment:
     no_proxy: "{{ inventory_hostname }}"
 


### PR DESCRIPTION
FIX switchover in `update_pgcluster.yml `with the old version of patroni.

In the old version of patroni(example 2.1.4), the keyword Master was used, not Primary, which is why switchover does not work on older versions of Patroni. This fix uses the Patroni API, tested on version 2.1.4.

Doc: https://patroni.readthedocs.io/en/latest/rest_api.html#switchover-and-failover-endpoints