### PR TITLE
Introduce new option disable_logrotate_for_postgresql

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -1047,6 +1047,10 @@ cron_jobs: []
 #    weekday: "*"
 #    job: "echo 'example job two command'"
 
+# Configure removal of the logrotate configuration file /etc/logrotate.d/postgresql-common
+# when set to true, PostgreSQL log will NOT be rotated by logrotate.
+disable_logrotate_for_postgresql: true # false => do not remove /etc/logrotate.d/postgresql-common, log will be rotated.
+
 # Configure mount points in /etc/fstab and mount the file system (if 'mount.src' is defined)
 mount:
   - path: "/pgdata"

--- a/automation/roles/packages/tasks/main.yml
+++ b/automation/roles/packages/tasks/main.yml
@@ -162,6 +162,7 @@
       ansible.builtin.file:
         dest: /etc/logrotate.d/postgresql-common
         state: absent
+      when: disable_logrotate_for_postgresql | bool
 
     - name: Install PostgreSQL packages
       ansible.builtin.apt:


### PR DESCRIPTION
When set disable_logrotate_for_postgresql: false
The new configuration option prevents removal of
/etc/logrotate.d/postgresql-common

Especially useful to keep the default behavior

Resolves: #1316