### PR TITLE
AWS: Create a VPC, if no default

### DIFF
--- a/automation/roles/cloud-resources/tasks/aws.yml
+++ b/automation/roles/cloud-resources/tasks/aws.yml
@@ -60,52 +60,75 @@
 # Create (if state is present)
 - block:
     # if server_network is specified, get vpc id for this subnet
-    - name: "AWS: Gather information about VPC for '{{ server_network }}'"
-      amazon.aws.ec2_vpc_subnet_info:
-        region: "{{ server_location }}"
-        subnet_ids: "{{ server_network }}"
-      register: vpc_subnet_info
+    - block:
+        - name: "AWS: Gather information about VPC for '{{ server_network }}'"
+          amazon.aws.ec2_vpc_subnet_info:
+            region: "{{ server_location }}"
+            subnet_ids: "{{ server_network }}"
+          register: vpc_subnet_info
+
+        - name: "Set variable: vpc_id"
+          ansible.builtin.set_fact:
+            vpc_id: "{{ vpc_subnet_info.subnets[0].vpc_id }}"
+          when: vpc_subnet_info.subnets[0].vpc_id is defined
       when: server_network | length > 0
 
-    - name: "Set variable: vpc_id"
-      ansible.builtin.set_fact:
-        vpc_id: "{{ vpc_subnet_info.subnets[0].vpc_id }}"
-      when:
-        - server_network | length > 0
-        - vpc_subnet_info.subnets[0].vpc_id is defined
-
     # if server_network is not specified, use default vpc subnet
-    - name: "AWS: Gather information about default VPC"
-      amazon.aws.ec2_vpc_net_info:
-        region: "{{ server_location }}"
-        filters:
-          "is-default": true
-      register: vpc_info
+    - block:
+        - name: "AWS: Gather information about default VPC"
+          amazon.aws.ec2_vpc_net_info:
+            region: "{{ server_location }}"
+            filters:
+              "is-default": true
+          register: vpc_info
+
+        # if no default vpc
+        - name: "No default VPC found"
+          ansible.builtin.debug:
+            msg: "No default VPC found in region {{ server_location }}"
+          when: vpc_info.vpcs | length == 0 or vpc_info.vpcs[0].id is not defined
+
+        - name: "AWS: Gather information about VPC subnet for default VPC"
+          amazon.aws.ec2_vpc_subnet_info:
+            region: "{{ server_location }}"
+            filters:
+              vpc-id: "{{ vpc_info.vpcs[0].id }}"
+          register: vpc_subnet_info
+          when: vpc_info.vpcs[0].id is defined
+
+        - name: "Set variable: vpc_id"
+          ansible.builtin.set_fact:
+            vpc_id: "{{ vpc_info.vpcs[0].id }}"
+          when: vpc_info.vpcs[0].id is defined
+
+        - name: "Set variable: server_network"
+          ansible.builtin.set_fact:
+            server_network: "{{ vpc_subnet_info.subnets[0].id }}"
+          when: vpc_subnet_info.subnets[0].id is defined
       when: server_network | length < 1
 
-    - name: "AWS: Gather information about VPC subnet for default VPC"
-      amazon.aws.ec2_vpc_subnet_info:
-        region: "{{ server_location }}"
-        filters:
-          vpc-id: "{{ vpc_info.vpcs[0].id }}"
-      register: vpc_subnet_info
-      when:
-        - server_network | length < 1
-        - vpc_info.vpcs[0].id is defined
+    # if server_network is not specified and there is no default VPC, create a VPC and subnet
+    - block:
+        - name: "AWS: Create VPC"
+          amazon.aws.ec2_vpc_net:
+            name: "{{ aws_vpc_name | default('postgres-cluster-vpc') }}"
+            cidr_block: "{{ aws_vpc_cidr | default('10.0.0.0/16') }}"
+            region: "{{ server_location }}"
+            state: present
+          register: aws_vpc
 
-    - name: "Set variable: vpc_id"
-      ansible.builtin.set_fact:
-        vpc_id: "{{ vpc_info.vpcs[0].id }}"
-      when:
-        - server_network | length < 1
-        - vpc_info.vpcs[0].id is defined
+        - name: "AWS: Create subnet"
+          amazon.aws.ec2_vpc_subnet:
+            vpc_id: "{{ aws_vpc.vpc.id }}"
+            cidr: "{{ aws_subnet_cidr | default('10.0.1.0/24') }}"
+            region: "{{ server_location }}"
+            state: present
+          register: aws_subnet
 
-    - name: "Set variable: server_network"
-      ansible.builtin.set_fact:
-        server_network: "{{ vpc_subnet_info.subnets[0].id }}"
-      when:
-        - server_network | length < 1
-        - vpc_subnet_info.subnets[0].id is defined
+        - name: "Set variable: server_network"
+          ansible.builtin.set_fact:
+            server_network: "{{ aws_subnet.subnet.id }}"
+      when: server_network | length < 1
 
     # Security Group (Firewall)
     - name: "AWS: Create or modify Security Group"


### PR DESCRIPTION
If the network is not specified, check for the default VPC. If no default VPC is found, a new VPC and subnet are created automatically.

Related: https://github.com/vitabaks/postgresql_cluster/discussions/788