### PR TITLE
Offline installation - add a flag to use preconfigured repos

### DIFF
--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -174,7 +174,7 @@
     - role: resolv_conf
     - role: etc_hosts
     - role: add-repository
-      when: not airgapped_install_mode | bool
+      when: not airgapped_install_preconfigured_repos | bool
     - role: packages
     - role: sudo
     - role: swap

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -174,6 +174,7 @@
     - role: resolv_conf
     - role: etc_hosts
     - role: add-repository
+      when: not airgapped_install_mode | bool
     - role: packages
     - role: sudo
     - role: swap

--- a/roles/pgbackrest/defaults/main.yml
+++ b/roles/pgbackrest/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+airgapped_install_libzstd_rpm_url: "https://dl.fedoraproject.org/pub/archive/epel/8.1/Everything/x86_64/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm"

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -22,7 +22,7 @@
         - name: Make sure pgdg repository is installed
           ansible.builtin.apt_repository:
             repo: "deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
-      when: not airgapped_install_mode | bool
+      when: not airgapped_install_preconfigured_repos | bool
 
     - name: Update apt cache
       ansible.builtin.apt:
@@ -56,7 +56,7 @@
           until: package_status is success
           delay: 5
           retries: 3
-      when: not airgapped_install_mode | bool
+      when: not airgapped_install_preconfigured_repos | bool
 
     - name: Clean yum cache
       ansible.builtin.command: yum clean all
@@ -78,7 +78,7 @@
 - block:
     - name: Get libzstd rpm package from archived EPEL
       ansible.builtin.get_url:
-        url: "{{ airgapped_install_libzstd_rpm_url | default('https://dl.fedoraproject.org/pub/archive/epel/8.1/Everything/x86_64/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm') }}"
+        url: "{{ airgapped_install_libzstd_rpm_url }}"
         dest: /tmp/
         timeout: 120
         validate_certs: false

--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -12,14 +12,17 @@
       delay: 5
       retries: 3
 
-    - name: Make sure pgdg apt key is installed
-      ansible.builtin.apt_key:
-        id: ACCC4CF8
-        url: https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc
+    - name: Only execute on an internet connected environment
+      block:
+        - name: Make sure pgdg apt key is installed
+          ansible.builtin.apt_key:
+            id: ACCC4CF8
+            url: https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc
 
-    - name: Make sure pgdg repository is installed
-      ansible.builtin.apt_repository:
-        repo: "deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+        - name: Make sure pgdg repository is installed
+          ansible.builtin.apt_repository:
+            repo: "deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+      when: not airgapped_install_mode | bool
 
     - name: Update apt cache
       ansible.builtin.apt:
@@ -36,21 +39,24 @@
   tags: pgbackrest, pgbackrest_repo, pgbackrest_install
 
 - block:  # RedHat pgdg repo
-    - name: Get pgdg-redhat-repo-latest.noarch.rpm
-      ansible.builtin.get_url:
-        url: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
-        dest: /tmp/
-        timeout: 30
-        validate_certs: false
+    - name: Only execute on an internet connected environment
+      block:
+        - name: Get pgdg-redhat-repo-latest.noarch.rpm
+          ansible.builtin.get_url:
+            url: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+            dest: /tmp/
+            timeout: 30
+            validate_certs: false
 
-    - name: Make sure pgdg repository is installed
-      ansible.builtin.package:
-        name: /tmp/pgdg-redhat-repo-latest.noarch.rpm
-        state: present
-      register: package_status
-      until: package_status is success
-      delay: 5
-      retries: 3
+        - name: Make sure pgdg repository is installed
+          ansible.builtin.package:
+            name: /tmp/pgdg-redhat-repo-latest.noarch.rpm
+            state: present
+          register: package_status
+          until: package_status is success
+          delay: 5
+          retries: 3
+      when: not airgapped_install_mode | bool
 
     - name: Clean yum cache
       ansible.builtin.command: yum clean all
@@ -72,7 +78,7 @@
 - block:
     - name: Get libzstd rpm package from archived EPEL
       ansible.builtin.get_url:
-        url: https://dl.fedoraproject.org/pub/archive/epel/8.1/Everything/x86_64/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm
+        url: "{{ airgapped_install_libzstd_rpm_url | default('https://dl.fedoraproject.org/pub/archive/epel/8.1/Everything/x86_64/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm') }}"
         dest: /tmp/
         timeout: 120
         validate_certs: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,8 +7,7 @@ proxy_env: {}  # yamllint disable rule:braces
 # ---------------------------------------------------------------------
 
 # This flag disables automatic installation of public yum / apt repositories.
-airgapped_install_mode: false
-airgapped_install_libzstd_rpm_url: ""
+airgapped_install_preconfigured_repos: false
 
 # Cluster variables
 cluster_vip: ""  # IP address for client access to the databases in the cluster (optional).

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,10 @@ proxy_env: {}  # yamllint disable rule:braces
 #  https_proxy: http://10.128.64.9:3128
 # ---------------------------------------------------------------------
 
+# This flag disables automatic installation of public yum / apt repositories.
+airgapped_install_mode: false
+airgapped_install_libzstd_rpm_url: ""
+
 # Cluster variables
 cluster_vip: ""  # IP address for client access to the databases in the cluster (optional).
 vip_interface: "{{ ansible_default_ipv4.interface }}"  # interface name (e.g., "ens32").


### PR DESCRIPTION
In this small PR I added a flag to switch of online repo-installation.
This is very useful in cases like #183. In my scenario I have preconfigured yum and apt repos, containing e.g. all RedHat and EPEL stuff and also the postgresql repo is added in a "baseline playbook" before this on.
I hope that there are others with similar issues :-)

By the way...thanks for this great playbook at all!