### PR TITLE
Set variable "ansible_python_interpreter" if not defined

### DIFF
--- a/add_balancer.yml
+++ b/add_balancer.yml
@@ -6,6 +6,12 @@
   any_errors_fatal: true
   gather_facts: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -9,6 +9,12 @@
     - ansible.builtin.import_tasks: roles/patroni/handlers/main.yml
 
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/balancers.yml
+++ b/balancers.yml
@@ -9,6 +9,12 @@
     vip_manager_disable: false # or 'true' for disable vip-manager service (if installed)
 
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -3,6 +3,12 @@
   hosts: postgres_cluster
   gather_facts: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
 

--- a/consul.yml
+++ b/consul.yml
@@ -8,6 +8,12 @@
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -10,6 +10,12 @@
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/etcd_cluster.yml
+++ b/etcd_cluster.yml
@@ -7,6 +7,12 @@
   gather_facts: true
 
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,7 +6,6 @@
   tasks:
     - name: Set variables for PostgreSQL Cluster deployment test
       ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
         firewall_enabled_at_boot: false
         firewall_enable_ipv6: false # Added to prevent test failures in CI.
         swap_file_create: false # Added to prevent test failures in CI.

--- a/pg_upgrade.yml
+++ b/pg_upgrade.yml
@@ -8,6 +8,11 @@
   become_user: postgres
   any_errors_fatal: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
 

--- a/pg_upgrade_rollback.yml
+++ b/pg_upgrade_rollback.yml
@@ -10,6 +10,11 @@
   gather_facts: true
   any_errors_fatal: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
     - name: Include upgrade variables

--- a/remove_cluster.yml
+++ b/remove_cluster.yml
@@ -3,6 +3,11 @@
   hosts: postgres_cluster
   become: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -6,6 +6,12 @@
   become_method: sudo
   any_errors_fatal: true
   pre_tasks:
+    - name: "Set variable: ansible_python_interpreter"
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: "/usr/bin/env python3"
+      when: "'python3' not in (ansible_python_interpreter | default(''))"
+      tags: always
+
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always


### PR DESCRIPTION
in the [previous](https://github.com/vitabaks/postgresql_cluster/pull/624) PR, it was suggested to set the `ansible_python_interpreter` variable globally at the inventory level. But if this variable is not specified, then errors are possible. 

Now we have added checks at the playbook level, if this variable is not defined (or rather does not have a python3 value) then the variable will be set automatically.