### PR TITLE
Improve Patroni leader health check logic

### DIFF
--- a/automation/playbooks/config_pgcluster.yml
+++ b/automation/playbooks/config_pgcluster.yml
@@ -103,7 +103,7 @@
         name: "{{ item }}"
         groups: secondary
         postgresql_exists: true
-      when: hostvars[item]['patroni_leader_result']['status'] != 200
+      when: hostvars[item]['patroni_leader_result']['status'] == 503
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       check_mode: false
@@ -113,7 +113,7 @@
         msg:
           - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
           - "Cluster Leader: {{ ansible_hostname }}"
-      when: inventory_hostname in groups['primary']
+      when: inventory_hostname in groups['primary'] | default([])
 
     # if 'cloud_provider' is 'aws', 'gcp', or 'azure'
     # set_fact: 'pgbackrest_install' to configure Postgres backups (TODO: Add the ability to configure backups in the UI)

--- a/automation/playbooks/pg_upgrade.yml
+++ b/automation/playbooks/pg_upgrade.yml
@@ -60,7 +60,7 @@
       ansible.builtin.add_host:
         name: "{{ item }}"
         groups: secondary
-      when: hostvars[item]['patroni_leader_result']['status'] != 200
+      when: hostvars[item]['patroni_leader_result']['status'] == 503
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
 
@@ -69,7 +69,7 @@
         msg:
           - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
           - "Cluster Leader: {{ ansible_hostname }}"
-      when: inventory_hostname in groups['primary']
+      when: inventory_hostname in groups['primary'] | default([])
   tags:
     - always
 

--- a/automation/playbooks/update_pgcluster.yml
+++ b/automation/playbooks/update_pgcluster.yml
@@ -66,7 +66,7 @@
       ansible.builtin.add_host:
         name: "{{ item }}"
         groups: secondary
-      when: hostvars[item]['patroni_leader_result']['status'] != 200
+      when: hostvars[item]['patroni_leader_result']['status'] == 503
       loop: "{{ groups['postgres_cluster'] }}"
       changed_when: false
       tags: always
@@ -76,7 +76,7 @@
         msg:
           - "Cluster Name: {{ patroni_cluster_name | default('postgres-cluster') }}"
           - "Cluster Leader: {{ ansible_hostname }}"
-      when: inventory_hostname in groups['primary']
+      when: inventory_hostname in groups['primary'] | default([])
       tags: always
 
 - name: "(1/4) PRE-UPDATE: Perform pre-update tasks"


### PR DESCRIPTION
Updated the health check to fail only if no healthy Patroni leader node is detected, using a more robust condition.

The error message now provides clearer instructions for troubleshooting cluster status and REST API connectivity.