### PR TITLE
ansible_python_interpreter: Use Python 3 (by default)

### DIFF
--- a/inventory
+++ b/inventory
@@ -56,7 +56,7 @@ ansible_ssh_port='22'
 ansible_user='root'
 ansible_ssh_pass='secretpassword'  # "sshpass" package is required for use "ansible_ssh_pass"
 #ansible_ssh_private_key_file=
-#ansible_python_interpreter='/usr/bin/python3'  # is required for use python3
+ansible_python_interpreter='/usr/bin/env python3'
 
 [pgbackrest:vars]
 #ansible_user='postgres'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,7 @@
   tasks:
     - name: Set variables for PostgreSQL Cluster deployment test
       ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
         firewall_enabled_at_boot: false
         firewall_enable_ipv6: false # Added to prevent test failures in CI.
         swap_file_create: false # Added to prevent test failures in CI.

--- a/roles/patroni/tasks/main.yml
+++ b/roles/patroni/tasks/main.yml
@@ -67,8 +67,6 @@
       when: patroni_pip_package_repo | length < 1 and patroni_install_version != "latest"
   when: installation_method == "repo" and patroni_installation_method == "pip"
   environment: "{{ proxy_env | default({}) }}"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   tags: patroni, patroni_install
 
 - block:  # when "patroni_pip_requirements_repo" and "patroni_pip_package_repo" is defined
@@ -114,8 +112,6 @@
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_repo | length > 0
   when: installation_method == "repo" and patroni_installation_method == "pip"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   tags: patroni, patroni_install
 
 - block:  # installation_method: "file" and patroni_installation_method: "pip"
@@ -157,8 +153,6 @@
         PIP_BREAK_SYSTEM_PACKAGES: "1"
       when: patroni_pip_package_file | length > 0
   when: installation_method == "file" and patroni_installation_method == "pip"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   tags: patroni, patroni_install
 
 - block:  # installation_method: "repo" and patroni_installation_method: "rpm/deb"
@@ -608,8 +602,6 @@
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
   # Run PITR
     - name: Stop patroni service on the Replica servers (if running)
       ansible.builtin.systemd:
@@ -640,8 +632,6 @@
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
       when: is_master | bool
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
 
     - block:  # for pgbackrest only (for use --delta restore)
         - name: Run "{{ pgbackrest_patroni_cluster_restore_command }}" on Master
@@ -736,8 +726,6 @@
         key: postgresql.parameters.archive_command
         value: "cd ."  # not doing anything yet with WAL-s
         content_type: json
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
       when: patroni_dynamic_json.stat.exists and
             keep_patroni_dynamic_json|bool and disable_archive_command|bool
 
@@ -746,8 +734,6 @@
         src: /etc/patroni/patroni.yml
         key: bootstrap.dcs.postgresql.parameters.archive_command
         value: "cd ."  # not doing anything yet with WAL-s
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
       when: disable_archive_command|bool
   when: patroni_cluster_bootstrap_method != "initdb" and
         (pgbackrest_install|bool or wal_g_install|bool) and
@@ -913,8 +899,6 @@
           - key: postgresql.authentication.superuser.password
             value: "{{ patroni_superuser_password }}"
         state: present
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
       when: hostvars[groups['master'][0]]['postgresql_user_result'] is changed
   when: patroni_cluster_bootstrap_method != "initdb" and
         (pgbackrest_install|bool or wal_g_install|bool) and

--- a/roles/update/tasks/patroni.yml
+++ b/roles/update/tasks/patroni.yml
@@ -14,8 +14,6 @@
       register: update_patroni_package_pip
   ignore_errors: true
   environment: "{{ proxy_env | default({}) }}"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   when: installation_method == "repo" and patroni_installation_method == "pip"
 
 # patroni_installation_method: "rpm/deb"

--- a/roles/upgrade/tasks/dcs_remove_cluster.yml
+++ b/roles/upgrade/tasks/dcs_remove_cluster.yml
@@ -8,8 +8,6 @@
       (.*)"Yes I am aware": "Yes I am aware"
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   when:
     - inventory_hostname in groups['primary']
 

--- a/roles/upgrade/tasks/maintenance_enable.yml
+++ b/roles/upgrade/tasks/maintenance_enable.yml
@@ -6,8 +6,6 @@
   ansible.builtin.command: "patronictl -c {{ patroni_config_file }} pause --wait {{ patroni_cluster_name }}"
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   register: pause_result
   failed_when: "'Cluster is already paused' not in pause_result.stderr and pause_result.rc != 0"
   when:

--- a/roles/upgrade/tasks/pre_checks.yml
+++ b/roles/upgrade/tasks/pre_checks.yml
@@ -33,8 +33,6 @@
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
     PIP_BREAK_SYSTEM_PACKAGES: "1"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
 
 - name: '[Pre-Check] Test PostgreSQL database access using a unix socket'
   ansible.builtin.command: >

--- a/roles/upgrade/tasks/rollback.yml
+++ b/roles/upgrade/tasks/rollback.yml
@@ -132,8 +132,6 @@
   ansible.builtin.command: "patronictl -c {{ patroni_config_file }} resume --wait {{ patroni_cluster_name }}"
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/bin:/usr/local/bin"
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   failed_when: false
 
 - name: '[Rollback] Check Patroni is healthy on the Leader'


### PR DESCRIPTION
This PR introduces changes to explicitly use Python 3 and dynamically determine the Python interpreter path using `/usr/bin/env python3` to ensure compatibility with various Linux distributions.

Additionally, explicit definitions of the `ansible_python_interpreter` variable have been removed from certain tasks as it is now globally specified for the entire playbook.