### PR TITLE
Login to Azure using Service Principal

### DIFF
--- a/automation/roles/cloud-resources/tasks/azure.yml
+++ b/automation/roles/cloud-resources/tasks/azure.yml
@@ -46,33 +46,46 @@
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin:/usr/bin"
         PIP_BREAK_SYSTEM_PACKAGES: "1"
 
-    # CLI required for task "Add virtual machine IP addresses to Load Balancer backend pool"
-    - name: Check if Azure CLI is installed
-      ansible.builtin.command: az --version
-      register: az_version_result
-      changed_when: false
-      failed_when: false
+    # Azure CLI
+    # Note: required for task "Add virtual machine IP addresses to Load Balancer backend pool"
+    - block:
+        - name: Check if Azure CLI is installed
+          ansible.builtin.command: az --version
+          register: az_version_result
+          changed_when: false
+          failed_when: false
 
-    # try to install CLI (if not installed)
-    - name: Install Azure CLI
-      community.general.homebrew:
-        name: azure-cli
-        state: present
-      ignore_errors: true
-      when:
-        - az_version_result.rc != 0
-        - ansible_distribution == "MacOSX"
+        # try to install CLI (if not installed)
+        - name: Install Azure CLI
+          community.general.homebrew:
+            name: azure-cli
+            state: present
+          ignore_errors: true
+          when:
+            - az_version_result.rc != 0
+            - ansible_distribution == "MacOSX"
 
-    - name: Install Azure CLI
-      ansible.builtin.shell: >
-        set -o pipefail;
-        curl -sL https://aka.ms/InstallAzureCli | bash
-      args:
-        executable: /bin/bash
-      ignore_errors: true
-      when:
-        - az_version_result.rc != 0
-        - ansible_distribution != "MacOSX"
+        - name: Install Azure CLI
+          ansible.builtin.shell: >
+            set -o pipefail;
+            curl -sL https://aka.ms/InstallAzureCli | bash
+          args:
+            executable: /bin/bash
+          ignore_errors: true
+          when:
+            - az_version_result.rc != 0
+            - ansible_distribution != "MacOSX"
+
+        # login
+        - name: Login to Azure using Service Principal
+          ansible.builtin.shell: |
+            az login --service-principal \
+            --username "{{ lookup('env', 'AZURE_CLIENT_ID') }}" \
+            --password "{{ lookup('env', 'AZURE_SECRET') }}" \
+            --tenant "{{ lookup('env', 'AZURE_TENANT') }}"
+          args:
+            executable: /bin/bash
+      when: cloud_load_balancer | bool
   delegate_to: 127.0.0.1
   become: false
   run_once: true


### PR DESCRIPTION
We use Azure CLI because there is currently no Ansible module available to manage the list of IP addresses within a backend pool.

Previously, manual authentication via `az login` was required, which was not feasible when deploying the cluster through the Console (UI) or CI/CD. With this change, we now use a Service Principal to automate the authentication process in Azure, making the deployment fully automated and suitable for CI/CD pipelines.

Fixed:

```
TASK [cloud-resources : Azure: Add virtual machine IP addresses to Load Balancer backend pool] ***
failed: [localhost] (item=postgres-cluster-azure-primary-backend) => {"ansible_loop_var": "item", "changed": true, "cmd": "az network lb address-pool address add --resource-group postgres-cluster-resource-group-eastus --lb-name postgres-cluster-azure-primary --pool-name postgres-cluster-azure-primary-backend --vnet postgres-cluster-network --name address-10.0.1.4 --ip-address 10.0.1.4\n", "delta": "0:00:02.614384", "end": "2024-09-25 10:54:27.768540", "item": "primary", "msg": "non-zero return code", "rc": 1, "start": "2024-09-25 10:54:25.154156", "stderr": "ERROR: Please run 'az login' to setup account.", "stderr_lines": ["ERROR: Please run 'az login' to setup account."], "stdout": "", "stdout_lines": []}
```