### PR TITLE
Make keepalived role more configurable (issue #683)

### DIFF
--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -12,4 +12,4 @@ keepalived_instances:
       auth_type: PASS
       auth_pass: "1ce24b6e"
     virtual_ipaddresses:
-      - "{{ cluster_vip  }}"
+      - "{{ cluster_vip }}"

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+keepalived_instances:
+  - name: VI_1
+    state: BACKUP
+    interface: "{{ vip_interface }}"
+    virtual_router_id: "{{ keepalived_virtual_router_id | default(123) }}"
+    priority: 100
+    advert_int: 2
+    check_status_command: /usr/libexec/keepalived/haproxy_check.sh
+    authentication:
+      auth_type: PASS
+      auth_pass: "1ce24b6e"
+    virtual_ipaddresses:
+      - "{{ cluster_vip  }}"

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -27,7 +27,7 @@
           ansible_ssh_port | default(22)
         )
       }}
-  ignore_errors: true  # show the error and continue the playbook execution
+  ignore_errors: true  # noqa ignore-errors # show the error and continue the playbook execution
   listen: "restart keepalived"
 
 ...

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -99,7 +99,7 @@
         line: "{{ item.line }}"
         backrefs: true
       loop:
-        - {regexp: '^.*interface', line: '   interface {{ vip_interface }}'}
+        - { regexp: '^.*interface', line: '   interface {{ vip_interface }}' }
       loop_control:
         label: "{{ item.line }}"
       notify: "restart keepalived"

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -43,12 +43,6 @@
   notify: "restart keepalived"
   tags: keepalived_conf, keepalived
 
-- name: Parse keepalived_instances as YAML
-  ansible.builtin.set_fact:
-    keepalived_instances_parsed: "{{ keepalived_instances | from_yaml }}"
-  when: add_balancer is not defined or not add_balancer|bool
-  tags: keepalived_conf, keepalived
-
 - name: Generate conf file "/etc/keepalived/keepalived.conf"
   ansible.builtin.template:
     src: templates/keepalived.conf.j2
@@ -57,8 +51,6 @@
     group: root
     mode: "0644"
   notify: "restart keepalived"
-  vars:
-    keepalived_instances: "{{ keepalived_instances_parsed }}"
   when: add_balancer is not defined or not add_balancer|bool
   tags: keepalived_conf, keepalived
 

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -62,10 +62,7 @@
   when: add_balancer is not defined or not add_balancer|bool
   tags: keepalived_conf, keepalived
 
-- name: Generate conf file "/etc/keepalived/keepalived.conf" for add_balancer
-  when: add_balancer is defined and add_balancer|bool
-  tags: keepalived_conf, keepalived
-  block:  # for add_balancer.yml
+- block:  # for add_balancer.yml
     - name: "Fetch keepalived.conf conf file from {{ groups.balancers[0] }}"
       run_once: true
       ansible.builtin.fetch:
@@ -79,9 +76,6 @@
       ansible.builtin.copy:
         src: files/keepalived.conf
         dest: /etc/keepalived/keepalived.conf
-        owner: root
-        group: root
-        mode: "0750"
       notify: "restart keepalived"
 
     - name: Remove keepalived.conf file from localhost
@@ -103,6 +97,8 @@
       loop_control:
         label: "{{ item.line }}"
       notify: "restart keepalived"
+  when: add_balancer is defined and add_balancer|bool
+  tags: keepalived_conf, keepalived
 
 - name: Selinux | Change the keepalived_t domain to permissive
   community.general.selinux_permissive:

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -28,6 +28,7 @@
     state: directory
     owner: root
     group: root
+    mode: "0750"
   tags: keepalived_conf, keepalived
 
 - name: Create vrrp_script "/usr/libexec/keepalived/haproxy_check.sh"
@@ -42,15 +43,29 @@
   notify: "restart keepalived"
   tags: keepalived_conf, keepalived
 
+- name: Parse keepalived_instances as YAML
+  ansible.builtin.set_fact:
+    keepalived_instances_parsed: "{{ keepalived_instances | from_yaml }}"
+  when: add_balancer is not defined or not add_balancer|bool
+  tags: keepalived_conf, keepalived
+
 - name: Generate conf file "/etc/keepalived/keepalived.conf"
   ansible.builtin.template:
     src: templates/keepalived.conf.j2
     dest: /etc/keepalived/keepalived.conf
+    owner: root
+    group: root
+    mode: "0644"
   notify: "restart keepalived"
+  vars:
+    keepalived_instances: "{{ keepalived_instances_parsed }}"
   when: add_balancer is not defined or not add_balancer|bool
   tags: keepalived_conf, keepalived
 
-- block:  # for add_balancer.yml
+- name: Generate conf file "/etc/keepalived/keepalived.conf" for add_balancer
+  when: add_balancer is defined and add_balancer|bool
+  tags: keepalived_conf, keepalived
+  block:  # for add_balancer.yml
     - name: "Fetch keepalived.conf conf file from {{ groups.balancers[0] }}"
       run_once: true
       ansible.builtin.fetch:
@@ -64,6 +79,9 @@
       ansible.builtin.copy:
         src: files/keepalived.conf
         dest: /etc/keepalived/keepalived.conf
+        owner: root
+        group: root
+        mode: "0750"
       notify: "restart keepalived"
 
     - name: Remove keepalived.conf file from localhost
@@ -81,20 +99,18 @@
         line: "{{ item.line }}"
         backrefs: true
       loop:
-        - { regexp: '^.*interface', line: '   interface {{ vip_interface }}' }
+        - {regexp: '^.*interface', line: '   interface {{ vip_interface }}'}
       loop_control:
         label: "{{ item.line }}"
       notify: "restart keepalived"
-  when: add_balancer is defined and add_balancer|bool
-  tags: keepalived_conf, keepalived
 
-- name: selinux | change the keepalived_t domain to permissive
+- name: Selinux | Change the keepalived_t domain to permissive
   community.general.selinux_permissive:
     name: keepalived_t
     permissive: true
   when: ansible_selinux.status is defined and
         ansible_selinux.status == 'enabled'
-  ignore_errors: true
+  ignore_errors: true  # noqa ignore-errors
   tags: keepalived, keepalived_selinux
 
 ...

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -6,9 +6,8 @@ global_defs {
 
 {% for instance in keepalived_instances %}
 {% if instance.check_status_command is defined %}
-
 vrrp_script chk_command_{{ instance.virtual_router_id }} {
-   script "{{ instance.check_status_command }} "
+   script "{{ instance.check_status_command }}"
    interval 2
    weight 2
 }
@@ -21,15 +20,15 @@ vrrp_instance {{ instance.name }} {
   advert_int {{ instance.advert_int }}
   state {{ instance.state }}
   virtual_ipaddress {
-  {% for ip in instance.virtual_ipaddresses %}
-  {{ ip }}
-{% endfor %}
+    {% for ip in instance.virtual_ipaddresses %}
+    {{ ip }}
+    {% endfor %}
   }
-{% if instance.check_status_command is defined %}
+  {% if instance.check_status_command is defined %}
   track_script {
     chk_command_{{ instance.virtual_router_id }}
-}
-{% endif %}
+  }
+  {% endif %}
   authentication {
     auth_type {{ instance.authentication.auth_type }}
     auth_pass {{ instance.authentication.auth_pass }}

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -3,27 +3,36 @@ global_defs {
    enable_script_security
    script_user root
 }
- 
-vrrp_script haproxy_check {
-   script "/usr/libexec/keepalived/haproxy_check.sh"
+
+{% for instance in keepalived_instances %}
+{% if instance.check_status_command is defined %}
+
+vrrp_script chk_command_{{ instance.virtual_router_id }} {
+   script "{{ instance.check_status_command }} "
    interval 2
    weight 2
 }
- 
-vrrp_instance VI_1 {
-   interface {{ vip_interface }}
-   virtual_router_id {{ keepalived_virtual_router_id | default(123) }}
-   priority  100
-   advert_int 2
-   state  BACKUP
-   virtual_ipaddress {
-       {{ cluster_vip  }}
-   }
-   track_script {
-       haproxy_check
-   }
-   authentication {
-      auth_type PASS
-      auth_pass 1ce24b6e
-   }
+{% endif %}
+
+vrrp_instance {{ instance.name }} {
+  interface {{ instance.interface }}
+  virtual_router_id {{ instance.virtual_router_id }}
+  priority {{ instance.priority }}
+  advert_int {{ instance.advert_int }}
+  state {{ instance.state }}
+  virtual_ipaddress {
+  {% for ip in instance.virtual_ipaddresses %}
+  {{ ip }}
+{% endfor %}
+  }
+{% if instance.check_status_command is defined %}
+  track_script {
+    chk_command_{{ instance.virtual_router_id }}
 }
+{% endif %}
+  authentication {
+    auth_type {{ instance.authentication.auth_type }}
+    auth_pass {{ instance.authentication.auth_pass }}
+  }
+}
+{% endfor %}


### PR DESCRIPTION
Issue reference: #683 

This change shouldn't affect the working environment, so, by default, the keepalived configuration remains the same. These fixes make the keepalived role configurable. They also update the configuration to comply with modern Ansible linters.