### PR TITLE
Fix issue with jija2 template interpolation 

### DIFF
--- a/roles/patroni/templates/patroni.yml.j2
+++ b/roles/patroni/templates/patroni.yml.j2
@@ -90,7 +90,7 @@ bootstrap:
       use_slots: true
       parameters:
       {% for parameter in postgresql_parameters %}
-        {{ parameter.option }}: {{ parameter.value }}
+        {{ parameter.option }}: "{{ parameter.value }}"
       {% endfor %}
     {% if patroni_standby_cluster.host is defined and patroni_standby_cluster.host | length > 0 %}
     standby_cluster:


### PR DESCRIPTION
Avoid problem when jinja2 treats value 'on' as True. In result in pg config will be value True. 

```
patroni[17197]: 2024-08-02 10:09:16,815 INFO: Changed archive_mode from 'on' to 'True' (restart might be required)
patroni[17197]: 2024-08-02 10:09:16,817 INFO: Changed synchronous_commit from 'on' to 'True'
patroni[17197]: 2024-08-02 10:09:16,818 INFO: Changed tcp_keepalives_count from '0' to '10'
patroni[17197]: 2024-08-02 10:09:16,818 INFO: Changed tcp_keepalives_idle from '0' to '300'
patroni[17197]: 2024-08-02 10:09:16,818 INFO: Changed tcp_keepalives_interval from '0' to '30'
patroni[17197]: 2024-08-02 10:09:16,818 INFO: Changed wal_compression from 'pglz' to 'True'
```
