### PR TITLE
Fix: Prevent division by zero in HugePages calculation

### DIFF
--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -55,8 +55,12 @@
       ansible.builtin.set_fact:
         huge_pages_required: >-
           {{
-            ((shared_buffers_gb | default(0) | int + (additional_huge_pages_gb | default(1)))
-            * 1024 * 1024) // huge_page_size.stdout | default(2048) | int
+            (
+              (shared_buffers_gb | default(0) | int
+              + additional_huge_pages_gb | default(1))
+              * 1024 * 1024
+            )
+            // (huge_page_size.stdout | int if huge_page_size.stdout | int > 0 else 2048)
           }}
       when:
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))

--- a/automation/roles/pre-checks/tasks/main.yml
+++ b/automation/roles/pre-checks/tasks/main.yml
@@ -33,6 +33,7 @@
   ansible.builtin.import_tasks: huge_pages.yml
   when:
     - inventory_hostname in groups['postgres_cluster']
+    - huge_pages_auto_conf | bool
 
 - name: Perform pre-checks for pgbackrest
   ansible.builtin.import_tasks: pgbackrest.yml

--- a/automation/roles/pre-checks/tasks/main.yml
+++ b/automation/roles/pre-checks/tasks/main.yml
@@ -33,7 +33,7 @@
   ansible.builtin.import_tasks: huge_pages.yml
   when:
     - inventory_hostname in groups['postgres_cluster']
-    - huge_pages_auto_conf | bool
+    - huge_pages_auto_conf | default(false) | bool
 
 - name: Perform pre-checks for pgbackrest
   ansible.builtin.import_tasks: pgbackrest.yml

--- a/automation/roles/pre-checks/tasks/main.yml
+++ b/automation/roles/pre-checks/tasks/main.yml
@@ -33,7 +33,6 @@
   ansible.builtin.import_tasks: huge_pages.yml
   when:
     - inventory_hostname in groups['postgres_cluster']
-    - huge_pages_auto_conf | default(false) | bool
 
 - name: Perform pre-checks for pgbackrest
   ansible.builtin.import_tasks: pgbackrest.yml


### PR DESCRIPTION
Ensures huge_page_size has a valid value before performing division to prevent errors.

Added a fallback to use the default 2048 if huge_page_size is invalid or zero. Improves stability when calculating required HugePages for shared buffers.

Fixed:

```
TASK [pre-checks : HugePages | Calculate required HugePages] *******************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ZeroDivisionError: integer division or modulo by zero
```