### PR TITLE
pgpass: run the task as the root user

### DIFF
--- a/automation/roles/pgpass/tasks/main.yml
+++ b/automation/roles/pgpass/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: "Configure a password file ({{ postgresql_home_dir }}/.pgpass)"
   become: true
-  become_user: postgres
+  become_user: root
   ansible.builtin.copy:
     content: |
       {% for pgpass in postgresql_pgpass %}


### PR DESCRIPTION
Issue: https://github.com/vitabaks/postgresql_cluster/issues/790

This PR resolves the issue where the Ansible task failed to configure the `.pgpass` file due to a “Permission denied” error when specifying a different path in the `postgresql_home_dir` variable.

Fixed:

```
TASK [pgpass: Configure a password file (/data/var/lib/postgresql/-pgpass)] *****************************************************
task path: /home/infraoperator/postgres_prod/postgresql_cluster/roles/pgpass/tasks/main.yml:3
fatal: [192.168.7.31]: FAILED! => {
"msg": "Failed to get information on remote file (/data/var/lib/postgresql/.pgpass): Permission denied"
}
```

 The task now uses `become_user: root` and adjusts permissions to ensure proper access for the postgres user.
