### PR TITLE
Fix: Do not perform on the Standby Cluster

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -521,7 +521,9 @@
             state: present
           become: true
           become_user: postgres
-      when: inventory_hostname == groups['master'][0]
+      when:
+        - inventory_hostname == groups['master'][0]
+        - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
 
     - name: Prepare PostgreSQL | check PostgreSQL is started
       become: true
@@ -946,9 +948,11 @@
             value: "{{ patroni_superuser_password }}"
         state: present
       when: hostvars[groups['master'][0]]['postgresql_user_result'] is changed
-  when: patroni_cluster_bootstrap_method != "initdb" and
-    (pgbackrest_install|bool or wal_g_install|bool) and
-    (existing_pgcluster is not defined or not existing_pgcluster|bool)
+  when:
+    - patroni_cluster_bootstrap_method != "initdb"
+    - (pgbackrest_install | bool or wal_g_install | bool)
+    - (existing_pgcluster is not defined or not existing_pgcluster | bool)
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   become: true
   become_user: postgres
   tags: patroni, point_in_time_recovery

--- a/automation/roles/pgbouncer/tasks/config.yml
+++ b/automation/roles/pgbouncer/tasks/config.yml
@@ -77,6 +77,6 @@
       when: exists_func_user.stdout == "f"
   when:
     - pgbouncer_auth_user | bool
-    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster leader
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
     - inventory_hostname == groups['master'][0] or (groups['primary'] is defined and inventory_hostname in groups['primary'])
   tags: pgbouncer, pgbouncer_conf, pgbouncer_auth_query

--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -17,5 +17,7 @@
     state: present
   ignore_errors: true
   loop: "{{ postgresql_databases | flatten(1) }}"
-  when: postgresql_databases is defined and postgresql_databases | length > 0
+  when:
+    - postgresql_databases | default('') | length > 0
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_databases

--- a/automation/roles/postgresql_extensions/tasks/main.yml
+++ b/automation/roles/postgresql_extensions/tasks/main.yml
@@ -14,6 +14,6 @@
   ignore_errors: true
   loop: "{{ postgresql_extensions | flatten(1) }}"
   when:
-    - postgresql_extensions is defined
-    - postgresql_extensions | length > 0
+    - postgresql_extensions | default('') | length > 0
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_extensions

--- a/automation/roles/postgresql_privs/tasks/main.yml
+++ b/automation/roles/postgresql_privs/tasks/main.yml
@@ -19,5 +19,5 @@
     - postgresql_privs | default('') | length > 0
     - item.role | default('') | length > 0
     - item.db | default('') | length > 0
-    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster leader
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_privs

--- a/automation/roles/postgresql_schemas/tasks/main.yml
+++ b/automation/roles/postgresql_schemas/tasks/main.yml
@@ -11,5 +11,7 @@
     state: present
   ignore_errors: true
   loop: "{{ postgresql_schemas | flatten(1) }}"
-  when: postgresql_schemas is defined and postgresql_schemas | length > 0
+  when:
+    - postgresql_schemas | default('') | length > 0
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_schemas

--- a/automation/roles/postgresql_users/tasks/main.yml
+++ b/automation/roles/postgresql_users/tasks/main.yml
@@ -20,7 +20,7 @@
   when:
     - postgresql_users | default('') | length > 0
     - item.password | default('') | length > 0 # Ensure the password is not empty
-    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster leader
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_users
 
 - name: Grant roles to users
@@ -39,5 +39,5 @@
   when:
     - postgresql_users | default('') | length > 0
     - item.role | default('') | length > 0
-    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster leader
+    - patroni_standby_cluster.host | default('') | length < 1 # do not perform on the Standby Cluster
   tags: postgresql_users


### PR DESCRIPTION
Issue: https://github.com/vitabaks/autobase/issues/1083

Skip tasks that require write access—such as user creation or password resets—when deploying the Standby Cluster, because these clusters are read-only and such operations will fail.