### PR TITLE
Replacing restart pgbouncer with reload pgbouncer

### DIFF
--- a/roles/pgbouncer/config/tasks/main.yml
+++ b/roles/pgbouncer/config/tasks/main.yml
@@ -19,7 +19,7 @@
   loop_control:
     index_var: idx
     label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
-  notify: "restart pgbouncer"
+  notify: "reload pgbouncer"
   when: existing_pgcluster is not defined or not existing_pgcluster|bool
   tags: pgbouncer, pgbouncer_conf
 

--- a/roles/pgbouncer/tasks/main.yml
+++ b/roles/pgbouncer/tasks/main.yml
@@ -133,7 +133,7 @@
   loop_control:
     index_var: idx
     label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
-  notify: "restart pgbouncer"
+  notify: "reload pgbouncer"
   when: existing_pgcluster is not defined or not existing_pgcluster|bool
   tags: pgbouncer_conf, pgbouncer
 
@@ -225,7 +225,7 @@
       loop_control:
         index_var: idx
         label: "{{ 'pgbouncer' if idx == 0 else 'pgbouncer-%d' % (idx + 1) }}"
-      notify: "restart pgbouncer"
+      notify: "reload pgbouncer"
       when: pgbouncer_listen_addr != "0.0.0.0"
   when: existing_pgcluster is defined and existing_pgcluster|bool
   tags: pgbouncer_conf, pgbouncer


### PR DESCRIPTION
Replacing restart pgbouncer with reload pgbouncer, in tasks for changing pgbouncer.ini, since when changing the configuration file, restarting pgbouncer is not required.