### PR TITLE
update_pgcluster.yml: Update pgBackRest package on the backup server

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -56,7 +56,7 @@ Note: About the expected downtime of the database during the update:
 
 When using load balancing for read-only traffic (the "Type A" and "Type C" schemes), zero downtime is expected (for read traffic), provided there is more than one replica in the cluster. For write traffic (to the Primary), the expected downtime is ~5-10 seconds.
 
-#### 1. PRE-UPDATE: Perform Pre-Checks
+#### 1. PRE-UPDATE: Perform pre-update tasks
 - Test PostgreSQL DB Access
 - Make sure that physical replication is active
   - Stop, if there are no active replicas
@@ -66,6 +66,8 @@ When using load balancing for read-only traffic (the "Type A" and "Type C" schem
 - Make sure there are no long-running transactions
   - no more than `max_transaction_sec`
   - Stop, if long-running transactions detected
+- Update the pgBackRest package on the backup server (Dedicated Repository Host).
+  - Note: This task runs only if the backup host is specified in the 'pgbackrest' group in the inventory file, and the variable `target` is set to '`system`'.
 #### 2. UPDATE: Secondary (one by one)
 - Stop read-only traffic
   - Enable `noloadbalance`, `nosync`, `nofailover` parameters in the patroni.yml

--- a/roles/update/tasks/pgbackrest_host.yml
+++ b/roles/update/tasks/pgbackrest_host.yml
@@ -1,6 +1,6 @@
 ---
 # Update pgbackrest package on the Dedicated Repository Host
-# if 'pgbackrest_repo_host' is defined and the host is specified in the pgbackrest group in the inventory file.
+# if 'pgbackrest_repo_host' is defined and the host is specified in the 'pgbackrest' group in the inventory file.
 - block:
     - name: Gather facts from pgbackrest server
       ansible.builtin.setup:

--- a/roles/update/tasks/pgbackrest_host.yml
+++ b/roles/update/tasks/pgbackrest_host.yml
@@ -52,6 +52,6 @@
   when:
     - pgbackrest_install | bool
     - pgbackrest_repo_host | default('') | length > 0
-    - groups['pgbackrest'] | default('') | length > 0
+    - groups['pgbackrest'] | default([]) | length > 0
 
 ...

--- a/roles/update/tasks/pgbackrest_host.yml
+++ b/roles/update/tasks/pgbackrest_host.yml
@@ -1,0 +1,57 @@
+---
+# Update pgbackrest package on the Dedicated Repository Host
+# if 'pgbackrest_repo_host' is defined and the host is specified in the pgbackrest group in the inventory file.
+- block:
+    - name: Gather facts from pgbackrest server
+      ansible.builtin.setup:
+      delegate_to: "{{ groups['pgbackrest'][0] }}"
+      run_once: true
+
+    - name: Update yum cache
+      delegate_to: "{{ groups['pgbackrest'][0] }}"
+      run_once: true
+      ansible.builtin.shell: yum clean all && yum -y makecache
+      args:
+        executable: /bin/bash
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version == '7'
+
+    - name: Update dnf cache
+      delegate_to: "{{ groups['pgbackrest'][0] }}"
+      run_once: true
+      ansible.builtin.shell: dnf clean all && dnf -y makecache
+      args:
+        executable: /bin/bash
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version >= '8'
+
+    - name: Update apt cache
+      delegate_to: "{{ groups['pgbackrest'][0] }}"
+      run_once: true
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+      when: ansible_os_family == "Debian"
+
+    - name: Install the latest version of pgbackrest package
+      delegate_to: "{{ groups['pgbackrest'][0] }}"
+      run_once: true
+      ansible.builtin.package:
+        name: pgbackrest
+        state: latest
+      register: update_pgbackrest_package
+      until: update_pgbackrest_package is success
+      delay: 5
+      retries: 3
+  when:
+    - pgbackrest_install | bool
+    - pgbackrest_repo_host | default('') | length > 0
+    - groups['pgbackrest'] | default('') | length > 0
+
+...

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -78,7 +78,7 @@
       ansible.builtin.include_role:
         name: update
         tasks_from: pgbackrest_host
-      when: groups['pgbackrest'] | default('') | length > 0 and target | lower == 'system'
+      when: groups['pgbackrest'] | default([]) | length > 0 and target | lower == 'system'
   tags:
     - update
     - pre-checks

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -71,6 +71,14 @@
       ansible.builtin.include_role:
         name: update
         tasks_from: pre_checks
+
+    # This task updates the pgBackRest package on the backup server (Dedicated Repository Host).
+    # It runs only if the 'pgbackrest' group is defined in the inventory and the update target is set to 'system'.
+    - name: Update pgBackRest package (Dedicated Repository Host)
+      ansible.builtin.include_role:
+        name: update
+        tasks_from: pgbackrest_host
+      when: groups['pgbackrest'] | default('') | length > 0 and target | lower == 'system'
   tags:
     - update
     - pre-checks

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -53,9 +53,9 @@
       when: inventory_hostname in groups['primary']
       tags: always
 
-- name: "(1/4) PRE-UPDATE: Perform Pre-Checks"
+- name: "(1/4) PRE-UPDATE: Perform pre-update tasks"
   hosts: "primary:secondary"
-  gather_facts: false
+  gather_facts: true
   become: true
   become_user: postgres
   any_errors_fatal: true
@@ -86,7 +86,7 @@
 - name: "(2/4) UPDATE: Secondary"
   hosts: secondary
   serial: 1 # update replicas one by one
-  gather_facts: false
+  gather_facts: true
   become: true
   become_method: sudo
   any_errors_fatal: true
@@ -142,7 +142,7 @@
 
 - name: "(3/4) UPDATE: Primary"
   hosts: primary
-  gather_facts: false
+  gather_facts: true
   become: true
   become_method: sudo
   any_errors_fatal: true
@@ -203,7 +203,7 @@
 
 - name: "(4/4) POST-UPDATE: Update extensions"
   hosts: postgres_cluster
-  gather_facts: false
+  gather_facts: true
   become: true
   become_user: postgres
   any_errors_fatal: true


### PR DESCRIPTION
Related issue: https://github.com/vitabaks/postgresql_cluster/issues/644

This task updates the pgBackRest package on the backup server (Dedicated Repository Host) before updating the Postgres cluster hosts.
It runs only if the 'pgbackrest' group is defined in the inventory and the update target is set to 'system'.