### PR TITLE
pgBackRest: Add '--no-online' option to stanza-create

### DIFF
--- a/roles/pgbackrest/stanza-create/tasks/main.yml
+++ b/roles/pgbackrest/stanza-create/tasks/main.yml
@@ -55,7 +55,7 @@
       become_user: "{{ pgbackrest_repo_user }}"
       delegate_to: "{{ groups['pgbackrest'][0] }}"
       run_once: true
-      ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} stanza-create"
+      ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-create"
       register: stanza_create_result
       changed_when:
         - stanza_create_result.rc == 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -612,7 +612,7 @@ pgbackrest_cron_jobs:
     day: "*"
     month: "*"
     weekday: "0"
-    job: "pgbackrest --type=full --stanza={{ pgbackrest_stanza }} backup"
+    job: "pgbackrest --stanza={{ pgbackrest_stanza }} --type=full backup"
     # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --type=full --stanza={{ pgbackrest_stanza }} backup; fi"
   - name: "pgBackRest: Diff Backup"
     file: "/etc/cron.d/pgbackrest-{{ patroni_cluster_name }}"
@@ -622,7 +622,7 @@ pgbackrest_cron_jobs:
     day: "*"
     month: "*"
     weekday: "1-6"
-    job: "pgbackrest --type=diff --stanza={{ pgbackrest_stanza }} backup"
+    job: "pgbackrest --stanza={{ pgbackrest_stanza }} --type=diff backup"
     # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --type=diff --stanza={{ pgbackrest_stanza }} backup; fi"
 
 


### PR DESCRIPTION
Add '--no-online' option to stanza-create to be able to configure on a Standby cluster.

Fixed:

```
TASK [pgbackrest/stanza-create : Create stanza "postgres-cluster"] ****************************************************************************************************************************************
fatal: [***.***.**.*** -> ***.***.**.***]: FAILED! => {"changed": false, "cmd": ["pgbackrest", "--stanza=postgres-cluster", "stanza-create"], "delta": "0:00:03.904155", "end": "2024-07-12 15:12:37.167039", "msg": "non-zero return code", "rc": 56, "start": "2024-07-12 15:12:33.262884", "stderr": "WARN: configuration file contains invalid option 'include-path'\nERROR: [056]: unable to find primary cluster - cannot proceed\n       HINT: are all available clusters in recovery?", "stderr_lines": ["WARN: configuration file contains invalid option 'include-path'", "ERROR: [056]: unable to find primary cluster - cannot proceed", "       HINT: are all available clusters in recovery?"], "stdout": "2024-07-12 15:12:33.276 P00   INFO: stanza-create command begin 2.52.1: --exec-id=148878-6af21ca1 --log-level-console=info --log-level-file=detail --log-path=/var/log/pgbackrest --pg1-host=***.***.**.*** --pg2-host=216.223.147.100 --pg3-host=216.223.147.228 --pg1-path=/var/lib/postgresql/14/main --pg2-path=/var/lib/postgresql/14/main --pg3-path=/var/lib/postgresql/14/main --pg1-port=5432 --pg2-port=5432 --pg3-port=5432 --pg1-socket-path=/var/run/postgresql --pg2-socket-path=/var/run/postgresql --pg3-socket-path=/var/run/postgresql --repo1-path=/data/service/pgbackrest --repo1-type=posix --stanza=postgres-cluster\n2024-07-12 15:12:36.858 P00   INFO: stanza-create command end: aborted with exception [056]", "stdout_lines": ["2024-07-12 15:12:33.276 P00   INFO: stanza-create command begin 2.52.1: --exec-id=148878-6af21ca1 --log-level-console=info --log-level-file=detail --log-path=/var/log/pgbackrest --pg1-host=***.***.**.*** --pg2-host=216.223.147.100 --pg3-host=216.223.147.228 --pg1-path=/var/lib/postgresql/14/main --pg2-path=/var/lib/postgresql/14/main --pg3-path=/var/lib/postgresql/14/main --pg1-port=5432 --pg2-port=5432 --pg3-port=5432 --pg1-socket-path=/var/run/postgresql --pg2-socket-path=/var/run/postgresql --pg3-socket-path=/var/run/postgresql --repo1-path=/data/service/pgbackrest --repo1-type=posix --stanza=postgres-cluster", "2024-07-12 15:12:36.858 P00   INFO: stanza-create command end: aborted with exception [056]"]}
```