### PR TITLE
Upgrade and rollback Improvements

### DIFF
--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -183,7 +183,8 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
   - Print the result of the pg_upgrade check
 
 #### 4. PRE-UPGRADE: Prepare the Patroni configuration
-- Edit patroni.yml
+- Backup the patroni.yml configuration file
+- Edit the patroni.yml configuration file
   - **Update parameters**: `data_dir`, `bin_dir`, `config_dir`
   - **Check if the 'standby_cluster' parameter is specified**
     - Remove parameters: `standby_cluster` (if exists)

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -46,7 +46,7 @@ On average, the PgBouncer pause duration is approximately 30 seconds. However, f
 
 This playbook performs a rollback of a PostgreSQL upgrade.
 
-Note: In some scenarios, if errors occur, the system may automatically initiate a rollback. Alternatively, if the automatic rollback does not occur, you can manually execute this playbook to revert the changes. 
+Note: In some scenarios, if errors occur, the pg_upgrade.yml playbook may automatically initiate a rollback. Alternatively, if the automatic rollback does not occur, you can manually execute the pg_upgrade_rollback.yml playbook to revert the changes. 
 
 ```bash
 ansible-playbook pg_upgrade_rollback.yml

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -46,6 +46,8 @@ On average, the PgBouncer pause duration is approximately 30 seconds. However, f
 
 This playbook performs a rollback of a PostgreSQL upgrade.
 
+Note: In some scenarios, if errors occur, the system may automatically initiate a rollback. Alternatively, if the automatic rollback does not occur, you can manually execute this playbook to revert the changes. 
+
 ```bash
 ansible-playbook pg_upgrade_rollback.yml
 ```
@@ -225,7 +227,7 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
   - Notes: max wait time: 2 minutes
   - Stop, if replication lag is high
   - Perform rollback
-  - Print error message: "There's a replication lag in the PostgreSQL Cluster. Please try again later"
+    - Print error message: "There's a replication lag in the PostgreSQL Cluster. Please try again later"
 - **Perform PAUSE on all pgbouncers servers**
   - Notes: if 'pgbouncer_install' is 'true' and 'pgbouncer_pool_pause' is 'true'
   - Notes: pgbouncer pause script (details in [pgbouncer_pause.yml](tasks/pgbouncer_pause.yml)) performs the following actions:
@@ -235,7 +237,7 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
     - If active queries do not complete within 30 seconds (`pgbouncer_pool_pause_terminate_after` variable), the script terminates slow active queries (longer than `pg_slow_active_query_treshold_to_terminate`).
     - If after that it is still not possible to pause the pgbouncer servers within 60 seconds (`pgbouncer_pool_pause_stop_after` variable) from the start of the script, the script exits with an error.
       - Perform rollback
-      - Print error message: "PgBouncer pools could not be paused, please try again later."
+        - Print error message: "PgBouncer pools could not be paused, please try again later."
 - **Stop PostgreSQL** on the Leader and Replicas
   - Check if old PostgreSQL is stopped
   - Check if new PostgreSQL is stopped
@@ -247,9 +249,9 @@ Please see the variable file vars/[upgrade.yml](../../vars/upgrade.yml)
       - "'Latest checkpoint location' is the same on the leader and its standbys"
   - if 'Latest checkpoint location' values doesn't match
     - Perform rollback
-    - Stop with error message:
-      - "Latest checkpoint location' doesn't match on leader and its standbys. Please try again later"
+      - Print error message: "Latest checkpoint location' doesn't match on leader and its standbys. Please try again later"
 - **Upgrade the PostgreSQL on the Primary** (using pg_upgrade --link)
+  - Perform rollback, if the upgrade failed
   - Print the result of the pg_upgrade
 - **Make sure that the new data directory are empty on the Replica**
 - **Upgrade the PostgreSQL on the Replica** (using rsync --hard-links)

--- a/roles/upgrade/tasks/extensions.yml
+++ b/roles/upgrade/tasks/extensions.yml
@@ -5,7 +5,11 @@
     {{ pg_new_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select datname from pg_catalog.pg_database where datname <> 'template0'"
   register: databases_list
+  until: databases_list is success
+  delay: 5
+  retries: 3
   changed_when: false
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
 
@@ -15,6 +19,7 @@
   loop_control:
     loop_var: pg_target_dbname
   when:
+    - databases_list is success
     - databases_list.stdout_lines is defined
     - databases_list.stdout_lines | length > 0
 

--- a/roles/upgrade/tasks/post_checks.yml
+++ b/roles/upgrade/tasks/post_checks.yml
@@ -31,6 +31,10 @@
     {{ pg_new_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "drop table IF EXISTS test_replication;
     create table test_replication as select generate_series(1, 10000)"
+  register: create_table_result
+  until: create_table_result is success
+  delay: 5
+  retries: 3
   when:
     - inventory_hostname in groups['primary']
 
@@ -46,6 +50,7 @@
   failed_when: false
   when:
     - inventory_hostname in groups['secondary']
+    - create_table_result is success
 
 - name: Drop a table "test_replication"
   ansible.builtin.command: >-
@@ -53,6 +58,7 @@
     "drop table IF EXISTS test_replication"
   when:
     - inventory_hostname in groups['primary']
+    - create_table_result is success
 
 - name: Print the result of checking the number of records
   ansible.builtin.debug:
@@ -61,6 +67,7 @@
       - "The number of records in the test_replication table the same as the Primary ({{ count_test.stdout }} rows)"
   when:
     - inventory_hostname in groups['secondary']
+    - count_test.stdout is defined
     - count_test.stdout | int == 10000
 
 # Error, if the number of records in the "test_replication" table does not match the Primary.
@@ -74,6 +81,7 @@
   ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['secondary']
+    - count_test.stdout is defined
     - count_test.stdout | int != 10000
 
 ...

--- a/roles/upgrade/tasks/post_checks.yml
+++ b/roles/upgrade/tasks/post_checks.yml
@@ -35,6 +35,7 @@
   until: create_table_result is success
   delay: 5
   retries: 3
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
 

--- a/roles/upgrade/tasks/post_upgrade.yml
+++ b/roles/upgrade/tasks/post_upgrade.yml
@@ -4,8 +4,12 @@
   ansible.builtin.command: >-
     {{ pg_new_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "show data_directory"
-  changed_when: false
   register: pg_current_datadir
+  until: pg_current_datadir is success
+  delay: 5
+  retries: 3
+  changed_when: false
+  ignore_errors: true  # show the error and continue the playbook execution
 
 # RedHat based
 - name: Delete the old PostgreSQL data directory
@@ -13,6 +17,7 @@
     path: "{{ pg_old_datadir }}"
     state: absent
   when:
+    - pg_current_datadir is success
     - pg_new_datadir == pg_current_datadir.stdout | trim
     - ansible_os_family == "RedHat"
 
@@ -22,6 +27,7 @@
     /usr/bin/pg_dropcluster {{ pg_old_version }} {{ postgresql_cluster_name }}
   failed_when: false
   when:
+    - pg_current_datadir is success
     - pg_new_datadir == pg_current_datadir.stdout | trim
     - ansible_os_family == "Debian"
 
@@ -31,6 +37,7 @@
     path: "{{ postgresql_wal_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}"
     state: absent
   when:
+    - pg_current_datadir is success
     - postgresql_wal_dir | length > 0
     - pg_new_wal_dir | length > 0
 
@@ -46,7 +53,7 @@
   until: package_remove is success
   delay: 5
   retries: 3
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - item is search(pg_old_version)
     - pg_old_packages_remove | bool
@@ -65,7 +72,7 @@
   until: apt_remove is success
   delay: 5
   retries: 3
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - item is search(pg_old_version)
     - pg_old_packages_remove | bool
@@ -81,6 +88,7 @@
 
     - name: Update the PostgreSQL configuration
       ansible.builtin.command: "{{ pg_new_bindir }}/pg_ctl reload -D {{ pg_new_datadir }}"
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - socket_access_result.stderr is defined
     - "'no pg_hba.conf entry' in socket_access_result.stderr"
@@ -108,7 +116,7 @@
       when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
   become: true
   become_user: postgres
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - pgbackrest_install | bool
     - pgbackrest_repo_host | length < 1
@@ -142,7 +150,7 @@
       when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - pgbackrest_install | bool
     - pgbackrest_repo_host | length > 0
@@ -162,7 +170,7 @@
         replace: "{{ postgresql_data_dir | regex_replace(postgresql_version, pg_new_version) }}"
   become: true
   become_user: root
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when: wal_g_install | bool
 
 # Wait for the analyze to complete
@@ -190,7 +198,7 @@
     done < /tmp/pg_terminator.pid
   args:
     executable: /bin/bash
-  ignore_errors: true
+  ignore_errors: true  # show the error and continue the playbook execution
   when: (pg_terminator_analyze is defined and pg_terminator_analyze is changed) or
         (pg_terminator_long_transactions is defined and pg_terminator_long_transactions is changed)
 
@@ -212,6 +220,9 @@
     {{ pg_new_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select current_setting('server_version')"
   register: postgres_version
+  until: postgres_version is success
+  delay: 5
+  retries: 3
   changed_when: false
   when: inventory_hostname in groups['primary']
 

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -278,6 +278,19 @@
   vars:
     ssh_key_user: postgres
 
+# if pg_new_wal_dir is defined (for synchronize wal dir)
+- name: '[Pre-Check] Make sure that the sshpass package are installed'
+  become: true
+  become_user: root
+  ansible.builtin.package:
+    name: sshpass
+    state: present
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
+  when: pg_new_wal_dir | length > 0
+
 # Rsync Checks
 - name: '[Pre-Check] Make sure that the rsync package are installed'
   become: true
@@ -285,6 +298,10 @@
   ansible.builtin.package:
     name: rsync
     state: present
+  register: package_status
+  until: package_status is success
+  delay: 5
+  retries: 3
 
 - name: '[Pre-Check] Rsync Checks: create testrsync file on Primary'
   become: true

--- a/roles/upgrade/tasks/rollback.yml
+++ b/roles/upgrade/tasks/rollback.yml
@@ -85,8 +85,17 @@
     - inventory_hostname in groups['primary']
     - pg_control_version.stdout == pg_new_version | replace('.', '')
 
-# Revert the paths to the old PostgreSQL
-- name: '[Rollback] Revert the paths to the old PostgreSQL in patroni.yml'
+# Restore the old Patroni configuration
+- name: '[Rollback] Restore the old patroni.yml configuration file'
+  ansible.builtin.copy:
+    src: "{{ patroni_config_file }}.bkp"
+    dest: "{{ patroni_config_file }}"
+    owner: postgres
+    group: postgres
+    mode: "0640"
+    remote_src: true
+
+- name: '[Rollback] Ensure old PostgreSQL paths are set in patroni.yml'
   ansible.builtin.replace:
     path: "{{ patroni_config_file }}"
     regexp: "{{ item.regexp }}"

--- a/roles/upgrade/tasks/update_config.yml
+++ b/roles/upgrade/tasks/update_config.yml
@@ -1,5 +1,12 @@
 ---
 # Prepare the parameters for Patroni.
+
+- name: "Backup the patroni.yml configuration file"
+  ansible.builtin.copy:
+    src: "{{ patroni_config_file }}"
+    dest: "{{ patroni_config_file }}.bkp"
+    remote_src: true
+
 # Update the directory path to a new version of PostgresSQL
 - name: "Edit patroni.yml | update parameters: data_dir, bin_dir, config_dir"
   ansible.builtin.replace:

--- a/roles/upgrade/tasks/update_extensions.yml
+++ b/roles/upgrade/tasks/update_extensions.yml
@@ -5,7 +5,11 @@
     {{ pg_new_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d {{ pg_target_dbname }} -tAXc
     "select extname from pg_catalog.pg_extension"
   register: pg_installed_extensions
+  until: pg_installed_extensions is success
+  delay: 5
+  retries: 3
   changed_when: false
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
 
@@ -16,7 +20,11 @@
     join pg_catalog.pg_available_extensions ae on extname = ae.name
     where installed_version <> default_version"
   register: pg_old_extensions
+  until: pg_old_extensions is success
+  delay: 5
+  retries: 3
   changed_when: false
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
 
@@ -28,6 +36,7 @@
       - "No update is required."
   when:
     - inventory_hostname in groups['primary']
+    - pg_old_extensions is success
     - pg_old_extensions.stdout_lines | length < 1
 
 # if pg_stat_cache is not installed
@@ -40,6 +49,8 @@
   loop: "{{ pg_old_extensions.stdout_lines | reject('match', '^pg_repack$') | list }}"
   when:
     - inventory_hostname in groups['primary']
+    - pg_old_extensions is success
+    - pg_installed_extensions is success
     - pg_old_extensions.stdout_lines | length > 0
     - (not 'pg_stat_kcache' in pg_installed_extensions.stdout_lines)
 
@@ -63,6 +74,8 @@
       ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
+    - pg_old_extensions is success
+    - pg_installed_extensions is success
     - pg_old_extensions.stdout_lines | length > 0
     - ('pg_stat_statements' in pg_old_extensions.stdout_lines or 'pg_stat_kcache' in pg_old_extensions.stdout_lines)
     - ('pg_stat_kcache' in pg_installed_extensions.stdout_lines)
@@ -76,6 +89,7 @@
   ignore_errors: true  # show the error and continue the playbook execution
   when:
     - inventory_hostname in groups['primary']
+    - pg_old_extensions is success
     - (pg_old_extensions.stdout_lines | length > 0 and 'pg_repack' in pg_old_extensions.stdout_lines)
 
 ...

--- a/roles/upgrade/tasks/upgrade_primary.yml
+++ b/roles/upgrade/tasks/upgrade_primary.yml
@@ -21,8 +21,23 @@
     shared_preload_libraries: "-c shared_preload_libraries='{{ pg_shared_preload_libraries_value }}'"
     timescaledb_restoring: "{{ \"-c timescaledb.restoring='on'\" if 'timescaledb' in pg_shared_preload_libraries_value else '' }}"
   register: pg_upgrade_result
+  ignore_errors: true  # show the error and perform rollback
   when:
     - inventory_hostname in groups['primary']
+
+# Stop, if the upgrade failed
+- block:
+    - name: Perform rollback
+      ansible.builtin.include_tasks: rollback.yml
+
+    - name: "ERROR: PostgreSQL upgrade failed"
+      ansible.builtin.fail:
+        msg:
+          - "The PostgreSQL upgrade has encountered an error and a rollback has been initiated."
+          - "For detailed information, please consult the pg_upgrade log located at '{{ pg_new_datadir }}/pg_upgrade_output.d'"
+  when:
+    - inventory_hostname in groups['primary']
+    - pg_upgrade_result is failed
 
 # If the length of the pg_upgrade_result.stdout_lines is greater than 100 lines,
 # the upgrade_output variable will include the first 70 lines, an ellipsis (...),

--- a/roles/upgrade/tasks/upgrade_primary.yml
+++ b/roles/upgrade/tasks/upgrade_primary.yml
@@ -35,9 +35,8 @@
         msg:
           - "The PostgreSQL upgrade has encountered an error and a rollback has been initiated."
           - "For detailed information, please consult the pg_upgrade log located at '{{ pg_new_datadir }}/pg_upgrade_output.d'"
-  when:
-    - inventory_hostname in groups['primary']
-    - pg_upgrade_result is failed
+      run_once: true
+  when: hostvars[groups['primary'][0]].pg_upgrade_result is failed
 
 # If the length of the pg_upgrade_result.stdout_lines is greater than 100 lines,
 # the upgrade_output variable will include the first 70 lines, an ellipsis (...),


### PR DESCRIPTION
- **1. Perform rollback, if the upgrade failed.**
  - Previously, the `pg_upgrade.yml` playbook stopped with an error that required a manual execution of the `pg_upgrade_rollback.yml` playbook, now this will be done automatically in case of problems with the pg_upgrade execution.

    Fixed:
    
    ```
    TASK [Upgrade Primary] *********************************************************
    TASK [upgrade : Upgrade the PostgreSQL to version 15 on the Primary (using pg_upgrade --link)] ***
    fatal: [172.30.58.35]: FAILED! => {"changed": true, "cmd": ["/usr/lib/postgresql/15/bin/pg_upgrade", "--username=postgres", "--old-bindir", "/usr/lib/postgresql/14/bin", "--new-bindir", "/usr/lib/postgresql/15/bin", "--old-datadir", "/pgdata/14/main", "--new-datadir", "/pgdata/15/main", "--old-options", "-c config_file=/etc/postgresql/14/main/postgresql.conf", "--new-options", "-c config_file=/etc/postgresql/15/main/postgresql.conf -c shared_preload_libraries='pg_stat_statements,auto_explain,timescaledb,pg_stat_kcache,pg_wait_sampling' -c timescaledb.restoring='on'", "--jobs=24", "--link"], "delta": "0:00:00.513224", "end": "2024-03-21 07:01:40.452925", "msg": "non-zero return code", "rc": 1, "start": "2024-03-21 07:01:39.939701", "stderr": "", "stderr_lines": [], "stdout": "Performing Consistency Checks\n-----------------------------\nChecking cluster versions                                   ok\n\n*failure*\nConsult the last few lines of \"/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log\" for\nthe probable cause of the failure.\n\nconnection to server on socket \"/pgdata/.s.PGSQL.50432\" failed: No such file or directory\n\tIs the server running locally and accepting connections on that socket?\n\ncould not connect to source postmaster started with the command:\n\"/usr/lib/postgresql/14/bin/pg_ctl\" -w -l \"/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log\" -D \"/pgdata/14/main\" -o \"-p 50432 -b -c config_file=/etc/postgresql/14/main/postgresql.conf -c listen_addresses='' -c unix_socket_permissions=0700 -c unix_socket_directories='/pgdata'\" start\nFailure, exiting", "stdout_lines": ["Performing Consistency Checks", "-----------------------------", "Checking cluster versions                                   ok", "", "*failure*", "Consult the last few lines of \"/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log\" for", "the probable cause of the failure.", "", "connection to server on socket \"/pgdata/.s.PGSQL.50432\" failed: No such file or directory", "\tIs the server running locally and accepting connections on that socket?", "", "could not connect to source postmaster started with the command:", "\"/usr/lib/postgresql/14/bin/pg_ctl\" -w -l \"/pgdata/15/main/pg_upgrade_output.d/20240321T070139.948/log/pg_upgrade_server.log\" -D \"/pgdata/14/main\" -o \"-p 50432 -b -c config_file=/etc/postgresql/14/main/postgresql.conf -c listen_addresses='' -c unix_socket_permissions=0700 -c unix_socket_directories='/pgdata'\" start", "Failure, exiting"]}
    NO MORE HOSTS LEFT *************************************************************
    PLAY RECAP *********************************************************************
    172.30.58.31               : ok=53   changed=11   unreachable=0    failed=0    skipped=93   rescued=0    ignored=0   
    172.30.58.32               : ok=53   changed=11   unreachable=0    failed=0    skipped=93   rescued=0    ignored=0   
    172.30.58.35               : ok=89   changed=22   unreachable=0    failed=1    skipped=75   rescued=0    ignored=0   
    Cleaning up project directory and file based variables
    00:01
    ERROR: Job failed: exit code 2
    ```

- **2. Backup/Restore the patroni.yml configuration file**
  - During the rollback, restore a previously created backup copy of the `patroni.yml` file, this ensures that all previously set parameters for the previous version of Postgres will be present.

    Fixed:
    
    ```
    '2024-03-19 11:29:36 MSK [3063-370]  LOG:  configuration file "/etc/postgresql/14/main/postgresql.conf" contains errors; unaffected changes were applied
    '2024-03-19 11:29:36 MSK [4071-1]  LOG:  could not open temporary statistics file "/var/run/postgresql/14-main.pg_stat_tmp/global.tmp": No such file or directory
    '2024-03-19 11:29:36 MSK [4071-2]  LOG:  could not open temporary statistics file "/var/run/postgresql/14-main.pg_stat_tmp/global.tmp": No such file or directory
    '2024-03-19 11:29:36 MSK [4071-3]  LOG:  could not open temporary statistics file "/var/run/postgresql/14-main.pg_stat_tmp/global.tmp": No such file or directory
    ```

- **3. Add retry and ignore errors for "Update extensions" and "Post-Checks"**
  - After the upgrade is completed and the pools are resumed, statistics are collected, and the database may experience a high load for some time (see https://github.com/vitabaks/postgresql_cluster/pull/601). These changes add repeated attempts for extensions update tasks, as well as ignoring errors in their execution to continue executing the playbook (errors will be visible in the ansible log)

    Fixed:
    
    ```
    TASK [upgrade : Get list of old PostgreSQL extensions (database: shieldems)] ***
    fatal: [172.30.58.34]: FAILED! => {"changed": false, "cmd": ["/usr/lib/postgresql/15/bin/psql", "-p", "5432", "-U", "postgres", "-d", "shieldems", "-tAXc", "select extname from pg_catalog.pg_extension e join pg_catalog.pg_available_extensions ae on extname = ae.name where installed_version <> default_version"], "delta": "0:00:00.037253", "end": "2024-03-20 05:27:55.299617", "msg": "non-zero return code", "rc": 2, "start": "2024-03-20 05:27:55.262364", "stderr": "psql: error: connection to server on socket \"/var/run/postgresql/.s.PGSQL.5432\" failed: FATAL:  sorry, too many clients already", "stderr_lines": ["psql: error: connection to server on socket \"/var/run/postgresql/.s.PGSQL.5432\" failed: FATAL:  sorry, too many clients already"], "stdout": "", "stdout_lines": []}
    NO MORE HOSTS LEFT *************************************************************
    PLAY RECAP *********************************************************************
    172.30.58.30               : ok=74   changed=21   unreachable=0    failed=0    skipped=114  rescued=0    ignored=0   
    172.30.58.33               : ok=74   changed=21   unreachable=0    failed=0    skipped=114  rescued=0    ignored=0   
    172.30.58.34               : ok=136  changed=38   unreachable=0    failed=1    skipped=89   rescued=0    ignored=0   
    172.30.58.36               : ok=74   changed=21   unreachable=0    failed=0    skipped=114  rescued=0    ignored=0   
    Cleaning up project directory and file based variables
    00:00
    ERROR: Job failed: exit code 2
    ```

- **4. Make sure that the `sshpass` package are installed**
  - if `pg_new_wal_dir` variable vis defined (for synchronize wal dir)

    Fixed:
    
    ```
    TASK [upgrade : Make sure the custom WAL directory "/pgwal/15/pg_wal" exists and is empty] ***
    ok: [172.30.59.17] => (item=absent)
    ok: [172.30.59.18] => (item=absent)
    ok: [172.30.59.19] => (item=absent)
    changed: [172.30.59.17] => (item=directory)
    changed: [172.30.59.18] => (item=directory)
    changed: [172.30.59.19] => (item=directory)
    TASK [upgrade : Synchronize /pgdata1/15/main/pg_wal to /pgwal/15/pg_wal] *******
    fatal: [172.30.59.19]: FAILED! => {"changed": false, "cmd": "sshpass", "msg": "[Errno 2] No such file or directory: b'sshpass'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    fatal: [172.30.59.18]: FAILED! => {"changed": false, "cmd": "sshpass", "msg": "[Errno 2] No such file or directory: b'sshpass'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [172.30.59.17]
    NO MORE HOSTS LEFT *************************************************************
    PLAY RECAP *********************************************************************
    172.30.59.17               : ok=94   changed=26   unreachable=0    failed=0    skipped=83   rescued=0    ignored=0   
    172.30.59.18               : ok=54   changed=12   unreachable=0    failed=1    skipped=103  rescued=0    ignored=0   
    172.30.59.19               : ok=54   changed=12   unreachable=0    failed=1    skipped=103  rescued=0    ignored=0   
    Cleaning up project directory and file based variables
    00:01
    ERROR: Job failed: exit code 2
    ```
