### PR TITLE
pgBackRest: Fix timeline divergence after PITR

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -673,7 +673,7 @@
         - name: Run "{{ pgbackrest_patroni_cluster_restore_command }}" on Replica
           ansible.builtin.command: >
             {{ pgbackrest_patroni_cluster_restore_command }}
-            {{ '--target-action=shutdown' if pgbackrest_patroni_cluster_restore_command is search('--type=') else '' }}
+            {{ '--target-action=pause' if pgbackrest_patroni_cluster_restore_command is search('--type=') else '' }}
           async: "{{ cluster_restore_timeout | default(86400) }}"  # timeout 24 hours
           poll: 0
           register: pgbackrest_restore_replica


### PR DESCRIPTION
This PR is intended to be fixed during PITR, when at the end of the playbook, the replicas were on a timeline different from the master node.
![image](https://github.com/user-attachments/assets/2c8facf1-129e-4b3b-ae24-42e54a2260bf)
The first solution that helped fix the error on the timeline was to restart patroni on replica nodes, which causes pg_rewind to run between replicas and the master, and the replicas received the necessary WAL files from the master node to align the timeline. But it didn't look like the right decision.

Also, when replicas were in the first timeline after recovery, errors were observed in the logs on the master node that a replication slot could not be created for the replica node:
```
STATEMENT:  START_REPLICATION SLOT "pgnode03" 0/76000000 TIMELINE 1
ERROR:  requested starting point 0/76000000 on timeline 1 is not in this server's history
DETAIL:  This server's history forked from timeline 1 at 0/73000498.
STATEMENT:  START_REPLICATION SLOT "pgnode02" 0/76000000 TIMELINE 1
ERROR:  requested starting point 0/76000000 on timeline 1 is not in this server's history
DETAIL:  This server's history forked from timeline 1 at 0/73000498.
``` 

The official documentation says that if target-action=shutdown is used, the recovery.signal file is not deleted, which prevents subsequent PostgreSQL launches in the cluster, since the server will wait for further recovery from the WAL repository, where the necessary files are missing, since after recovery it is necessary to make a new backup. A simple intervention with deleting the recovery.signal file before running patroni on replicas does not help solve the problem with the missing timeline.

The solution is to change the target-action for replicas from shutdown to pause, in this case the replica starts as a ready-made PostgreSQL instance and immediately connects to the master node and pulls the necessary WALs from it for the desired timeline.
![image](https://github.com/user-attachments/assets/6aceace2-fbe8-4a4a-80cf-6e949d14c3f4)
