### PR TITLE
Add basic security for Patroni REST API

### DIFF
--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -25,9 +25,15 @@ restapi:
   connect_address: {{ inventory_hostname }}:{{ patroni_restapi_port }}
 #  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
 #  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
+{% if patroni_restapi_password | default('') | length > 0 %}
+  authentication:
+      username: {{ patroni_restapi_username | default('patroni') }}
+      password: {{ patroni_restapi_password }}
+{% else %}
 #  authentication:
 #    username: username
 #    password: password
+{% endif %}
 
 {% if not dcs_exists|bool and dcs_type == 'etcd' %}
 etcd3:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,6 +18,8 @@ patroni_superuser_username: "postgres"
 patroni_superuser_password: "postgres-pass"  # please change password
 patroni_replication_username: "replicator"
 patroni_replication_password: "replicator-pass"  # please change password
+patroni_restapi_username: "patroni"
+patroni_restapi_password: "restapi-pass"  # please change password
 
 synchronous_mode: false  # or 'true' for enable synchronous database replication
 synchronous_mode_strict: false  # if 'true' then block all client writes to the master, when a synchronous replica is not available


### PR DESCRIPTION
This PR adds two variables: `patroni_restapi_username` and `patroni_restapi_password` to add authentication for Patroni REST API providing basic security for unsafe operations.