### PR TITLE
confd: haproxy: optional log-format

### DIFF
--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -12,6 +12,10 @@ global
 defaults
     mode               tcp
     log                global
+    option             tcplog
+{% if haproxy_log_format is defined %}
+    log-format         '{{ haproxy_log_format }}'
+{% endif %}
     retries            2
     timeout queue      5s
     timeout connect    5s
@@ -32,7 +36,6 @@ listen master
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.master }}
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
-    option tcplog
     option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
@@ -53,7 +56,6 @@ listen master_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.master_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
-    option tcplog
     option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
@@ -68,7 +70,6 @@ listen replicas
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -94,7 +95,6 @@ listen replicas_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -114,7 +114,6 @@ listen replicas_sync
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /sync{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -140,7 +139,6 @@ listen replicas_sync_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_sync_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /sync{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -160,7 +158,6 @@ listen replicas_async
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_async }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -186,7 +183,6 @@ listen replicas_async_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_async_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -12,6 +12,10 @@ global
 defaults
     mode               tcp
     log                global
+    option             tcplog
+{% if haproxy_log_format is defined %}
+    log-format         '{{ haproxy_log_format }}'
+{% endif %}
     retries            2
     timeout queue      5s
     timeout connect    5s
@@ -32,7 +36,6 @@ listen master
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.master }}
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
-    option tcplog
     option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
@@ -55,7 +58,6 @@ listen master_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.master_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.master }}
-    option tcplog
     option httpchk OPTIONS /primary
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
@@ -71,7 +73,6 @@ listen replicas
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -99,7 +100,6 @@ listen replicas_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /replica?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -120,7 +120,6 @@ listen replicas_sync
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /sync{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -148,7 +147,6 @@ listen replicas_sync_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_sync_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /sync{{ '?' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -169,7 +167,6 @@ listen replicas_async
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_async }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}
@@ -197,7 +194,6 @@ listen replicas_async_direct
     bind {{ inventory_hostname }}:{{ haproxy_listen_port.replicas_async_direct }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
-    option tcplog
     {% if balancer_tags | default('') | length > 0 %}
     option httpchk OPTIONS /async?lag={{ patroni_maximum_lag_on_replica }}{{ '&' + balancer_tags.split(',') | map('trim') | map('regex_replace', '([^=]+)=(.*)', 'tag_\\1=\\2') | join('&') }}
     {% else %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,7 +46,7 @@ haproxy_timeout:
   client: "60m"
   server: "60m"
 # Optionally declare log format for haproxy.
-# Uncommend following lines for JSON structured log format.
+# Uncomment following lines for JSON structured log format.
 # haproxy_log_format: "{
 #   \"pid\":%pid,\
 #   \"haproxy_frontend_type\":\"tcp\",\

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -45,6 +45,35 @@ haproxy_maxconn:
 haproxy_timeout:
   client: "60m"
   server: "60m"
+# Optionally declare log format for haproxy.
+# Uncommend following lines for JSON structured log format.
+# haproxy_log_format: "{
+#   \"pid\":%pid,\
+#   \"haproxy_frontend_type\":\"tcp\",\
+#   \"haproxy_process_concurrent_connections\":%ac,\
+#   \"haproxy_frontend_concurrent_connections\":%fc,\
+#   \"haproxy_backend_concurrent_connections\":%bc,\
+#   \"haproxy_server_concurrent_connections\":%sc,\
+#   \"haproxy_backend_queue\":%bq,\
+#   \"haproxy_server_queue\":%sq,\
+#   \"haproxy_queue_wait_time\":%Tw,\
+#   \"haproxy_server_wait_time\":%Tc,\
+#   \"response_time\":%Td,\
+#   \"session_duration\":%Tt,\
+#   \"request_termination_state\":\"%tsc\",\
+#   \"haproxy_server_connection_retries\":%rc,\
+#   \"remote_addr\":\"%ci\",\
+#   \"remote_port\":%cp,\
+#   \"frontend_addr\":\"%fi\",\
+#   \"frontend_port\":%fp,\
+#   \"frontend_ssl_version\":\"%sslv\",\
+#   \"frontend_ssl_ciphers\":\"%sslc\",\
+#   \"haproxy_frontend_name\":\"%f\",\
+#   \"haproxy_backend_name\":\"%b\",\
+#   \"haproxy_server_name\":\"%s\",\
+#   \"response_size\":%B,\
+#   \"request_size\":%U\
+#   }"
 
 # keepalived (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'true')
 keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last octet of 'cluster_vip' IP address is used by default.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,8 +46,8 @@ haproxy_timeout:
   client: "60m"
   server: "60m"
 # Optionally declare log format for haproxy.
-# Uncomment following lines for JSON structured log format.
-#haproxy_log_format: "{
+# Uncomment following lines (and remove extra space in front of variable definition) for JSON structured log format.
+# haproxy_log_format: "{
 #  \"pid\":%pid,\
 #  \"haproxy_frontend_type\":\"tcp\",\
 #  \"haproxy_process_concurrent_connections\":%ac,\

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -47,33 +47,33 @@ haproxy_timeout:
   server: "60m"
 # Optionally declare log format for haproxy.
 # Uncomment following lines for JSON structured log format.
-# haproxy_log_format: "{
-#   \"pid\":%pid,\
-#   \"haproxy_frontend_type\":\"tcp\",\
-#   \"haproxy_process_concurrent_connections\":%ac,\
-#   \"haproxy_frontend_concurrent_connections\":%fc,\
-#   \"haproxy_backend_concurrent_connections\":%bc,\
-#   \"haproxy_server_concurrent_connections\":%sc,\
-#   \"haproxy_backend_queue\":%bq,\
-#   \"haproxy_server_queue\":%sq,\
-#   \"haproxy_queue_wait_time\":%Tw,\
-#   \"haproxy_server_wait_time\":%Tc,\
-#   \"response_time\":%Td,\
-#   \"session_duration\":%Tt,\
-#   \"request_termination_state\":\"%tsc\",\
-#   \"haproxy_server_connection_retries\":%rc,\
-#   \"remote_addr\":\"%ci\",\
-#   \"remote_port\":%cp,\
-#   \"frontend_addr\":\"%fi\",\
-#   \"frontend_port\":%fp,\
-#   \"frontend_ssl_version\":\"%sslv\",\
-#   \"frontend_ssl_ciphers\":\"%sslc\",\
-#   \"haproxy_frontend_name\":\"%f\",\
-#   \"haproxy_backend_name\":\"%b\",\
-#   \"haproxy_server_name\":\"%s\",\
-#   \"response_size\":%B,\
-#   \"request_size\":%U\
-#   }"
+#haproxy_log_format: "{
+#  \"pid\":%pid,\
+#  \"haproxy_frontend_type\":\"tcp\",\
+#  \"haproxy_process_concurrent_connections\":%ac,\
+#  \"haproxy_frontend_concurrent_connections\":%fc,\
+#  \"haproxy_backend_concurrent_connections\":%bc,\
+#  \"haproxy_server_concurrent_connections\":%sc,\
+#  \"haproxy_backend_queue\":%bq,\
+#  \"haproxy_server_queue\":%sq,\
+#  \"haproxy_queue_wait_time\":%Tw,\
+#  \"haproxy_server_wait_time\":%Tc,\
+#  \"response_time\":%Td,\
+#  \"session_duration\":%Tt,\
+#  \"request_termination_state\":\"%tsc\",\
+#  \"haproxy_server_connection_retries\":%rc,\
+#  \"remote_addr\":\"%ci\",\
+#  \"remote_port\":%cp,\
+#  \"frontend_addr\":\"%fi\",\
+#  \"frontend_port\":%fp,\
+#  \"frontend_ssl_version\":\"%sslv\",\
+#  \"frontend_ssl_ciphers\":\"%sslc\",\
+#  \"haproxy_frontend_name\":\"%f\",\
+#  \"haproxy_backend_name\":\"%b\",\
+#  \"haproxy_server_name\":\"%s\",\
+#  \"response_size\":%B,\
+#  \"request_size\":%U\
+#  }"
 
 # keepalived (if 'cluster_vip' is specified and 'with_haproxy_load_balancing' is 'true')
 keepalived_virtual_router_id: "{{ cluster_vip.split('.')[3] | int }}" # The last octet of 'cluster_vip' IP address is used by default.


### PR DESCRIPTION
New optional var for haproxy log-format. Supplied with an example of JSON structured log format (commented out by default).