### PR TITLE
Fix haproxy j2 template formatting #616

### DIFF
--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -72,7 +72,8 @@ listen replicas
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -96,7 +97,8 @@ listen replicas_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -113,7 +115,8 @@ listen replicas_sync
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -137,7 +140,8 @@ listen replicas_sync_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /sync{% if balancer_tags | default('') | length > 0 %}{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -154,7 +158,8 @@ listen replicas_async
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -178,7 +183,8 @@ listen replicas_async_direct
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
     option tcplog
-    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}{% endif %}
+    option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{% if balancer_tags | default('') | length > 0 %}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') + '\n' }}
+{% endif %}
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions


### PR DESCRIPTION
Moved '{% endif %}' to the next line to resolve a formatting issue that was causing the generated configuration to not reflect the correct line separation.

#616