### PR TITLE
Add the ability to set Patroni tags (including custom tags) at the host level

### DIFF
--- a/inventory
+++ b/inventory
@@ -6,6 +6,7 @@
 # "postgresql_exists='true'" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
 # "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
+# patroni_tags="key=value" tags for Patroni in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
 
 # In this example, all components will be installed on PostgreSQL nodes.
 # You can deploy the haproxy balancers and the etcd or consul cluster on other dedicated servers (recomended).
@@ -21,7 +22,7 @@
 10.128.64.140 consul_node_role=server consul_bootstrap_expect=true consul_datacenter=dc1
 10.128.64.142 consul_node_role=server consul_bootstrap_expect=true consul_datacenter=dc1
 10.128.64.143 consul_node_role=server consul_bootstrap_expect=true consul_datacenter=dc1
-#10.128.64.144 consul_node_role=client consul_datacenter=dc1
+#10.128.64.144 consul_node_role=client consul_datacenter=dc2
 #10.128.64.145 consul_node_role=client consul_datacenter=dc2
 
 # if with_haproxy_load_balancing: true
@@ -33,12 +34,13 @@
 
 # PostgreSQL nodes
 [master]
-10.128.64.140 hostname=pgnode01 postgresql_exists=false
+10.128.64.140 hostname=pgnode01 postgresql_exists=false # patroni_tags="datacenter=dc1"
 
 [replica]
-10.128.64.142 hostname=pgnode02 postgresql_exists=false
-10.128.64.143 hostname=pgnode03 postgresql_exists=false
-#10.128.64.144 hostname=pgnode04 postgresql_exists=false new_node=true
+10.128.64.142 hostname=pgnode02 postgresql_exists=false # patroni_tags="datacenter=dc1"
+10.128.64.143 hostname=pgnode03 postgresql_exists=false # patroni_tags="datacenter=dc1"
+#10.128.64.144 hostname=pgnode04 postgresql_exists=false patroni_tags="datacenter=dc2" new_node=true
+#10.128.64.145 hostname=pgnode04 postgresql_exists=false patroni_tags="datacenter=dc2" new_node=true
 
 [postgres_cluster:children]
 master

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -18,6 +18,7 @@
         consul_bootstrap_expect: true # if dcs_type: "consul"
         postgresql_version: "16" # to test custom WAL dir
         pgbouncer_processes: 2 # Test multiple pgbouncer processes (so_reuseport)
+        patroni_tags: "datacenter=dc1,key1=value1"
         cacheable: true
       delegate_to: localhost
       run_once: true # noqa run-once

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -214,16 +214,16 @@ tags:
 {% if patroni_tags is defined and patroni_tags | length > 0 %}
   {{ patroni_tags | replace(" ", "") | replace("=", ": ") | replace(",", "\n  ") }}
 {% endif %}
-{% if 'nofailover=' not in patroni_tags | default('') | replace(" ", "") %}
+{% if 'nofailover' not in patroni_tags | default('') | replace(" ", "") %}
   nofailover: false
 {% endif %}
-{% if 'noloadbalance=' not in patroni_tags | default('') | replace(" ", "") %}
+{% if 'noloadbalance' not in patroni_tags | default('') | replace(" ", "") %}
   noloadbalance: false
 {% endif %}
-{% if 'nosync=' not in patroni_tags | default('') | replace(" ", "") %}
+{% if 'nosync' not in patroni_tags | default('') | replace(" ", "") %}
   nosync: false
 {% endif %}
-{% if 'clonefrom=' not in patroni_tags | default('') | replace(" ", "") %}
+{% if 'clonefrom' not in patroni_tags | default('') | replace(" ", "") %}
   clonefrom: false
 {% endif %}
 

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -214,16 +214,17 @@ tags:
 {% if patroni_tags is defined and patroni_tags | length > 0 %}
   {{ patroni_tags | replace(" ", "") | replace("=", ": ") | replace(",", "\n  ") }}
 {% endif %}
-{% if 'nofailover' not in patroni_tags | default('') | replace(" ", "") %}
-  nofailover: false
-{% endif %}
-{% if 'noloadbalance' not in patroni_tags | default('') | replace(" ", "") %}
-  noloadbalance: false
-{% endif %}
-{% if 'nosync' not in patroni_tags | default('') | replace(" ", "") %}
+{% set normalized_tags = patroni_tags | default('') | replace(" ", "") %}
+{% if 'nosync=' not in normalized_tags %}
   nosync: false
 {% endif %}
-{% if 'clonefrom' not in patroni_tags | default('') | replace(" ", "") %}
+{% if 'noloadbalance=' not in normalized_tags %}
+  noloadbalance: false
+{% endif %}
+{% if 'nofailover=' not in normalized_tags %}
+  nofailover: false
+{% endif %}
+{% if 'clonefrom=' not in normalized_tags %}
   clonefrom: false
 {% endif %}
 

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -211,10 +211,14 @@ watchdog:
   safety_margin: 5
 
 tags:
+{% if patroni_tags is defined and patroni_tags | length > 0 %}
+  {{ patroni_tags | replace(" ", "") | replace("=", ": ") | replace(",", "\n  ") }}
+{% else %}
   nofailover: false
   noloadbalance: false
   clonefrom: false
   nosync: false
+{% endif %}
 
   # specify a node to replicate from (cascading replication)
 #  replicatefrom: (node name)

--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -213,11 +213,18 @@ watchdog:
 tags:
 {% if patroni_tags is defined and patroni_tags | length > 0 %}
   {{ patroni_tags | replace(" ", "") | replace("=", ": ") | replace(",", "\n  ") }}
-{% else %}
+{% endif %}
+{% if 'nofailover=' not in patroni_tags | default('') | replace(" ", "") %}
   nofailover: false
+{% endif %}
+{% if 'noloadbalance=' not in patroni_tags | default('') | replace(" ", "") %}
   noloadbalance: false
-  clonefrom: false
+{% endif %}
+{% if 'nosync=' not in patroni_tags | default('') | replace(" ", "") %}
   nosync: false
+{% endif %}
+{% if 'clonefrom=' not in patroni_tags | default('') | replace(" ", "") %}
+  clonefrom: false
 {% endif %}
 
   # specify a node to replicate from (cascading replication)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -79,8 +79,8 @@ patroni_etcd_password: "" # (optional) password for etcd authentication
 patroni_etcd_protocol: "" # (optional) http or https, if not specified http is used
 
 # more options you can specify in the roles/patroni/templates/patroni.yml.j2
-# https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd
-# https://patroni.readthedocs.io/en/latest/SETTINGS.html#consul
+# https://patroni.readthedocs.io/en/latest/yaml_configuration.html#etcd
+# https://patroni.readthedocs.io/en/latest/yaml_configuration.html#consul
 
 # if dcs_type: "consul"
 consul_version: "1.15.8"
@@ -343,7 +343,7 @@ patroni_master_start_timeout: 300
 patroni_maximum_lag_on_failover: 1048576 # (1MB) the maximum bytes a follower may lag to be able to participate in leader election.
 patroni_maximum_lag_on_replica: "100MB" # the maximum of lag that replica can be in order to be available for read-only queries.
 
-# https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callbacks#dynamic-configuration-settings
+# https://patroni.readthedocs.io/en/latest/yaml_configuration.html#postgresql
 patroni_callbacks: []
 #  - {action: "on_role_change", script: ""}
 #  - {action: "on_stop", script: ""}


### PR DESCRIPTION
Related issue: https://github.com/vitabaks/postgresql_cluster/issues/586

Added the ability to add tags for Patroni (including custom tags) at the host level in the inventory file.
  - Variable: `patroni_tags`
    - tags for Patroni in "key=value" format separated by commas 
  - Doc: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags

Example:

```
root@pgnode01:/# patronictl -c /etc/patroni/patroni.yml list
+ Cluster: postgres-cluster (7351028658196582445) --+-----------+-----------------+
| Member   | Host        | Role    | State     | TL | Lag in MB | Tags            |
+----------+-------------+---------+-----------+----+-----------+-----------------+
| pgnode01 | 10.172.0.20 | Leader  | running   |  2 |           | datacenter: dc1 |
| pgnode02 | 10.172.0.21 | Replica | streaming |  2 |         0 | datacenter: dc1 |
| pgnode03 | 10.172.0.22 | Replica | streaming |  2 |         0 | datacenter: dc2 |
+----------+-------------+---------+-----------+----+-----------+-----------------+
```
