### PR TITLE
Add the ability to set tags for load balancers

### DIFF
--- a/inventory
+++ b/inventory
@@ -6,8 +6,8 @@
 # "postgresql_exists=true" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
 # "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
-# patroni_tags="key=value" the Patroni tags in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
-# balancer_tags="key=value" the Balancer tags for the /replica, /sync, /async endpoints. It is crucial that each specified tag is also added to the Patroni tags via the 'patroni_tags' variable.
+# patroni_tags="key=value" the Patroni tags in "key=value" format separated by commas (details: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
+# balancer_tags="key=value" the Balancer tags for the /replica, /sync, /async endpoints. Add the tag to the 'patroni_tags' variable first.
 
 # if dcs_exists: false and dcs_type: "etcd"
 [etcd_cluster]  # recommendation: 3, or 5-7 nodes

--- a/inventory
+++ b/inventory
@@ -2,15 +2,12 @@
 # The specified ip addresses will be used to listen by the cluster components.
 # Attention! Specify private IP addresses so that the cluster does not listen a public IP addresses.
 # For deploying via public IPs, add 'ansible_host=public_ip_address' variable for each node.
-
-# "postgresql_exists='true'" if PostgreSQL is already exists and running
+#
+# "postgresql_exists=true" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
 # "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
-# patroni_tags="key=value" The Patroni tags in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
-# balancer_tags="key=value" User-defined balancers tags for the /replica /sync /async endpoints. It is required that the tag is also added to the Patroni tags ('patroni_tags' variable)
-
-# In this example, all components will be installed on PostgreSQL nodes.
-# You can deploy the haproxy balancers and the etcd or consul cluster on other dedicated servers (recomended).
+# patroni_tags="key=value" the Patroni tags in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
+# balancer_tags="key=value" the Balancer tags for the /replica, /sync, /async endpoints. It is crucial that each specified tag is also added to the Patroni tags via the 'patroni_tags' variable.
 
 # if dcs_exists: false and dcs_type: "etcd"
 [etcd_cluster]  # recommendation: 3, or 5-7 nodes
@@ -62,6 +59,6 @@ ansible_ssh_pass='secretpassword'  # "sshpass" package is required for use "ansi
 #ansible_python_interpreter='/usr/bin/python3'  # is required for use python3
 
 [pgbackrest:vars]
-ansible_user='postgres'
-ansible_ssh_pass='secretpassword'
+#ansible_user='postgres'
+#ansible_ssh_pass='secretpassword'
 

--- a/inventory
+++ b/inventory
@@ -6,7 +6,8 @@
 # "postgresql_exists='true'" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
 # "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
-# patroni_tags="key=value" tags for Patroni in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
+# patroni_tags="key=value" The Patroni tags in "key=value" format separated by commas (details here: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
+# balancer_tags="key=value" User-defined balancers tags for the /replica /sync /async endpoints. It is required that the tag is also added to the Patroni tags ('patroni_tags' variable)
 
 # In this example, all components will be installed on PostgreSQL nodes.
 # You can deploy the haproxy balancers and the etcd or consul cluster on other dedicated servers (recomended).
@@ -27,10 +28,11 @@
 
 # if with_haproxy_load_balancing: true
 [balancers]
-10.128.64.140
-10.128.64.142
-10.128.64.143
-#10.128.64.144 new_node=true
+10.128.64.140 # balancer_tags="datacenter=dc1"
+10.128.64.142 # balancer_tags="datacenter=dc1"
+10.128.64.143 # balancer_tags="datacenter=dc1"
+#10.128.64.144 balancer_tags="datacenter=dc2"
+#10.128.64.145 balancer_tags="datacenter=dc2" new_node=true
 
 # PostgreSQL nodes
 [master]
@@ -39,7 +41,7 @@
 [replica]
 10.128.64.142 hostname=pgnode02 postgresql_exists=false # patroni_tags="datacenter=dc1"
 10.128.64.143 hostname=pgnode03 postgresql_exists=false # patroni_tags="datacenter=dc1"
-#10.128.64.144 hostname=pgnode04 postgresql_exists=false patroni_tags="datacenter=dc2" new_node=true
+#10.128.64.144 hostname=pgnode04 postgresql_exists=false patroni_tags="datacenter=dc2"
 #10.128.64.145 hostname=pgnode04 postgresql_exists=false patroni_tags="datacenter=dc2" new_node=true
 
 [postgres_cluster:children]

--- a/inventory
+++ b/inventory
@@ -6,7 +6,7 @@
 # "postgresql_exists=true" if PostgreSQL is already exists and running
 # "hostname=" variable is optional (used to change the server name)
 # "new_node=true" to add a new server to an existing cluster using the add_pgnode.yml playbook
-# patroni_tags="key=value" the Patroni tags in "key=value" format separated by commas (details: https://patroni.readthedocs.io/en/latest/yaml_configuration.html#tags)
+# patroni_tags="key=value" the Patroni tags in "key=value" format separated by commas.
 # balancer_tags="key=value" the Balancer tags for the /replica, /sync, /async endpoints. Add the tag to the 'patroni_tags' variable first.
 
 # if dcs_exists: false and dcs_type: "etcd"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,7 @@
         postgresql_version: "16" # to test custom WAL dir
         pgbouncer_processes: 2 # Test multiple pgbouncer processes (so_reuseport)
         patroni_tags: "datacenter=dc1,key1=value1"
+        balancer_tags: "datacenter=dc1"
         cacheable: true
       delegate_to: localhost
       run_once: true # noqa run-once

--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -69,7 +69,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -91,7 +91,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -107,7 +107,7 @@ listen replicas_sync
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -129,7 +129,7 @@ listen replicas_sync_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -145,7 +145,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -167,7 +167,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions

--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -69,7 +69,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -91,7 +91,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -107,7 +107,7 @@ listen replicas_sync
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -129,7 +129,7 @@ listen replicas_sync_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -145,7 +145,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -167,7 +167,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -72,7 +72,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -96,7 +96,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -113,7 +113,7 @@ listen replicas_sync
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -137,7 +137,7 @@ listen replicas_sync_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -154,7 +154,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -178,7 +178,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -72,7 +72,7 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -96,7 +96,7 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -113,7 +113,7 @@ listen replicas_sync
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -137,7 +137,7 @@ listen replicas_sync_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -154,7 +154,7 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -178,7 +178,7 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions


### PR DESCRIPTION
- Related issue: https://github.com/vitabaks/postgresql_cluster/issues/586
- Related PR: https://github.com/vitabaks/postgresql_cluster/pull/611

Variable: `balancer_tags`
- the Balancer tags for the /replica, /sync, /async endpoints.
    - It is crucial that each specified tag is also added to the Patroni tags via the 'patroni_tags' variable.
    - This ensures that the load balancer considers these tags when deciding to redirect traffic to appropriate database instances.
- Doc: https://patroni.readthedocs.io/en/latest/rest_api.html#health-check-endpoints

Example (/etc/haproxy/haproxy.cfg ):

```
global
    maxconn 100000
    log /dev/log    local0
    log /dev/log    local1 notice
    chroot /var/lib/haproxy
    stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
    stats timeout 30s
    user haproxy
    group haproxy
    daemon

defaults
    mode               tcp
    log                global
    retries            2
    timeout queue      5s
    timeout connect    5s
    timeout client     60m
    timeout server     60m
    timeout check      15s

listen stats
    mode http
    bind 10.172.0.20:7000
    stats enable
    stats uri /

listen master
    bind 10.172.0.20:5000
    maxconn 10000
    option tcplog
    option httpchk OPTIONS /primary
    http-check expect status 200
    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 server pgnode01 10.172.0.20:6432 check port 8008
 server pgnode02 10.172.0.21:6432 check port 8008
 server pgnode03 10.172.0.22:6432 check port 8008


listen replicas
    bind 10.172.0.20:5001
    maxconn 10000
    option tcplog
    option httpchk OPTIONS /replica?lag=100MB&tag_datacenter=dc1
    balance roundrobin
    http-check expect status 200
    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 server pgnode01 10.172.0.20:6432 check port 8008
 server pgnode02 10.172.0.21:6432 check port 8008
 server pgnode03 10.172.0.22:6432 check port 8008


listen replicas_sync
    bind 10.172.0.20:5002
    maxconn 10000
    option tcplog
    option httpchk OPTIONS /sync?tag_datacenter=dc1
    balance roundrobin
    http-check expect status 200
    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 server pgnode01 10.172.0.20:6432 check port 8008
 server pgnode02 10.172.0.21:6432 check port 8008
 server pgnode03 10.172.0.22:6432 check port 8008


listen replicas_async
    bind 10.172.0.20:5003
    maxconn 10000
    option tcplog
    option httpchk OPTIONS /async?lag=100MB&tag_datacenter=dc1
    balance roundrobin
    http-check expect status 200
    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
 server pgnode01 10.172.0.20:6432 check port 8008
 server pgnode02 10.172.0.21:6432 check port 8008
 server pgnode03 10.172.0.22:6432 check port 8008
```

## To separate load balancers across different data centers

1. To separate load balancers across different data centers (each has its VIP), just create separate inventory files (e.q. `cluster.hosts`, `balancers_dc1.hosts`, `balancers_dc2.hosts`). See an example [here](https://github.com/vitabaks/postgresql_cluster/discussions/605#discussioncomment-8870224)
2. To separate the read-only traffic across different data centers, add the `datacenter=<name>` tag to the ‘patroni_tags’ and ‘balancer_tags’ variables in the inventory for the respective hosts. See an example [here](https://github.com/vitabaks/postgresql_cluster/blob/master/inventory)