### PR TITLE
Allow adjusting logging parameters, even when patroni_log_destination is not logfile

### DIFF
--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -5,20 +5,20 @@ scope: {{ patroni_cluster_name }}
 name: {{ ansible_hostname }}
 namespace: /{{ patroni_etcd_namespace | default('service') }}
 
-{% if patroni_log_destination == 'logfile' %}
 log:
   level: {{ patroni_log_level |upper }}
   traceback_level: {{ patroni_log_traceback_level |upper }}
   format: {{ patroni_log_format |quote }}
   dateformat: {{ patroni_log_dateformat |quote }}
   max_queue_size: {{ patroni_log_max_queue_size |int }}
+  {% if patroni_log_destination == 'logfile' %}
   dir: {{ patroni_log_dir }}
   file_num: {{ patroni_log_file_num |int }}
   file_size: {{ patroni_log_file_size |int }}
+  {% endif %}
   loggers:
     patroni.postmaster: {{ patroni_log_loggers_patroni_postmaster |upper }}
     urllib3: {{ patroni_log_loggers_urllib3 |upper }}
-{% endif %}
 
 restapi:
   listen: {{ patroni_restapi_listen_addr }}:{{ patroni_restapi_port }}


### PR DESCRIPTION
Logging configuration is no longer skipped when logging to stderr.

Resolves: #1222