### PR TITLE
Add pgvectorscale extension

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -62,7 +62,7 @@
         enable_pg_partman: true
         enable_citus: "{{ 'false' if ansible_distribution_version == '24.04' else 'true' }}"  # TODO Ubuntu 24.04
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
-        enable_pgvectorscale: "{{ 'false' if ansible_os_family != 'Debian' else 'true' }}" # only deb packages are available
+        enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -62,6 +62,7 @@
         enable_pg_partman: true
         enable_citus: "{{ 'false' if ansible_distribution_version == '24.04' else 'true' }}"  # TODO Ubuntu 24.04
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
+        enable_pgvectorscale: "{{ 'false' if ansible_os_family != 'Debian' else 'true' }}" # only deb packages are available
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -68,6 +68,7 @@
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.
         postgresql_extensions:
           - { ext: "vector", db: "postgres" }
+          - { ext: "vectorscale", db: "postgres" }
           - { ext: "pg_search", db: "postgres", schema: "paradedb" }
           - { ext: "pg_analytics", db: "postgres" }
         #  - { ext: "", db: "" }

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -62,7 +62,7 @@
         enable_pg_partman: true
         enable_citus: "{{ 'false' if ansible_distribution_version == '24.04' else 'true' }}"  # TODO Ubuntu 24.04
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
-        enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
+        enable_pgvectorscale: true # "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -62,7 +62,7 @@
         enable_pg_partman: true
         enable_citus: "{{ 'false' if ansible_distribution_version == '24.04' else 'true' }}"  # TODO Ubuntu 24.04
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
-        enable_pgvectorscale: true # "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
+        enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -280,6 +280,7 @@
   when:
     - enable_pgvectorscale | default(false) | bool
     - ansible_os_family == "Debian"
+    - ansible_distribution_release in ['bookworm', 'jammy', 'noble']
 
 # ParadeDB (pg_search, pg_analytics) - https://github.com/paradedb/paradedb
 # (if 'enable_paradedb' or 'enable_pg_search', 'enable_pg_analytics' is 'true')

--- a/automation/roles/packages/tasks/extensions.yml
+++ b/automation/roles/packages/tasks/extensions.yml
@@ -233,10 +233,53 @@
   retries: 3
   when:
     - (enable_pgvector | default(false)| bool) or
+      (enable_pgvectorscale | default(false) | bool) or
       (enable_paradedb | default(false) | bool)
     - (ansible_os_family == 'Debian' and pg_version | default(postgresql_version) | int >= 11) or
       (ansible_os_family == 'RedHat' and pg_version | default(postgresql_version) | int >= 12)
   tags: pgvector
+
+# pgvectorscale - https://github.com/timescale/pgvectorscale
+# (if 'enable_pgvectorscale' is 'true')
+- block:
+    - name: Looking up the latest version of pgvectorscale
+      ansible.builtin.set_fact:
+        pgvectorscale_version: >-
+          {{
+            (lookup('url', 'https://api.github.com/repos/timescale/pgvectorscale/releases/latest', split_lines=False)
+            | from_json).get('tag_name')
+            | replace('v', '')
+          }}
+      when: pgvectorscale_version | default('latest') == 'latest'
+
+    - name: Download pgvectorscale archive
+      ansible.builtin.get_url:
+        url: "{{ pgvectorscale_repo }}/{{ pgvectorscale_archive }}"
+        dest: "/tmp/{{ pgvectorscale_archive }}"
+        timeout: 60
+        validate_certs: false
+
+    - name: Extract pgvectorscale package
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ pgvectorscale_archive }}"
+        dest: "/tmp/"
+        remote_src: true
+
+    # Debian (only deb packages are available)
+    - name: "Install pgvectorscale v{{ pgvectorscale_version }} package"
+      ansible.builtin.apt:
+        deb: "/tmp/{{ pgvectorscale_package }}"
+      register: apt_status
+      until: apt_status is success
+      delay: 5
+      retries: 3
+  vars:
+    pgvectorscale_repo: "https://github.com/timescale/pgvectorscale/releases/download/{{ pgvectorscale_version }}"
+    pgvectorscale_archive: "pgvectorscale-{{ pgvectorscale_version }}-pg{{ pg_version | default(postgresql_version) }}-amd64.zip" # yamllint disable rule:line-length
+    pgvectorscale_package: "pgvectorscale-postgresql-{{ pg_version | default(postgresql_version) }}_{{ pgvectorscale_version }}-Linux_amd64.deb" # yamllint disable rule:line-length
+  when:
+    - enable_pgvectorscale | default(false) | bool
+    - ansible_os_family == "Debian"
 
 # ParadeDB (pg_search, pg_analytics) - https://github.com/paradedb/paradedb
 # (if 'enable_paradedb' or 'enable_pg_search', 'enable_pg_analytics' is 'true')

--- a/automation/roles/pre-checks/tasks/extensions.yml
+++ b/automation/roles/pre-checks/tasks/extensions.yml
@@ -13,6 +13,26 @@
     - (enable_timescale | default(false) | bool) or (enable_timescaledb | default(false) | bool)
     - postgresql_version | string is version(timescale_minimal_pg_version | default(12) | string, '<')
 
+- name: Timescale (pgvectorscale) | Checking PostgreSQL version
+  run_once: true
+  ansible.builtin.fail:
+    msg:
+      - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the pgvectorscale."
+      - "PostgreSQL version must be {{ pgvectorscale_minimal_pg_version | default(15) }} or higher."
+  when:
+    - enable_pgvectorscale | default(false) | bool
+    - postgresql_version | string is version(pgvectorscale_minimal_pg_version | default(15) | string, '<')
+
+- name: Timescale (pgvectorscale) | Checking supported operating system and version
+  run_once: true
+  ansible.builtin.fail:
+    msg:
+      - "pgvectorscale is not supported on {{ ansible_distribution }} {{ ansible_distribution_release }}."
+      - "Supported OS: Debian (bookworm), Ubuntu (jammy, noble)."
+  when:
+    - enable_pgvectorscale | default(false) | bool
+    - not (ansible_os_family == "Debian" and ansible_distribution_release in ['bookworm', 'jammy', 'noble'])
+
 - name: ParadeDB | Checking PostgreSQL version
   run_once: true
   ansible.builtin.fail:

--- a/automation/vars/Debian.yml
+++ b/automation/vars/Debian.yml
@@ -50,6 +50,7 @@ system_packages:
   - acl
   - dnsutils
   - moreutils
+  - unzip
 
 install_perf: false  # or 'true' to install "perf" (Linux profiling with performance counters) and "FlameGraph".
 

--- a/automation/vars/Debian.yml
+++ b/automation/vars/Debian.yml
@@ -51,6 +51,8 @@ system_packages:
   - dnsutils
   - moreutils
   - unzip
+  - tar
+  - zstd
 
 install_perf: false  # or 'true' to install "perf" (Linux profiling with performance counters) and "FlameGraph".
 

--- a/automation/vars/RedHat.yml
+++ b/automation/vars/RedHat.yml
@@ -69,6 +69,9 @@ system_packages:
   - acl
   - bind-utils
   - moreutils
+  - unzip
+  - tar
+  - zstd
 
 install_perf: false  # or 'true' to install "perf" (Linux profiling with performance counters) and "FlameGraph".
 


### PR DESCRIPTION
Add [Timescale](https://www.timescale.com) `pgvectorscale` extension.

[pgvectorscale](https://github.com/timescale/pgvectorscale) builds on pgvector with higher performance embedding search and cost-efficient storage for AI applications.


### Variables

- `enable_pgvectorscale ` to install **pgvectorscale** and **pgvector** extensions
- `pgvectorscale_version`, default: `latest`

Compatible with Debian 12, Ubuntu 22.04 and 24.04 (_only deb packages are available_) for Postgres 15 and 16

### Deploy Timescale HA Cluster with pgvectorscale

To deploy a PostgreSQL High-Availability Cluster with the [pgvectorscale](https://github.com/timescale/pgvectorscale) extension, add the `enable_pgvectorscale` variable:

```
ansible-playbook deploy_pgcluster.yml  -e "enable_timescale=true" -e "enable_pgvectorscale=true"
```

>[!note]
> Variable `enable_timescale` is optional, in this example we install pgvectorscale, pgvector, and timescaledb extensions.
