### PR TITLE
Update etcd version to 3.5.23

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -117,7 +117,7 @@ dcs_exists: false # or 'true' if you do not want Autobase to deploy and manage e
 
 # if dcs_type: "etcd" and dcs_exists: false
 # renovate: datasource=github-releases depName=etcd-io/etcd extractVersion=^v(?<version>.*)$
-etcd_version: 3.5.21
+etcd_version: 3.5.23
 etcd_conf_dir: "/etc/etcd"
 etcd_data_dir: "/var/lib/etcd"
 etcd_cluster_name: "etcd-{{ patroni_cluster_name }}" # ETCD_INITIAL_CLUSTER_TOKEN


### PR DESCRIPTION
Bumps the default etcd_version from 3.5.21 to 3.5.23 in the defaults.

https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md