### PR TITLE
pgBackRest: Run "Create stanza" only on master if it's not posix

### DIFF
--- a/automation/roles/pgbackrest/stanza-create/tasks/main.yml
+++ b/automation/roles/pgbackrest/stanza-create/tasks/main.yml
@@ -2,10 +2,10 @@
 
 # Create a stanza locally (if "pgbackrest_repo_host" is not set)
 - block:
-    - name: Get repo1-path value
+    - name: Get repo1-path and repo1_type value
       ansible.builtin.set_fact:
         repo1_path: "{{ pgbackrest_conf['global'] | selectattr('option', 'equalto', 'repo1-path') | map(attribute='value') | list | first }}"
-      when: pgbackrest_repo_type | lower == 'posix'
+        repo1_type: "{{ pgbackrest_conf['global'] | selectattr('option', 'equalto', 'repo1-type') | map(attribute='value') | list | first }}"
 
     - name: "Make sure the {{ repo1_path }} directory exists"
       ansible.builtin.file:
@@ -14,7 +14,7 @@
         owner: postgres
         group: postgres
         mode: "0750"
-      when: repo1_path | default('') | length > 0
+      when: repo1_type | lower == 'posix'
 
     - name: Create stanza "{{ pgbackrest_stanza }}"
       become: true
@@ -24,6 +24,8 @@
       changed_when:
         - stanza_create_result.rc == 0
         - stanza_create_result.stdout is not search("already exists")
+      when: repo1_type | lower == 'posix' or
+            (repo1_type | lower != 'posix' and inventory_hostname == groups['master'][0])  # run only on master if it's not posix
   when:
     - pgbackrest_repo_host | length < 1
     - "'postgres_cluster' in group_names"


### PR DESCRIPTION
This update modifies the stanza creation process for pgbackrest to run on all nodes only if repo1-type is posix. For other types (e.g., S3), the stanza creation is limited to the primary node, addressing errors caused by running stanza creation on multiple hosts in non-posix setups.

Fixed: 

```
TASK [pgbackrest/stanza-create : Create stanza "postgres-cluster-azure"] *******
fatal: [10.0.1.6]: FAILED! => {"changed": false, "cmd": ["pgbackrest", "--stanza=postgres-cluster-azure", "--no-online", "stanza-create"], "delta": "0:00:00.118962", "end": "2024-10-10 10:35:24.666687", "msg": "non-zero return code", "rc": 40, "start": "2024-10-10 10:35:24.547725", "stderr": "", "stderr_lines": [], "stdout": "2024-10-10 10:35:24.555 P00   INFO: stanza-create command begin 2.53.1: --exec-id=10823-ffa2c2b9 --log-level-console=info --log-level-file=detail --log-path=/var/log/pgbackrest --no-online --pg2-host=10.0.1.4 --pg3-host=10.0.1.5 --pg1-path=/pgdata/16/main --pg2-path=/pgdata/16/main --pg3-path=/pgdata/16/main --pg2-port=5432 --pg3-port=5432 --repo1-azure-account=<redacted> --repo1-azure-container=postgres-cluster-azure-backup --repo1-azure-key=<redacted> --repo1-azure-key-type=shared --repo1-path=/pgbackrest --repo1-type=azure --stanza=postgres-cluster-azure\n2024-10-10 10:35:24.555 P00   INFO: stanza-create for stanza 'postgres-cluster-azure' on repo1\n2024-10-10 10:35:24.665 P00  ERROR: [040]: archive directory not empty\n2024-10-10 10:35:24.665 P00   INFO: stanza-create command end: aborted with exception [040]", "stdout_lines": ["2024-10-10 10:35:24.555 P00   INFO: stanza-create command begin 2.53.1: --exec-id=10823-ffa2c2b9 --log-level-console=info --log-level-file=detail --log-path=/var/log/pgbackrest --no-online --pg2-host=10.0.1.4 --pg3-host=10.0.1.5 --pg1-path=/pgdata/16/main --pg2-path=/pgdata/16/main --pg3-path=/pgdata/16/main --pg2-port=5432 --pg3-port=5432 --repo1-azure-account=<redacted> --repo1-azure-container=postgres-cluster-azure-backup --repo1-azure-key=<redacted> --repo1-azure-key-type=shared --repo1-path=/pgbackrest --repo1-type=azure --stanza=postgres-cluster-azure", "2024-10-10 10:35:24.555 P00   INFO: stanza-create for stanza 'postgres-cluster-azure' on repo1", "2024-10-10 10:35:24.665 P00  ERROR: [040]: archive directory not empty", "2024-10-10 10:35:24.665 P00   INFO: stanza-create command end: aborted with exception [040]"]}
changed: [10.0.1.4]
changed: [10.0.1.5]
```