### PR TITLE
GCP: Add support for bare metal instances

### DIFF
--- a/automation/roles/cloud-resources/tasks/gcp.yml
+++ b/automation/roles/cloud-resources/tasks/gcp.yml
@@ -469,7 +469,7 @@
     host: "{{ item.networkInterfaces[0].accessConfigs[0].natIP }}"
     port: 22
     delay: 5
-    timeout: 300
+    timeout: "{{ 1800 if server_type is search('metal') else 300 }}"  # timeout 30 minutes for bare metal instances and 5 minutes for regular VMs
   loop: "{{ server_result.results }}"
   loop_control:
     label: "{{ item.networkInterfaces[0].accessConfigs[0].natIP | default('N/A') }}"

--- a/automation/roles/cloud-resources/tasks/gcp.yml
+++ b/automation/roles/cloud-resources/tasks/gcp.yml
@@ -261,7 +261,7 @@
         metadata:
           ssh-keys: "root:{{ ssh_key_content }}"
         scheduling:
-          onHostMaintenance: "{{ 'TERMINATE' if (server_spot | bool or server_type is search('metal')) else 'MIGRATE' }}"
+          on_host_maintenance: "{{ 'TERMINATE' if (server_spot | bool or server_type is search('metal')) else 'MIGRATE' }}"
           preemptible: "{{ server_spot | default(gcp_compute_instance_preemptible | default(false)) | bool }}"
         tags:
           items:

--- a/automation/roles/cloud-resources/tasks/gcp.yml
+++ b/automation/roles/cloud-resources/tasks/gcp.yml
@@ -261,6 +261,7 @@
         metadata:
           ssh-keys: "root:{{ ssh_key_content }}"
         scheduling:
+          onHostMaintenance: "{{ 'TERMINATE' if (server_spot | bool or server_type is search('metal')) else 'MIGRATE' }}"
           preemptible: "{{ server_spot | default(gcp_compute_instance_preemptible | default(false)) | bool }}"
         tags:
           items:


### PR DESCRIPTION
This PR adds support for **bare metal** instances in GCP. 

For these instance types, the `on_host_maintenance: "TERMINATE"` option is automatically set, as required by GCP. 
For all other standard instance types, the `"MIGRATE"` option is used, allowing instances to migrate during maintenance.