### PR TITLE
pgvectorscale: Update the Postgres version pre-check

### DIFF
--- a/automation/roles/pre-checks/tasks/extensions.yml
+++ b/automation/roles/pre-checks/tasks/extensions.yml
@@ -18,10 +18,10 @@
   ansible.builtin.fail:
     msg:
       - "The current PostgreSQL version ({{ postgresql_version }}) is not supported by the pgvectorscale."
-      - "PostgreSQL version must be {{ pgvectorscale_minimal_pg_version | default(15) }} or higher."
+      - "PostgreSQL version must be {{ pgvectorscale_minimal_pg_version | default(13) }} or higher."
   when:
     - enable_pgvectorscale | default(false) | bool
-    - postgresql_version | string is version(pgvectorscale_minimal_pg_version | default(15) | string, '<')
+    - postgresql_version | string is version(pgvectorscale_minimal_pg_version | default(13) | string, '<')
 
 - name: Timescale (pgvectorscale) | Checking supported operating system and version
   run_once: true


### PR DESCRIPTION
With the release of version [0.4.0](https://github.com/timescale/pgvectorscale/releases/tag/0.4.0), the minimum supported version of PostgreSQL 13.

Update `pgvectorscale_minimal_pg_version` variable.