### PR TITLE
Not ansible_check_mode for ssh_keys

### DIFF
--- a/roles/pgbackrest/tasks/main.yml
+++ b/roles/pgbackrest/tasks/main.yml
@@ -174,8 +174,10 @@
 
 # if 'pgbackrest_repo_host' or 'backup-standby' are specified
 - ansible.builtin.import_tasks: ssh_keys.yml
-  when: (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
-        (pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y')
+  when: 
+    - (pgbackrest_repo_host is defined and pgbackrest_repo_host | length > 0) or
+      (pgbackrest_conf.global | selectattr('option', 'equalto', 'backup-standby') | map(attribute='value') | list | last | default('') == 'y')
+    - not ansible_check_mode
   tags: pgbackrest, pgbackrest_ssh_keys
 
 - ansible.builtin.import_tasks: cron.yml


### PR DESCRIPTION
This PR is intended to fix an error in the check-diff pipeline of GitLabs when pgbackrest with the posix type is configured, since key exchange between servers cannot be performed during check-diff.