### PR TITLE
Do not set tags: nosync when sync_priority is defined

### DIFF
--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -267,7 +267,7 @@ tags:
   {{ patroni_tags | replace(" ", "") | replace("=", ": ") | replace(",", "\n  ") }}
 {% endif %}
 {% set normalized_tags = patroni_tags | default('') | replace(" ", "") %}
-{% if 'nosync=' not in normalized_tags %}
+{% if 'nosync=' not in normalized_tags and 'sync_priority=' not in normalized_tags %}
   nosync: false
 {% endif %}
 {% if 'noloadbalance=' not in normalized_tags %}


### PR DESCRIPTION
nosync and sync_priority settings are mutually exclusive, update the template to define nosync only when nosync and sync_priority is not defined.

Resolves: #1341