### PR TITLE
Don't change permissions for the log directory when not needed

### DIFF
--- a/automation/roles/patroni/tasks/config.yml
+++ b/automation/roles/patroni/tasks/config.yml
@@ -15,7 +15,7 @@
     owner: postgres
     group: postgres
     state: directory
-    mode: "0750"
+    mode: "u+rwx,g+rx"
   when: patroni_log_destination == 'logfile'
   tags: patroni
 
@@ -23,9 +23,8 @@
   ansible.builtin.file:
     path: "{{ postgresql_log_dir }}"
     owner: postgres
-    group: postgres
     state: directory
-    mode: "0700"
+    mode: "u+rwx"
   tags: patroni
 
 - name: Update patroni config file


### PR DESCRIPTION
Don't change permissions for the log directory when not needed

This change ensures that group and other permissions on the log 
directory aren't changed by autobase, when not needed.

Resolves: #1280