### PR TITLE
Always separate pg_hba.conf parameters with space

### DIFF
--- a/automation/roles/patroni/templates/pg_hba.conf.j2
+++ b/automation/roles/patroni/templates/pg_hba.conf.j2
@@ -85,7 +85,7 @@
 
 # TYPE      DATABASE                 USER                     ADDRESS                  METHOD
 {% for client in postgresql_pg_hba %}
-  {{ client.type.ljust(10) |default('{% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}') }}{{ client.database.ljust(25) |default('all') }}{{ client.user.ljust(25) |default('all') }}{{ client.address.ljust(25) |default('') }}{{ client.method |default('md5') }} {{ client.options |default(None) }}
+  {{ client.type.ljust(9) |default('{% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}') }} {{ client.database.ljust(24) |default('all') }} {{ client.user.ljust(24) |default('all') }} {{ client.address.ljust(24) |default('') }} {{ client.method |default('md5') }} {{ client.options |default(None) }}
 {% endfor %}
 {% for host in groups['postgres_cluster'] %}
   {% if tls_cert_generate | default(false) | bool %}hostssl{% else %}host{% endif %}      all                      all                      {{ hostvars[host]['patroni_bind_address'] | default(hostvars[host]['bind_address'], true) }}/32         {{ postgresql_password_encryption_algorithm }}


### PR DESCRIPTION
This template update ensures there is at least 1 space between parameters in pg_hba.conf . This is crucial  when parameter exceeds predefined number of characters (25 in case of IP address). Having a space prevents specifically a situation when a long IPv6 address concatenates with client.method, resulting in invalid pg_hba.conf.

Fixes: #1232