### PR TITLE
Fix molecule tests: Add pgvectorscale_version variable

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -63,6 +63,7 @@
         enable_citus: "{{ 'false' if ansible_distribution_version == '24.04' else 'true' }}"  # TODO Ubuntu 24.04
         enable_paradedb: "{{ 'false' if ansible_distribution_release == 'bullseye' else 'true' }}"  # pg_search and pg_analytics (no packages for debian 11)
         enable_pgvectorscale: "{{ 'true' if ansible_distribution_release in ['bookworm', 'jammy', 'noble'] else 'false' }}" # only deb packages are available
+        pgvectorscale_version: "0.5.0"  # TODO (v0.5.1 does not contain packages)
         # create extension
         postgresql_schemas:
           - { schema: "paradedb", db: "postgres", owner: "postgres" }  # pg_search must be installed in the paradedb schema.


### PR DESCRIPTION
v[0.5.1](https://github.com/timescale/pgvectorscale/releases/tag/0.5.1) does not contain packages

Fixed:

```
FAILED! => {"changed": false, "dest": "/tmp/pgvectorscale-0.5.1-pg16-amd64.zip", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://github.com/timescale/pgvectorscale/releases/download/0.5.1/pgvectorscale-0.5.1-pg16-amd64.zip"}
```