### PR TITLE
Patroni: Add permanent replication slots

### DIFF
--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -86,20 +86,33 @@ bootstrap:
       {% for parameter in postgresql_parameters %}
         {{ parameter.option }}: {{ parameter.value }}
       {% endfor %}
-  {% if patroni_standby_cluster.host is defined and patroni_standby_cluster.host | length > 0 %}
+    {% if patroni_standby_cluster.host is defined and patroni_standby_cluster.host | length > 0 %}
     standby_cluster:
       host: {{ patroni_standby_cluster.host }}
       port: {{ patroni_standby_cluster.port }}
-    {% if patroni_standby_cluster.primary_slot_name is defined and patroni_standby_cluster.primary_slot_name | length > 0 %}
+      {% if patroni_standby_cluster.primary_slot_name is defined and patroni_standby_cluster.primary_slot_name | length > 0 %}
       primary_slot_name: {{ patroni_standby_cluster.primary_slot_name }}
-    {% endif %}
-    {% if patroni_standby_cluster.restore_command is defined and patroni_standby_cluster.restore_command | length > 0 %}
+      {% endif %}
+      {% if patroni_standby_cluster.restore_command is defined and patroni_standby_cluster.restore_command | length > 0 %}
       restore_command: {{ patroni_standby_cluster.restore_command }}
-    {% endif %}
-    {% if patroni_standby_cluster.recovery_min_apply_delay is defined and patroni_standby_cluster.recovery_min_apply_delay | length > 0 %}
+      {% endif %}
+      {% if patroni_standby_cluster.recovery_min_apply_delay is defined and patroni_standby_cluster.recovery_min_apply_delay | length > 0 %}
       recovery_min_apply_delay: {{ patroni_standby_cluster.recovery_min_apply_delay }}
+     {% endif %}
     {% endif %}
-  {% endif %}
+    {% if patroni_slots is defined and patroni_slots | length > 0 %}
+    slots:
+      {% for slot in patroni_slots %}
+      {{ slot.slot }}:
+        type: {{ slot.type }}
+        {% if slot.plugin | default('') | length > 0 %}
+        plugin: {{ slot.plugin }}
+        {% endif %}
+        {% if slot.database | default('') | length > 0 %}
+        database: {{ slot.database }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
 
 {% if postgresql_exists|bool %}
 #  initdb:  # List options to be passed on to initdb

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -365,11 +365,11 @@ patroni_standby_cluster:
 # Permanent replication slots.
 # These slots will be preserved during switchover/failover.
 # https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
-patroni_slots:
-  - slot: "logical_replication_slot" # the name of the permanent replication slot.
-    type: "logical" # the type of slot. Could be physical or logical (if the slot is logical, you have to define 'database' and 'plugin').
-    plugin: "pgoutput" # the plugin name for the logical slot.
-    database: "postgres" # the database name where logical slots should be created.
+patroni_slots: []
+#  - slot: "logical_replication_slot" # the name of the permanent replication slot.
+#    type: "logical" # the type of slot. Could be 'physical' or 'logical' (if the slot is logical, you have to define 'database' and 'plugin').
+#    plugin: "pgoutput" # the plugin name for the logical slot.
+#    database: "postgres" # the database name where logical slots should be created.
 #  - slot: "test_logical_replication_slot"
 #    type: "logical"
 #    plugin: "pgoutput"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -362,6 +362,19 @@ patroni_standby_cluster:
 #  restore_command: ""  # command to restore WAL records from the remote master to standby leader (optional)
 #  recovery_min_apply_delay: ""  # how long to wait before actually apply WAL records on a standby leader (optional)
 
+# Permanent replication slots.
+# These slots will be preserved during switchover/failover.
+# https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
+patroni_slots:
+  - slot: "logical_replication_slot" # the name of the permanent replication slot.
+    type: "logical" # the type of slot. Could be physical or logical (if the slot is logical, you have to define 'database' and 'plugin').
+    plugin: "pgoutput" # the plugin name for the logical slot.
+    database: "postgres" # the database name where logical slots should be created.
+#  - slot: "test_logical_replication_slot"
+#    type: "logical"
+#    plugin: "pgoutput"
+#    database: "test"
+
 patroni_log_destination: stderr  # or 'logfile'
 # if patroni_log_destination: logfile
 patroni_log_dir: /var/log/patroni

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -221,7 +221,7 @@ postgresql_parameters:
   - { option: "archive_command", value: "cd ." }  # not doing anything yet with WAL-s
 #  - { option: "archive_command", value: "{{ wal_g_archive_command }}" }  # archive WAL-s using WAL-G
 #  - { option: "archive_command", value: "{{ pgbackrest_archive_command }}" }  # archive WAL-s using pgbackrest
-  - { option: "wal_level", value: "replica" }
+  - { option: "wal_level", value: "logical" }
   - { option: "wal_keep_size", value: "2GB" }
   - { option: "max_wal_senders", value: "10" }
   - { option: "max_replication_slots", value: "10" }


### PR DESCRIPTION
### Add the ability to define permanent replication slots.
  - Variable: `patroni_slots` (by default, the value is not defined)

Example:

```yaml
patroni_slots:
  - slot: "<logical_replication_slot_name>" # the name of the permanent replication slot.
    type: "logical" # the type of slot. Could be physical or logical (if the slot is logical, you have to define 'database' and 'plugin').
    plugin: "pgoutput" # the plugin name for the logical slot.
    database: "<my_db_name>" # the database name where logical slots should be created.
```

These slots will be preserved during switchover/failover. Permanent slots that don’t exist will be created by Patroni. 

#### How it works:

With PostgreSQL 11 onwards permanent physical slots are created on all nodes and their position is advanced every loop_wait seconds. For PostgreSQL versions older than 11 permanent physical replication slots are maintained only on the current primary. The logical slots are copied from the primary to a standby with restart, and after that their position advanced every loop_wait seconds (if necessary). Copying logical slot files performed via libpq connection and using either rewind or superuser credentials.

> There is always a chance that the logical slot position on the replica is a bit behind the former primary, therefore application should be prepared that some messages could be received the second time after the failover.

> Permanent replication slots are synchronized only from the primary/standby_leader to replica nodes. That means, **applications are supposed to be using them only from the leader node**. Using them on replica nodes will cause indefinite growth of pg_wal on all other nodes in the cluster. 

Doc: https://patroni.readthedocs.io/en/latest/dynamic_configuration.html

#### Additionally

- Set 'wal_level=**logical**' by default