### PR TITLE
Update WAL-G to v3.0.3

### DIFF
--- a/roles/wal-g/tasks/main.yml
+++ b/roles/wal-g/tasks/main.yml
@@ -42,7 +42,7 @@
     - name: Copy WAL-G binary file to /usr/local/bin/
       ansible.builtin.copy:
         src: "/tmp/wal-g-pg-ubuntu-{{ ansible_distribution_version }}-amd64"
-        dest: "{{ wal_g_path }}"
+        dest: "{{ wal_g_path.split(' ')[0] }}"  # use split to get only the path without options
         mode: u+x,g+x,o+x
         remote_src: true
   when:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -490,7 +490,7 @@ pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts |
 
 # WAL-G
 wal_g_install: false  # or 'true'
-wal_g_version: "3.0.2"
+wal_g_version: "3.0.3"
 wal_g_path: "/usr/local/bin/wal-g --config {{ postgresql_home_dir }}/.walg.json"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration
   - { option: "AWS_ACCESS_KEY_ID", value: "{{ AWS_ACCESS_KEY_ID | default('') }}" }  # define values or pass via --extra-vars

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -489,7 +489,7 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: true  # or 'true'
+wal_g_install: false  # or 'true'
 wal_g_version: "3.0.3"
 wal_g_path: "/usr/local/bin/wal-g --config {{ postgresql_home_dir }}/.walg.json"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -489,7 +489,7 @@ pg_probackup_restore_command: "{{ pg_probackup_command_parts | join('') }}"
 pg_probackup_patroni_cluster_bootstrap_command: "{{ pg_probackup_command_parts | join('') }}"
 
 # WAL-G
-wal_g_install: false  # or 'true'
+wal_g_install: true  # or 'true'
 wal_g_version: "3.0.3"
 wal_g_path: "/usr/local/bin/wal-g --config {{ postgresql_home_dir }}/.walg.json"
 wal_g_json:  # config https://github.com/wal-g/wal-g#configuration


### PR DESCRIPTION
https://github.com/wal-g/wal-g/releases/tag/v3.0.3

- Update WAL-G to v3.0.3
- Use `split` to get only the path without options when installing a binary file