### PR TITLE
pg_upgrade.yml: Use pg_old_dir for old psql binaries before upgrade

### DIFF
--- a/automation/roles/upgrade/tasks/initdb.yml
+++ b/automation/roles/upgrade/tasks/initdb.yml
@@ -40,7 +40,7 @@
 
 - name: Get the current install user
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select rolname from pg_roles where oid = 10"
   changed_when: false
   register: pg_install_user

--- a/automation/roles/upgrade/tasks/pre_checks.yml
+++ b/automation/roles/upgrade/tasks/pre_checks.yml
@@ -36,7 +36,7 @@
 
 - name: '[Pre-Check] Test PostgreSQL database access using a unix socket'
   ansible.builtin.command: >
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc 'select 1'
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc 'select 1'
   register: socket_access_result
   changed_when: false
   failed_when: "socket_access_result.rc != 0 and 'no pg_hba.conf entry' not in socket_access_result.stderr"
@@ -60,7 +60,7 @@
 
 - name: '[Pre-Check] Check the current version of PostgreSQL'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select setting::integer/10000 from pg_settings where name = 'server_version_num'"
   register: pg_current_version
   changed_when: false
@@ -71,7 +71,7 @@
 # for compatibility with Postgres 9.x
 - name: '[Pre-Check] Check the current version of PostgreSQL'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select substring(setting from '^[0-9]+\.[0-9]+') from pg_settings where name = 'server_version'"
   register: pg_current_version_9x
   changed_when: false
@@ -110,7 +110,7 @@
 # which will later be cleaned up before executing initdb for a new version of PostgreSQL
 - name: '[Pre-Check] Ensure new data directory is different from the current one'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "show data_directory"
   changed_when: false
   register: pg_current_datadir
@@ -138,7 +138,7 @@
 
 - name: '[Pre-Check] Make sure that physical replication is active'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select count(*) from pg_stat_replication
      where application_name != 'pg_basebackup'"
   register: pg_replication_state
@@ -156,7 +156,7 @@
 
 - name: '[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | human_readable }})'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pg_wal_lsn_diff(pg_current_wal_lsn(),replay_lsn) as pg_lag_bytes
       from pg_stat_replication
       order by pg_lag_bytes desc limit 1"
@@ -183,7 +183,7 @@
 # for compatibility with Postgres 9.x
 - name: '[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | human_readable }})'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pg_xlog_location_diff(pg_current_xlog_location(),replay_location) as pg_lag_bytes
       from pg_stat_replication
       order by pg_lag_bytes desc limit 1"
@@ -209,7 +209,7 @@
 
 - name: '[Pre-Check] Make sure there are no long-running transactions (more than {{ max_transaction_sec }} seconds)'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pid, usename, client_addr, clock_timestamp() - xact_start as xact_age,
       state, wait_event_type ||':'|| wait_event as wait_events,
       left(regexp_replace(query, E'[ \\t\\n\\r]+', ' ', 'g'),100) as query
@@ -242,7 +242,7 @@
 # for compatibility with Postgres 9.x
 - name: '[Pre-Check] Make sure there are no long-running transactions (more than {{ max_transaction_sec }} seconds)'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pid, usename, client_addr, clock_timestamp() - xact_start as xact_age,
       state, left(regexp_replace(query, E'[ \\t\\n\\r]+', ' ', 'g'),100) as query
       from pg_stat_activity
@@ -332,7 +332,7 @@
 # Tablespaces
 - name: '[Pre-Check] Check if PostgreSQL tablespaces exist'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pg_tablespace_location(oid) as tablespace_location
       from pg_tablespace
       where spcname not in ('pg_default','pg_global')"
@@ -374,7 +374,7 @@
 # Test access via unix socket to be able to perform 'PAUSE' command
 - name: '[Pre-Check] Test PgBouncer access via unix socket'
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -h /var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}
+    {{ pg_old_bindir }}/psql -h /var/run/pgbouncer{{ '-%d' % (idx + 1) if idx > 0 else '' }}
     -p {{ pgbouncer_listen_port }}
     -U {{ patroni_superuser_username }}
     -d pgbouncer

--- a/automation/roles/upgrade/tasks/schema_compatibility.yml
+++ b/automation/roles/upgrade/tasks/schema_compatibility.yml
@@ -2,7 +2,7 @@
 
 - name: Get the current shared_preload_libraries settings
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "show shared_preload_libraries"
   changed_when: false
   register: pg_shared_preload_libraries
@@ -11,7 +11,7 @@
 
 - name: Get the current cron.database_name settings
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select current_setting('cron.database_name', true)"
   changed_when: false
   register: pg_cron_database_name

--- a/automation/roles/upgrade/tasks/stop_services.yml
+++ b/automation/roles/upgrade/tasks/stop_services.yml
@@ -2,7 +2,7 @@
 
 - name: "Execute CHECKPOINT before stopping PostgreSQL"
   ansible.builtin.command: >
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc "CHECKPOINT"
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc "CHECKPOINT"
   async: "{{ pg_start_stop_timeout | int }}"  # run the command asynchronously
   poll: 0
   register: checkpoint_result
@@ -18,7 +18,7 @@
 # Wait for the window to appear without high replication lag before stopping PostgreSQL
 - name: "Wait until replication lag is less than {{ max_replication_lag_bytes | human_readable }}"
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select coalesce(max(pg_wal_lsn_diff(pg_current_wal_lsn(),replay_lsn)),1) as pg_lag_bytes
       from pg_stat_replication"
   register: pg_lag_bytes
@@ -51,7 +51,7 @@
 # for compatibility with Postgres 9.x
 - name: "Wait until replication lag is less than {{ max_replication_lag_bytes | human_readable }}"
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select coalesce(max(pg_xlog_location_diff(pg_current_xlog_location(),replay_location)),1) as pg_lag_bytes
       from pg_stat_replication"
   register: pg_lag_bytes_9x

--- a/automation/roles/upgrade/tasks/upgrade_check.yml
+++ b/automation/roles/upgrade/tasks/upgrade_check.yml
@@ -2,7 +2,7 @@
 
 - name: Get the current shared_preload_libraries settings
   ansible.builtin.command: >-
-    {{ postgresql_bin_dir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
+    {{ pg_old_bindir }}/psql -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "show shared_preload_libraries"
   changed_when: false
   register: pg_shared_preload_libraries_result


### PR DESCRIPTION
Use the path to the old version of the psql binaries (`pg_old_dir` variable) before upgrading.

Fixed
![image](https://github.com/user-attachments/assets/6ab370e9-9c26-487a-b016-b15fa59f2f41)

If a new PostgreSQL version was specified in the `postgresql_version` variable before running the upgrade procedure, an error occurred. We now explicitly use the old version, specified in the `pg_old_version` variable, before performing the upgrade. 