### PR TITLE
config_pgcluster: Create extensions after restarting Postgres

### DIFF
--- a/automation/config_pgcluster.yml
+++ b/automation/config_pgcluster.yml
@@ -202,9 +202,6 @@
     - role: postgresql-privs
       when: inventory_hostname in groups['primary']
 
-    - role: postgresql-extensions
-      when: inventory_hostname in groups['primary']
-
     - role: wal-g
       when: wal_g_install | bool
 
@@ -347,7 +344,7 @@
   tags:
     - patroni_conf
 
-- name: config_pgcluster.yml | PostgreSQL Cluster Info
+- name: config_pgcluster.yml | Configure PostgreSQL Cluster and info
   hosts: primary
   become: true
   become_method: sudo
@@ -366,5 +363,7 @@
       ansible.builtin.include_vars: "vars/{{ ansible_os_family }}.yml"
       tags: always
   roles:
+    - role: postgresql-extensions
+
     # finish (info)
     - role: deploy-finish


### PR DESCRIPTION
Previously, the role for creating extensions was executed before the restart, which could result in errors.

Example:

```
failed: [10.129.50.35] (item={'ext': 'pg_cron', 'db': 'postgres', 'schema': 'pg_catalog'}) => {"ansible_loop_var": "item", "changed": false, "item": {"db": "postgres", "ext": "pg_cron", "schema": "pg_catalog"}, "msg": "Management of PostgreSQL extension failed: pg_cron can only be loaded via shared_preload_libraries\nHINT:  Add pg_cron to the shared_preload_libraries configuration variable in ********ql.conf.\n"}
```

Now, extensions will be created after the restart. 

>[!note]
> If the [pending_restart](https://github.com/vitabaks/postgresql_cluster/blob/2.0.0/automation/vars/main.yml#L307) variable is set to `true`, the cluster will be restarted if required (e.g., when changing `shared_preload_libraries`).