### PR TITLE
Added default `ansible_python_interpreter`; Compatibility with Ansible 10

### DIFF
--- a/add_balancer.yml
+++ b/add_balancer.yml
@@ -6,12 +6,6 @@
   any_errors_fatal: true
   gather_facts: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/add_pgnode.yml
+++ b/add_pgnode.yml
@@ -9,12 +9,6 @@
     - ansible.builtin.import_tasks: roles/patroni/handlers/main.yml
 
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/balancers.yml
+++ b/balancers.yml
@@ -9,12 +9,6 @@
     vip_manager_disable: false # or 'true' for disable vip-manager service (if installed)
 
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/config_pgcluster.yml
+++ b/config_pgcluster.yml
@@ -3,12 +3,6 @@
   hosts: postgres_cluster
   gather_facts: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
 

--- a/consul.yml
+++ b/consul.yml
@@ -8,12 +8,6 @@
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/deploy_pgcluster.yml
+++ b/deploy_pgcluster.yml
@@ -10,12 +10,6 @@
   environment: "{{ proxy_env | default({}) }}"
 
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/etcd_cluster.yml
+++ b/etcd_cluster.yml
@@ -7,12 +7,6 @@
   gather_facts: true
 
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,3 +18,10 @@ os_minimum_versions:
   OracleLinux: 8
   Ubuntu: 22.04
   Debian: 11
+
+# Set correct interpreter for ansible-core
+# Since ansible-core 2.17 (ansible 10 on pypi), ansible_python_interpreter wouldn't accept arguments anymore
+# See:
+# - https://github.com/ansible/ansible/issues/83476
+# - https://github.com/ansible/ansible/issues/83603
+ansible_python_interpreter: "{{ ansible_version['full'] is version('2.17', '>=') | ternary('/usr/bin/python3', '/usr/bin/env python3') }}"

--- a/inventory
+++ b/inventory
@@ -56,7 +56,7 @@ ansible_ssh_port='22'
 ansible_user='root'
 ansible_ssh_pass='secretpassword'  # "sshpass" package is required for use "ansible_ssh_pass"
 #ansible_ssh_private_key_file=
-ansible_python_interpreter='/usr/bin/env python3'
+#ansible_python_interpreter='/usr/bin/env python3'
 
 [pgbackrest:vars]
 #ansible_user='postgres'

--- a/pg_upgrade.yml
+++ b/pg_upgrade.yml
@@ -8,11 +8,6 @@
   become_user: postgres
   any_errors_fatal: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
 

--- a/pg_upgrade_rollback.yml
+++ b/pg_upgrade_rollback.yml
@@ -10,11 +10,6 @@
   gather_facts: true
   any_errors_fatal: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
     - name: Include upgrade variables

--- a/remove_cluster.yml
+++ b/remove_cluster.yml
@@ -3,11 +3,6 @@
   hosts: postgres_cluster
   become: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
     - name: Include OS-specific variables

--- a/update_pgcluster.yml
+++ b/update_pgcluster.yml
@@ -6,12 +6,6 @@
   become_method: sudo
   any_errors_fatal: true
   pre_tasks:
-    - name: "Set variable: ansible_python_interpreter"
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: "/usr/bin/env python3"
-      when: "'python3' not in (ansible_python_interpreter | default(''))"
-      tags: always
-
     - name: Include main variables
       ansible.builtin.include_vars: "vars/main.yml"
       tags: always


### PR DESCRIPTION
`ansible-core` >= 2.17 (ansible 10 on pypi) made `ansible_python_interpreter` only accept a path to an executable now, so specifying `ansible_python_interpreter` with arguments like `/usr/bin/env python3` will error with `/bin/sh: /usr/bin/env python3: No such file or directory`.

This PR set `ansible_python_interpreter` to `/usr/bin/python3` for `ansible-core` >= 2.17, and `/usr/bin/env python3` for `ansible-core` < 2.17 for backward compatibility.

See:
- https://github.com/ansible/ansible/issues/83476
- https://github.com/ansible/ansible/issues/83603

Fixes #728 