### PR TITLE
Upgrade: Make sure that the 'recovery.signal' file is absent

### DIFF
--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -132,6 +132,7 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
 - **Check if PostgreSQL tablespaces exist**
   - Print tablespace location (if exists)
   - Note: If tablespaces are present they will be upgraded (step 5) on replicas using rsync
+- **Make sure that the 'recovery.signal' file is absent** in the data directory
 - **Test PgBouncer access via unix socket**
   - Ensure correct permissions for PgBouncer unix socket directory
   - Test access via unix socket to be able to perform 'PAUSE' command

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -333,6 +333,11 @@
     - inventory_hostname in groups['primary']
     - tablespace_location.stdout_lines | length > 0
 
+- name: Make sure that the 'recovery.signal' file is absent in the data directory
+  ansible.builtin.file:
+    path: "{{ pg_old_datadir }}/recovery.signal"
+    state: absent
+
 # PgBouncer (if 'pgbouncer_pool_pause' is 'true')
 - name: Ensure correct permissions for PgBouncer unix socket directory
   become: true


### PR DESCRIPTION
Before upgrade, make sure that the '`recovery.signal`' file is absent in the data directory.

Fixed:

```
postgres@mds-pgnode02:~$ cat /pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log
-----------------------------------------------------------------
  pg_upgrade run on Thu Mar 21 07:01:39 2024
-----------------------------------------------------------------

command: "/usr/lib/postgresql/14/bin/pg_ctl" -w -l "/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log" -D "/pgdata/14/main" -o "-p 50432 -b -c config_file=/etc/postgresql/14/main/postgresql.conf -c listen_addresses='' -c unix_socket_permissions=0700 -c unix_socket_directories='/pgdata'" start >> "/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log" 2>&1
waiting for server to start....'2024-03-21 07:01:40 MSK [344587-1]  LOG:  Auto detecting pg_stat_kcache.linux_hz parameter...
'2024-03-21 07:01:40 MSK [344587-2]  LOG:  pg_stat_kcache.linux_hz is set to 500000
'2024-03-21 07:01:40 MSK [344587-3]  LOG:  redirecting log output to logging collector process
'2024-03-21 07:01:40 MSK [344587-4]  HINT:  Future log output will appear in directory "/var/log/postgresql".
 stopped waiting
pg_ctl: could not start server
Examine the log output.

postgres@mds-pgnode02:~$
'2024-03-21 07:01:29 MSK [260565-44]  LOG:  database system is shut down
'2024-03-21 07:01:40 MSK [344587-5]  LOG:  starting PostgreSQL 14.9 (Debian 14.9-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
'2024-03-21 07:01:40 MSK [344587-6]  LOG:  listening on Unix socket "/pgdata/.s.PGSQL.50432"
'2024-03-21 07:01:40 MSK [344589-1]  LOG:  database system was shut down at 2024-03-21 07:01:29 MSK
'2024-03-21 07:01:40 MSK [344589-2]  FATAL:  must specify restore_command when standby mode is not enabled
'2024-03-21 07:01:40 MSK [344587-7]  LOG:  startup process (PID 344589) exited with exit code 1
'2024-03-21 07:01:40 MSK [344587-8]  LOG:  aborting startup due to startup process failure
'2024-03-21 07:01:40 MSK [344587-9]  LOG:  database system is shut down`
```