### PR TITLE
Set default nameservers to empty list

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -836,9 +836,9 @@ netdata_conf:
 ############################################################
 
 # DNS servers (/etc/resolv.conf)
-nameservers:
-  - "1.1.1.1" # Cloudflare DNS (primary)
-  - "8.8.8.8" # Google DNS (secondary)
+nameservers: []
+#  - "1.1.1.1" # Cloudflare DNS (primary)
+#  - "8.8.8.8" # Google DNS (secondary)
 
 # /etc/hosts (optional)
 etc_hosts: []


### PR DESCRIPTION
The default `nameservers` variable is now an empty list instead of specifying Cloudflare and Google DNS. This allows for more flexible configuration and avoids hardcoding external DNS servers.

Fixed: https://github.com/vitabaks/autobase/issues/1278