### PR TITLE
Ensure retrieval of hugepage size in check mode

### DIFF
--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -18,24 +18,6 @@
             | first | default('128MB'))
           }}
 
-    - name: "HugePages | Get Hugepagesize value from /proc/meminfo"
-      ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
-      changed_when: false
-      register: huge_page_size
-    
-    - name: "Debug | Hugepagesize command result"
-      ansible.builtin.debug:
-        var: huge_page_size
-    
-    - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
-      ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
-      changed_when: false
-      register: huge_pages_total
-    
-    - name: "Debug | HugePages_Total command result"
-      ansible.builtin.debug:
-        var: huge_pages_total
-
     - name: "HugePages | Set variable: shared_buffers_gb"
       ansible.builtin.set_fact:
         shared_buffers_gb: "{{ (shared_buffers_value | int) // 1024 }}"
@@ -54,6 +36,22 @@
           No HugePages configuration is required.
       when:
         - (shared_buffers_gb | default(0) | int) < (min_shared_buffers_gb | default(8) | int)
+
+    - name: "HugePages | Get Hugepagesize value from /proc/meminfo"
+      ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
+      changed_when: false
+      check_mode: true
+      register: huge_page_size
+      when:
+        - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
+
+    - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
+      ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
+      changed_when: false
+      check_mode: true
+      register: huge_pages_total
+      when:
+        - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
 
     - name: "HugePages | Calculate required HugePages"
       ansible.builtin.set_fact:

--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -18,6 +18,16 @@
             | first | default('128MB'))
           }}
 
+    - name: "HugePages | Get Hugepagesize value from /proc/meminfo"
+      ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
+      changed_when: false
+      register: huge_page_size
+
+    - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
+      ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
+      changed_when: false
+      register: huge_pages_total
+
     - name: "HugePages | Set variable: shared_buffers_gb"
       ansible.builtin.set_fact:
         shared_buffers_gb: "{{ (shared_buffers_value | int) // 1024 }}"
@@ -36,20 +46,6 @@
           No HugePages configuration is required.
       when:
         - (shared_buffers_gb | default(0) | int) < (min_shared_buffers_gb | default(8) | int)
-
-    - name: "HugePages | Get Hugepagesize value from /proc/meminfo"
-      ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
-      changed_when: false
-      register: huge_page_size
-      when:
-        - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
-
-    - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
-      ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
-      changed_when: false
-      register: huge_pages_total
-      when:
-        - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
 
     - name: "HugePages | Calculate required HugePages"
       ansible.builtin.set_fact:

--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -40,7 +40,7 @@
     - name: "HugePages | Get Hugepagesize value from /proc/meminfo"
       ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
       changed_when: false
-      check_mode: true
+      check_mode: false
       register: huge_page_size
       when:
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))
@@ -48,7 +48,7 @@
     - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
       ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
       changed_when: false
-      check_mode: true
+      check_mode: false
       register: huge_pages_total
       when:
         - shared_buffers_gb | default(0) | int >= (min_shared_buffers_gb | default(8))

--- a/automation/roles/pre-checks/tasks/huge_pages.yml
+++ b/automation/roles/pre-checks/tasks/huge_pages.yml
@@ -22,11 +22,19 @@
       ansible.builtin.command: "awk '/Hugepagesize/ {print $2}' /proc/meminfo"
       changed_when: false
       register: huge_page_size
-
+    
+    - name: "Debug | Hugepagesize command result"
+      ansible.builtin.debug:
+        var: huge_page_size
+    
     - name: "HugePages | Get HugePages_Total value from /proc/meminfo"
       ansible.builtin.command: "awk '/HugePages_Total/ {print $2}' /proc/meminfo"
       changed_when: false
       register: huge_pages_total
+    
+    - name: "Debug | HugePages_Total command result"
+      ansible.builtin.debug:
+        var: huge_pages_total
 
     - name: "HugePages | Set variable: shared_buffers_gb"
       ansible.builtin.set_fact:


### PR DESCRIPTION
This update adds `check_mode: false` to the tasks retrieving `Hugepagesize` and `HugePages_Total` values from `/proc/meminfo`. This ensures these tasks are executed even in Ansible’s check mode, allowing necessary data to be consistently retrieved for subsequent calculations.

Before:

```
TASK [pre-checks : HugePages | info] *******************************************
ok: [172.30.58.35] => {
    "msg": {
        "huge_page_size_kb": "0",
        "huge_pages_required": "16896",
        "huge_pages_sufficient": false,
        "huge_pages_total": "0",
        "shared_buffers_gb": "32"
    }
}
```

After:

```
TASK [pre-checks : HugePages | info] *******************************************
ok: [172.30.58.35] => {
    "msg": {
        "huge_page_size_kb": "2048",
        "huge_pages_required": "16896",
        "huge_pages_sufficient": false,
        "huge_pages_total": "19020",
        "shared_buffers_gb": "32"
    }
}
```