### PR TITLE
Upgrade: Fix: Apply timeout directly to psql in PgBouncer pause script

### DIFF
--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -82,6 +82,7 @@ If these checks pass, the playbook switches back to the old PostgreSQL paths and
 | `max_transaction_sec` | Maximum allowed duration for a transaction in seconds. | `15` |
 | `copy_files_to_all_server` | Copy files located in the "files" directory to all servers. (optional) | `[]` |
 | `pgbouncer_pool_pause` | Pause pgbouncer pools during upgrade. | `true` |
+| `pgbouncer_pool_pause_timeout` | The maximum waiting time (in seconds) for the pool to be paused. For each iteration of the loop when trying to pause all pools. | `2` |
 | `pgbouncer_pool_pause_terminate_after` | Time in seconds after which script terminates slow active queries. | `30` |
 | `pgbouncer_pool_pause_stop_after` | Time in seconds after which the script exits with an error if unable to pause all pgbouncer pools. | `60` |
 | `pg_slow_active_query_treshold` | Time in milliseconds to wait for active queries before trying to pause the pool. | `1000` |

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -68,7 +68,7 @@
     pgb_servers="$pg_servers"
     pgb_servers_count="$pg_servers_count"
     pgb_count="{{ (groups['primary'] | default([]) | length + groups['secondary'] | default([]) | length) * (pgbouncer_processes | default(1) | int) }}"
-    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
+    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 timeout 2 psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
     pgb_resume_command='kill -SIGUSR2 $(pidof pgbouncer)'
 
     start_time=$(date +%s)
@@ -90,7 +90,7 @@
 
       if [[ "$total_pg_slow_active_count" == 0 ]]; then
         # pause pgbouncer on all pgb_servers. We send via ssh to all pgbouncers in parallel and collect results from all (maximum wait time 2 seconds)
-        IFS=$'\n' pause_results=($(echo -e "$pgb_servers" | xargs -I {} -P "$pgb_servers_count" -n 1 ssh -o StrictHostKeyChecking=no {} "timeout 2 $pgb_pause_command 2>&1 || true"))
+        IFS=$'\n' pause_results=($(echo -e "$pgb_servers" | xargs -I {} -P "$pgb_servers_count" -n 1 ssh -o StrictHostKeyChecking=no {} "$pgb_pause_command 2>&1 || true"))
         echo "${pause_results[*]}"
         # analyze the pause_results array to count the number of paused pgbouncers
         pgb_paused_count=$(echo "${pause_results[*]}" | grep -o -e "PAUSE" -e "already suspended/paused" | wc -l)

--- a/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -68,7 +68,7 @@
     pgb_servers="$pg_servers"
     pgb_servers_count="$pg_servers_count"
     pgb_count="{{ (groups['primary'] | default([]) | length + groups['secondary'] | default([]) | length) * (pgbouncer_processes | default(1) | int) }}"
-    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 timeout 2 psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
+    pgb_pause_command="printf '%s\n' {{ pgb_unix_socket_dirs }} | xargs -I {} -P {{ pgbouncer_processes | default(1) | int }} -n 1 timeout {{ pgbouncer_pool_pause_timeout }} psql -h {} -p {{ pgbouncer_listen_port }} -U {{ patroni_superuser_username }} -d pgbouncer -tAXc 'PAUSE'"
     pgb_resume_command='kill -SIGUSR2 $(pidof pgbouncer)'
 
     start_time=$(date +%s)

--- a/vars/upgrade.yml
+++ b/vars/upgrade.yml
@@ -81,6 +81,8 @@ copy_files_to_all_server: []
 
 # if 'pgbouncer_install' is 'true'
 pgbouncer_pool_pause: true  # or 'false' if you don't want to pause pgbouncer pools during upgrade.
+# the maximum waiting time (in seconds) for the pool to be paused. For each iteration of the loop when trying to pause all pools.
+pgbouncer_pool_pause_timeout: 2
 # the time (in seconds) after which instead of waiting for the completion of the active queries, the script terminates the slow active queries.
 pgbouncer_pool_pause_terminate_after: 30
 # the time (in seconds) after which the script exit with an error if it was not possible to pause all pgbouncer pools.


### PR DESCRIPTION
**Problem**:
The PgBouncer pause script was hanging indefinitely on highly loaded database servers (more than 20,000 inserts per second) because the 'timeout' command was applied to the 'ssh' session, which includes the 'psql' command execution. In cases where the database server was under heavy load, the 'PAUSE' command could not complete within the expected time frame, causing the entire script to hang.

**Solution**:
Modified the script to apply the 'timeout' command directly to the 'psql' command. This ensures that if the 'psql' command does not complete within a 2-second timeout, it will be forcibly terminated, preventing the script from hanging.

#### Additionally

- Add `pgbouncer_pool_pause_timeout` variable.
  - the maximum waiting time (in seconds) for the pool to be paused. For each iteration of the loop when trying to pause all pools. Default `2`