### PR TITLE
Update the tasks to check the availability of the VIP address

### DIFF
--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -8,13 +8,25 @@
     state: restarted
   listen: "restart keepalived"
 
+# This task checks the cluster VIP's availability, selecting the appropriate port:
+# - during maintenance, it targets the database through PgBouncer or directly.
+# - otherwise, it defaults to SSH, applicable during deployment when the database is not yet available.
 - name: Wait for the cluster ip address (VIP) "{{ cluster_vip }}" is running
   ansible.builtin.wait_for:
     host: "{{ cluster_vip }}"
-    port: "{{ ansible_ssh_port | default(22) }}"
+    port: "{{ target_port }}"
     state: started
     timeout: 15  # max wait time: 30 seconds
     delay: 2
+  vars:
+    target_port: >-
+      {{
+        (postgresql_cluster_maintenance | default(false) | bool) |
+        ternary(
+          pgbouncer_listen_port if pgbouncer_install | bool else postgresql_port,
+          ansible_ssh_port | default(22)
+        )
+      }}
   ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart keepalived"
 

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -13,7 +13,7 @@
     host: "{{ cluster_vip }}"
     port: "{{ ansible_ssh_port | default(22) }}"
     state: started
-    timeout: 30  # max wait time: 1 minute
+    timeout: 15  # max wait time: 30 seconds
     delay: 2
   ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart keepalived"

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -15,6 +15,7 @@
     state: started
     timeout: 60
     delay: 2
+  ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart keepalived"
 
 ...

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -13,7 +13,7 @@
     host: "{{ cluster_vip }}"
     port: "{{ ansible_ssh_port | default(22) }}"
     state: started
-    retries: 30  # max wait time: 1 minute
+    timeout: 30  # max wait time: 1 minute
     delay: 2
   ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart keepalived"

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -13,7 +13,7 @@
     host: "{{ cluster_vip }}"
     port: "{{ ansible_ssh_port | default(22) }}"
     state: started
-    timeout: 60
+    retries: 30  # max wait time: 1 minute
     delay: 2
   ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart keepalived"

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -394,14 +394,11 @@
 - name: Make sure that the cluster ip address (VIP) "{{ cluster_vip }}" is running
   ansible.builtin.wait_for:
     host: "{{ cluster_vip }}"
-    port: "{{ target_port }}"
+    port: "{{ pgbouncer_listen_port if pgbouncer_install | bool else postgresql_port }}"
     state: started
-    timeout: 3
+    timeout: 15  # max wait time: 30 seconds
     delay: 2
-  vars:
-    target_port: >-
-      {{ pgbouncer_listen_port if pgbouncer_install | bool
-      else (ansible_ssh_port | default(22)) }}
+  ignore_errors: true  # show the error and continue the playbook execution
   when:
     - cluster_vip | length > 0
 

--- a/roles/vip-manager/handlers/main.yml
+++ b/roles/vip-manager/handlers/main.yml
@@ -13,7 +13,7 @@
     host: "{{ cluster_vip }}"
     port: "{{ pgbouncer_listen_port if pgbouncer_install | bool else postgresql_port }}"
     state: started
-    timeout: 30  # max wait time: 1 minute
+    timeout: 15  # max wait time: 30 seconds
     delay: 2
   ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart vip-manager"

--- a/roles/vip-manager/handlers/main.yml
+++ b/roles/vip-manager/handlers/main.yml
@@ -11,10 +11,11 @@
 - name: Wait for the cluster ip address (VIP) "{{ cluster_vip }}" is running
   ansible.builtin.wait_for:
     host: "{{ cluster_vip }}"
-    port: "{{ ansible_ssh_port | default(22) }}"
+    port: "{{ pgbouncer_listen_port if pgbouncer_install | bool else postgresql_port }}"
     state: started
-    timeout: 60
+    timeout: 30  # max wait time: 1 minute
     delay: 2
+  ignore_errors: true  # show the error and continue the playbook execution
   listen: "restart vip-manager"
 
 ...


### PR DESCRIPTION
Update task "Wait for the cluster IP address (VIP) is running" (if `cluster_vip` is defined)

**keepalived**
  - Add 'ignore_errors: true' to show the error and continue the playbook execution
    - In some environments with strict SSH access rules, checking the availability of an IP address over an SSH port may not work. To handle such cases, we added 'ignore_errors' to the task "Wait for the cluster IP address (VIP) is running" to continue the playbook execution even if the IP address check fails.
  - Use the `pgbouncer_listen_port` (or `postgresql_port` if 'pgbouncer_install' is 'false') to check the availability of the VIP address. Otherwise, it defaults to SSH port, applicable during deployment when the database is not yet available. 
  - Change the check timeout from 2 minutes to 30 seconds

**vip-manager**
  - Add 'ignore_errors: true' to show the error and continue the playbook execution
  - Use the `pgbouncer_listen_port` (or `postgresql_port` if 'pgbouncer_install' is 'false') to check the availability of the VIP address
  - Change the check timeout from 2 minutes to 30 seconds