### PR TITLE
pg_upgrade.yml: Add ‘string’ filter for postgresql version variables

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -66,7 +66,7 @@ jobs:
         run: make bootstrap-dev
 
       - name: Run Molecule tests
-        run: make molecule-test-scenario MOLECULE_SCENARIO="pg_upgrade"
+        run: make molecule-test
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -66,7 +66,7 @@ jobs:
         run: make bootstrap-dev
 
       - name: Run Molecule tests
-        run: make molecule-test
+        run: make molecule-test-scenario MOLECULE_SCENARIO="pg_upgrade"
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -16,7 +16,7 @@
         dcs_type: "{{ ['etcd', 'consul'] | random }}" # Set 'dcs_type' to either 'etcd' or 'consul' randomly
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
-        postgresql_version: "16" # to test custom WAL dir
+        postgresql_version: 16 # to test custom WAL dir
         pgbouncer_processes: 2 # Test multiple pgbouncer processes (so_reuseport)
         patroni_tags: "datacenter=dc1,key1=value1"
         balancer_tags: "datacenter=dc1"

--- a/automation/molecule/pg_upgrade/converge.yml
+++ b/automation/molecule/pg_upgrade/converge.yml
@@ -16,7 +16,7 @@
         dcs_type: "{{ ['etcd', 'consul'] | random }}" # Set 'dcs_type' to either 'etcd' or 'consul' randomly
         consul_node_role: server # if dcs_type: "consul"
         consul_bootstrap_expect: true # if dcs_type: "consul"
-        postgresql_version: "14" # redefine the version to install for the upgrade test
+        postgresql_version: 14 # redefine the version to install for the upgrade test
         pgbouncer_processes: 4 # Test multiple pgbouncer processes (so_reuseport)
         cacheable: true
       delegate_to: localhost
@@ -43,8 +43,8 @@
 
     - name: Set variables for PostgreSQL upgrade test
       ansible.builtin.set_fact:
-        pg_old_version: "14"
-        pg_new_version: "16"
+        pg_old_version: 14
+        pg_new_version: 16
 
     - name: Add repository GPG key
       ansible.builtin.command: "rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{{ ansible_distribution_major_version }}"

--- a/automation/roles/add-repository/tasks/main.yml
+++ b/automation/roles/add-repository/tasks/main.yml
@@ -97,7 +97,7 @@
             - ansible_distribution == "OracleLinux"
             - ansible_distribution_major_version is version('8', '>=')
       vars:
-        pg_devel_package: "postgresql{{ postgresql_version | replace('.', '') }}-devel"
+        pg_devel_package: "postgresql{{ postgresql_version | string | replace('.', '') }}-devel"
       when:
         - pg_devel_package in postgresql_packages
 

--- a/automation/roles/upgrade/tasks/pgbouncer_pause.yml
+++ b/automation/roles/upgrade/tasks/pgbouncer_pause.yml
@@ -39,7 +39,7 @@
       where pid <> pg_backend_pid()
       and state <> 'idle'
       and query_start < clock_timestamp() - interval '{{ pg_slow_active_query_treshold }} ms'
-      {{ "and backend_type = 'client backend'" if pg_old_version is version('10', '>=') else '' }}
+      {{ "and backend_type = 'client backend'" if pg_old_version | string is version('10', '>=') else '' }}
     pg_slow_active_terminate_query: >-
       select
         clock_timestamp(),
@@ -50,7 +50,7 @@
       where pid <> pg_backend_pid()
       and state <> 'idle'
       and query_start < clock_timestamp() - interval '{{ pg_slow_active_query_treshold_to_terminate }} ms'
-      {{ "and backend_type = 'client backend'" if pg_old_version is version('10', '>=') else '' }}
+      {{ "and backend_type = 'client backend'" if pg_old_version | string is version('10', '>=') else '' }}
     pgb_unix_socket_dirs: >-
       {% set unix_socket_dir = ['/var/run/pgbouncer'] %}
       {%- for idx in range(1, pgbouncer_processes | default(1) | int) -%}

--- a/automation/roles/upgrade/tasks/post_upgrade.yml
+++ b/automation/roles/upgrade/tasks/post_upgrade.yml
@@ -55,7 +55,7 @@
   retries: 3
   ignore_errors: true  # show the error and continue the playbook execution
   when:
-    - item is search(pg_old_version)
+    - item | string is search(pg_old_version | string)
     - pg_old_packages_remove | bool
     - ansible_os_family == "RedHat"
 
@@ -74,7 +74,7 @@
   retries: 3
   ignore_errors: true  # show the error and continue the playbook execution
   when:
-    - item is search(pg_old_version)
+    - item | string is search(pg_old_version | string)
     - pg_old_packages_remove | bool
     - ansible_os_family == "Debian"
 

--- a/automation/roles/upgrade/tasks/post_upgrade.yml
+++ b/automation/roles/upgrade/tasks/post_upgrade.yml
@@ -34,7 +34,7 @@
 # if pg_new_wal_dir is defined
 - name: Delete the old PostgreSQL WAL directory
   ansible.builtin.file:
-    path: "{{ postgresql_wal_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}"
+    path: "{{ postgresql_wal_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_old_version | string) }}"
     state: absent
   when:
     - pg_current_datadir is success
@@ -48,7 +48,7 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: absent
-  loop: "{{ postgresql_packages | regex_replace(postgresql_version, pg_old_version) }}"
+  loop: "{{ postgresql_packages | replace(postgresql_version | string, pg_old_version | string) }}"
   register: package_remove
   until: package_remove is success
   delay: 5
@@ -67,7 +67,7 @@
     name: "{{ item }}"
     state: absent
     purge: true
-  loop: "{{ postgresql_packages | regex_replace(postgresql_version, pg_old_version) }}"
+  loop: "{{ postgresql_packages | replace(postgresql_version | string, pg_old_version | string) }}"
   register: apt_remove
   until: apt_remove is success
   delay: 5
@@ -159,14 +159,14 @@
     - name: "WAL-G | Update PostgreSQL data directory path in .walg.json"
       ansible.builtin.replace:
         path: "{{ postgresql_home_dir }}/.walg.json"
-        regexp: "{{ postgresql_data_dir | regex_replace(postgresql_version, pg_old_version) }}"
-        replace: "{{ postgresql_data_dir | regex_replace(postgresql_version, pg_new_version) }}"
+        regexp: "{{ postgresql_data_dir | replace(postgresql_version | string, pg_old_version | string) }}"
+        replace: "{{ postgresql_data_dir | replace(postgresql_version | string, pg_new_version | string) }}"
 
     - name: "WAL-G | Update PostgreSQL data directory path in cron jobs"
       ansible.builtin.replace:
         path: "{{ wal_g_cron_jobs[0].file | default('/etc/cron.d/walg') }}"
-        regexp: "{{ postgresql_data_dir | regex_replace(postgresql_version, pg_old_version) }}"
-        replace: "{{ postgresql_data_dir | regex_replace(postgresql_version, pg_new_version) }}"
+        regexp: "{{ postgresql_data_dir | replace(postgresql_version | string, pg_old_version | string) }}"
+        replace: "{{ postgresql_data_dir | replace(postgresql_version | string, pg_new_version | string) }}"
   become: true
   become_user: root
   ignore_errors: true  # show the error and continue the playbook execution

--- a/automation/roles/upgrade/tasks/pre_checks.yml
+++ b/automation/roles/upgrade/tasks/pre_checks.yml
@@ -7,8 +7,8 @@
     msg:
       - "One or more required variables have empty values."
       - "Please specify a value for the variables: pg_old_version, pg_new_version"
-  failed_when: pg_old_version | length < 1 or pg_new_version | length < 1
-  when: pg_old_version | length < 1 or pg_new_version | length < 1
+  failed_when: pg_old_version | string | length < 1 or pg_new_version | string | length < 1
+  when: pg_old_version | string | length < 1 or pg_new_version | string | length < 1
 
 # Stop, if the directories of the old and new versions are the same
 - name: "Make sure that the old and new data and config directories do not match"

--- a/automation/roles/upgrade/tasks/pre_checks.yml
+++ b/automation/roles/upgrade/tasks/pre_checks.yml
@@ -66,7 +66,7 @@
   changed_when: false
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '>=')
+    - pg_old_version | string is version('10', '>=')
 
 # for compatibility with Postgres 9.x
 - name: '[Pre-Check] Check the current version of PostgreSQL'
@@ -77,11 +77,11 @@
   changed_when: false
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '<')
+    - pg_old_version | string is version('10', '<')
 
 - name: "Set variable 'current_pg_version'"
   ansible.builtin.set_fact:
-    current_pg_version: "{{ pg_current_version.stdout if pg_old_version is version('10', '>=') else pg_current_version_9x.stdout }}"
+    current_pg_version: "{{ pg_current_version.stdout if pg_old_version | string is version('10', '>=') else pg_current_version_9x.stdout }}"
   when:
     - inventory_hostname in groups['primary']
 
@@ -168,7 +168,7 @@
   delay: 5
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '>=')
+    - pg_old_version | string is version('10', '>=')
 
 # Stop, if replication lag is high
 - name: "Pre-Check error. High replication lag"
@@ -195,7 +195,7 @@
   delay: 5
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '<')
+    - pg_old_version | string is version('10', '<')
 
 # Stop, if replication lag is high (for 9x)
 - name: "Pre-Check error. High replication lag"
@@ -223,7 +223,7 @@
   until: pg_long_transactions.stdout | length < 1
   retries: 30 # 1 minute
   delay: 2
-  when: pg_old_version is version('10', '>=')
+  when: pg_old_version | string is version('10', '>=')
 
 # Stop, if long-running transactions detected
 - block:
@@ -254,7 +254,7 @@
   until: pg_long_transactions_9x.stdout | length < 1
   retries: 30 # 1 minute
   delay: 2
-  when: pg_old_version is version('10', '<')
+  when: pg_old_version | string is version('10', '<')
 
 # Stop, if long-running transactions detected (for 9x)
 - block:

--- a/automation/roles/upgrade/tasks/rollback.yml
+++ b/automation/roles/upgrade/tasks/rollback.yml
@@ -83,7 +83,7 @@
       - "The old cluster will need to be restored from backup."
   when:
     - inventory_hostname in groups['primary']
-    - pg_control_version.stdout == pg_new_version | replace('.', '')
+    - pg_control_version.stdout == pg_new_version | string | replace('.', '')
 
 # Restore the old Patroni configuration
 - name: '[Rollback] Restore the old patroni.yml configuration file'

--- a/automation/roles/upgrade/tasks/statistics.yml
+++ b/automation/roles/upgrade/tasks/statistics.yml
@@ -39,7 +39,7 @@
       poll: 0
       register: pg_terminator_analyze
       ignore_errors: true  # ignore errors if the task runs for over an 'vacuumdb_analyze_timeout'.
-      when: pg_new_version is version('9.6', '>=')
+      when: pg_new_version | string is version('9.6', '>=')
 
     # Monitor long-running transactions and terminate them (for more than 'vacuumdb_analyze_terminate_treshold')
     - name: "pg_terminator: Monitor and terminate the long-running transactions (more than {{ max_tx_sec }} seconds) during collecting statistics"
@@ -68,7 +68,7 @@
       ignore_errors: true  # ignore errors if the task runs for over an 'vacuumdb_analyze_timeout'.
       vars:
         max_tx_sec: "{{ vacuumdb_analyze_terminate_treshold }}"
-      when: pg_new_version is version('10', '>=') and vacuumdb_analyze_terminate_treshold | int > 0
+      when: pg_new_version | string is version('10', '>=') and vacuumdb_analyze_terminate_treshold | int > 0
 
     # ANALYZE
     - name: "Run vacuumdb to analyze the PostgreSQL databases"

--- a/automation/roles/upgrade/tasks/stop_services.yml
+++ b/automation/roles/upgrade/tasks/stop_services.yml
@@ -29,7 +29,7 @@
   failed_when: false
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '>=')
+    - pg_old_version | string is version('10', '>=')
 
 # Stop, if replication lag is high
 - block:
@@ -62,7 +62,7 @@
   failed_when: false
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_version is version('10', '<')
+    - pg_old_version | string is version('10', '<')
 
 # Stop, if replication lag is high (for 9x)
 - block:

--- a/automation/roles/upgrade/tasks/upgrade_secondary.yml
+++ b/automation/roles/upgrade/tasks/upgrade_secondary.yml
@@ -49,8 +49,8 @@
   become_user: postgres
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_datadir|dirname == pg_upper_datadir + '/' + pg_old_version
-    - pg_new_datadir|dirname == pg_upper_datadir + '/' + pg_new_version
+    - pg_old_datadir|dirname == pg_upper_datadir + '/' + (pg_old_version | string)
+    - pg_new_datadir|dirname == pg_upper_datadir + '/' + (pg_new_version | string)
 
 # If the source and target directories are non-versioned directories
 # (example: /pgdata/main -> /pgdata/main<pg_new_version>)
@@ -81,8 +81,8 @@
   become_user: postgres
   when:
     - inventory_hostname in groups['primary']
-    - pg_old_datadir|dirname != pg_upper_datadir + '/' + pg_old_version
-    - pg_new_datadir|dirname != pg_upper_datadir + '/' + pg_new_version
+    - pg_old_datadir|dirname != pg_upper_datadir + '/' + (pg_old_version | string)
+    - pg_new_datadir|dirname != pg_upper_datadir + '/' + (pg_new_version | string)
 
 # Tablespaces (if exists)
 - block:

--- a/automation/roles/wal-g/tasks/main.yml
+++ b/automation/roles/wal-g/tasks/main.yml
@@ -34,14 +34,14 @@
 # (if 'wal_g_installation_method' is 'binary')
 # Note: excluding RHEL 8 as GLIBC version 2.29 or higher is required.
 - block:
-    - name: "Download WAL-G v{{ wal_g_version | replace('v', '') }} binary"
+    - name: "Download WAL-G v{{ wal_g_version | string | replace('v', '') }} binary"
       ansible.builtin.get_url:
         url: "{{ wal_g_repo }}/{{ wal_g_archive }}"
         dest: /tmp/
         timeout: 60
         validate_certs: false
       vars:
-        wal_g_repo: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | replace('v', '') }}"
+        wal_g_repo: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | string | replace('v', '') }}"
         wal_g_archive: "wal-g-pg-ubuntu-20.04-amd64.tar.gz"
       environment: "{{ proxy_env | default({}) }}"
 
@@ -145,10 +145,10 @@
       when: go_installed_version.stderr is search("command not found") or
             go_installed_version.stdout is version(wal_g_latest_version.stdout, '<')
 
-    - name: "Download WAL-G v{{ wal_g_version | replace('v', '') }} source code"
+    - name: "Download WAL-G v{{ wal_g_version | string | replace('v', '') }} source code"
       ansible.builtin.git:
         repo: https://github.com/wal-g/wal-g.git
-        version: v{{ wal_g_version | replace('v', '') }}
+        version: v{{ wal_g_version | string | replace('v', '') }}
         dest: /tmp/wal-g
         force: true
 
@@ -195,9 +195,9 @@
 
 # older versions of WAL-G (for compatibility)
 - block:
-    - name: "Download WAL-G v{{ wal_g_version | replace('v', '') }} binary"
+    - name: "Download WAL-G v{{ wal_g_version | string | replace('v', '') }} binary"
       ansible.builtin.get_url:
-        url: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | replace('v', '') }}/wal-g.linux-amd64.tar.gz"
+        url: "https://github.com/wal-g/wal-g/releases/download/v{{ wal_g_version | string | replace('v', '') }}/wal-g.linux-amd64.tar.gz"
         dest: /tmp/
         timeout: 60
         validate_certs: false

--- a/automation/vars/upgrade.yml
+++ b/automation/vars/upgrade.yml
@@ -15,20 +15,20 @@ pg_new_version: ""  # specify the target version of PostgreSQL for the upgrade
 # Adjust these variables if the paths are different from the default value.
 
 # Directory containing binaries for the old PostgreSQL version.
-pg_old_bindir: "{{ postgresql_bin_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}"
+pg_old_bindir: "{{ postgresql_bin_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_old_version | string) }}"
 # Data directory path for the old PostgreSQL version.
-pg_old_datadir: "{{ postgresql_data_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}"
+pg_old_datadir: "{{ postgresql_data_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_old_version | string) }}"
 # Configuration directory path for the old PostgreSQL version.
-pg_old_confdir: "{{ postgresql_conf_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}"
+pg_old_confdir: "{{ postgresql_conf_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_old_version | string) }}"
 
 # Directory containing binaries for the new PostgreSQL version.
-pg_new_bindir: "{{ postgresql_bin_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_new_version) }}"
+pg_new_bindir: "{{ postgresql_bin_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_new_version | string) }}"
 # Data directory path for the new PostgreSQL version.
-pg_new_datadir: "{{ postgresql_data_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_new_version) }}"
+pg_new_datadir: "{{ postgresql_data_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_new_version | string) }}"
 # Configuration directory path for the new PostgreSQL version.
-pg_new_confdir: "{{ postgresql_conf_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_new_version) }}"
+pg_new_confdir: "{{ postgresql_conf_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_new_version | string) }}"
 # Custom WAL directory for the new PostgreSQL version (symlink will be created) [optional].
-pg_new_wal_dir: "{{ postgresql_wal_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_new_version) }}"
+pg_new_wal_dir: "{{ postgresql_wal_dir | regex_replace('(/$)', '') | replace(postgresql_version | string, pg_new_version | string) }}"
 
 # pg_upper_datadir: Specifies the top-level directory containing both old and new PostgreSQL data directories.
 # The variable is derived from pg_new_datadir by removing any trailing slash and getting its grandparent directory.
@@ -38,7 +38,7 @@ pg_upper_datadir: "{{ pg_new_datadir | regex_replace('/$', '') | dirname | dirna
 
 # List of package names for the new PostgreSQL version to be installed.
 # automatically detects the list of packages based on the 'postgresql_packages' variable
-pg_new_packages: "{{ postgresql_packages | regex_replace(postgresql_version, pg_new_version) }}"
+pg_new_packages: "{{ postgresql_packages | replace(postgresql_version | string, pg_new_version | string) }}"
 
 # Alternatively, you can explicitly specify the list of new packages to install.
 # This gives you more control and should be used if the automatic update does not meet your needs.


### PR DESCRIPTION
# Description

Ansible pg_upgrade.yml pre_check is failed when postgresql_version is int, because
regex_replace ansible filter expects a string or pattern.

Initially postgresql_version was a string, but changed in this [PR](https://github.com/vitabaks/postgresql_cluster/commit/1cf159e97ef1f51142184b3c3bf1a39641d660ce) to int 


```
ansible-playbook pg_upgrade.yml -e "pg_old_version=15 pg_new_version=16"

TASK [upgrade : Make sure that the old and new data and config directories do not match] ***********************************************
fatal: [192.168.40.135]: FAILED! => {"msg": "The conditional check '(pg_old_datadir == pg_new_datadir) or (pg_old_confdir == pg_new_confdir)' failed. The error was: An unhandled exception occurred while templating '{{ postgresql_data_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({{ postgresql_data_dir | regex_replace('(/$)', '') | regex_replace(postgresql_version, pg_old_version) }}): first argument must be string or compiled pattern. first argument must be string or compiled pattern\n\nThe error appears to be in '/home/loman/postgresql_cluster/automation/roles/upgrade/tasks/pre_checks.yml': line 14, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Stop, if the directories of the old and new versions are the same\n- name: \"Make sure that the old and new data and config directories do not match\"\n  ^ here\n"}
```

