### PR TITLE
Fix (Upgrade): Update pg-path in local pgbackrest.conf

### DIFF
--- a/roles/upgrade/tasks/post_upgrade.yml
+++ b/roles/upgrade/tasks/post_upgrade.yml
@@ -96,24 +96,24 @@
 # pgBackRest (local)
 - block:
     - name: pgbackrest | Check pg-path option
-      ansible.builtin.command: "grep -c '^pg.*-path=' {{ pgbackrest_conf_file }}"
+      ansible.builtin.command: "grep -c '^pg[0-9]*-path=' {{ pgbackrest_conf_file }}"
       register: pg_path_count
       changed_when: false
 
     - name: pgbackrest | Update pg-path in pgbackrest.conf
-      ansible.builtin.lineinfile:
+      ansible.builtin.replace:
         path: "{{ pgbackrest_conf_file }}"
-        regexp: '^pg{{ idx + 1 }}-path='
-        line: 'pg{{ idx + 1 }}-path={{ pg_new_datadir }}'
+        regexp: '^pg{{ idx + 1 }}-path=.*$'
+        replace: 'pg{{ idx + 1 }}-path={{ pg_new_datadir }}'
       loop: "{{ range(0, pg_path_count.stdout | int) | list }}"
       loop_control:
         index_var: idx
         label: "pg{{ idx + 1 }}-path={{ pg_new_datadir }}"
-      when: pg_path_count.stdout | length > 0
+      when: pg_path_count.stdout | int > 0
 
     - name: pgbackrest | Upgrade stanza "{{ pgbackrest_stanza }}"
       ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-upgrade"
-      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool and pgbackrest_repo_host | length < 1
+      when: pg_path_count.stdout | int > 0 and pgbackrest_stanza_upgrade | bool and pgbackrest_repo_host | length < 1
   become: true
   become_user: postgres
   ignore_errors: true  # show the error and continue the playbook execution
@@ -125,28 +125,28 @@
     - name: pgbackrest | Check pg-path option
       delegate_to: "{{ groups['pgbackrest'][0] }}"
       run_once: true
-      ansible.builtin.command: "grep -c '^pg.*-path=' {{ pgbackrest_conf_file | dirname }}/conf.d/{{ pgbackrest_stanza }}.conf"
+      ansible.builtin.command: "grep -c '^pg[0-9]*-path=' {{ pgbackrest_conf_file | dirname }}/conf.d/{{ pgbackrest_stanza }}.conf"
       register: pg_path_count
       changed_when: false
 
     - name: pgbackrest | Update pg-path in pgbackrest.conf
       delegate_to: "{{ groups['pgbackrest'][0] }}"
       run_once: true
-      ansible.builtin.lineinfile:
+      ansible.builtin.replace:
         path: "{{ pgbackrest_conf_file | dirname }}/conf.d/{{ pgbackrest_stanza }}.conf"
-        regexp: '^pg{{ idx + 1 }}-path='
-        line: 'pg{{ idx + 1 }}-path={{ pg_new_datadir }}'
+        regexp: '^pg{{ idx + 1 }}-path=.*$'
+        replace: 'pg{{ idx + 1 }}-path={{ pg_new_datadir }}'
       loop: "{{ range(0, pg_path_count.stdout | int) | list }}"
       loop_control:
         index_var: idx
         label: "pg{{ idx + 1 }}-path={{ pg_new_datadir }}"
-      when: pg_path_count.stdout | length > 0
+      when: pg_path_count.stdout | int > 0
 
     - name: pgbackrest | Upgrade stanza "{{ pgbackrest_stanza }}"
       delegate_to: "{{ groups['pgbackrest'][0] }}"
       run_once: true
       ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-upgrade"
-      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
+      when: pg_path_count.stdout | int > 0 and pgbackrest_stanza_upgrade | bool
   become: true
   become_user: "{{ pgbackrest_repo_user }}"
   ignore_errors: true  # show the error and continue the playbook execution

--- a/roles/upgrade/tasks/post_upgrade.yml
+++ b/roles/upgrade/tasks/post_upgrade.yml
@@ -113,13 +113,12 @@
 
     - name: pgbackrest | Upgrade stanza "{{ pgbackrest_stanza }}"
       ansible.builtin.command: "pgbackrest --stanza={{ pgbackrest_stanza }} --no-online stanza-upgrade"
-      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool
+      when: pg_path_count.stdout | length > 0 and pgbackrest_stanza_upgrade | bool and pgbackrest_repo_host | length < 1
   become: true
   become_user: postgres
   ignore_errors: true  # show the error and continue the playbook execution
   when:
     - pgbackrest_install | bool
-    - pgbackrest_repo_host | length < 1
 
 # pgBackRest (dedicated)
 - block:


### PR DESCRIPTION
1. Update pg-path in local pgbackrest.conf
    - The conditions of the task block were incorrect, which is why the local configuration file was not updated. \
 As a result, we encountered errors archiving WAL and backing up to a dedicated pgBackRest server because the new version of Postgres was indicated there while the old version was still in the local configuration.\
This fix ensures that the `pg-path` option will be updated on both the dedicated server and the local database servers.

2. Update the `grep` command and use the `replace` module.
    - Make the code more reliable by using the `replace` module instead of `lineinfile`, which will prevent adding new lines instead of changing the content. Also, change the conditions of the `grep` command to look for a more accurate match for the `pgN-path` option.