### PR TITLE
ssh-keys: Fix the typo in the condition

### DIFF
--- a/roles/ssh-keys/tasks/main.yml
+++ b/roles/ssh-keys/tasks/main.yml
@@ -47,7 +47,7 @@
       loop: "{{ ssh_known_host_results.results }}"
   ignore_errors: true
   when:
-    - anable_ssh_key_based_authentication is defined
+    - enable_ssh_key_based_authentication is defined
     - enable_ssh_key_based_authentication | bool
     - not ansible_check_mode
   tags: ssh_keys


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/672