### PR TITLE
Molecule: Avoid requests 2.32.0 during testing

### DIFF
--- a/.config/python/dev/requirements.txt
+++ b/.config/python/dev/requirements.txt
@@ -1,3 +1,4 @@
+requests==2.31.0
 docker==6.1.3
 molecule==6.0.3
 molecule-plugins==23.5.3


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/662

requests 2.32 is incompatible with vendored versions of docker-py from inside community.docker collection. 

Related: 
- https://github.com/ansible/molecule/pull/4185
- https://github.com/docker/docker-py/issues/3256