### PR TITLE
Update WAL-G to v3.0.2

### DIFF
--- a/roles/wal-g/tasks/main.yml
+++ b/roles/wal-g/tasks/main.yml
@@ -132,6 +132,13 @@
         version: v{{ wal_g_version }}
         dest: /tmp/wal-g
 
+    - name: Run go mod tidy to ensure dependencies are correct
+      ansible.builtin.command: go mod tidy
+      args:
+        chdir: /tmp/wal-g
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
+
     - name: Build WAL-G deps
       become: true
       become_user: root

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -490,7 +490,7 @@ pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts |
 
 # WAL-G
 wal_g_install: false  # or 'true'
-wal_g_version: "3.0.0"
+wal_g_version: "3.0.2"
 wal_g_path: "/usr/local/bin/wal-g"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
   - { option: "AWS_ACCESS_KEY_ID", value: "{{ AWS_ACCESS_KEY_ID | default('') }}" }  # define values or pass via --extra-vars


### PR DESCRIPTION
Update WAL-G to v3.0.2 - https://github.com/wal-g/wal-g/releases

Additionally:
- Run `go mod tidy` before building to ensure dependencies are correct