### PR TITLE
fix: use appropriate environment variable to pass the auth token to the UI app

### DIFF
--- a/console/docker-compose.yml
+++ b/console/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       autobase-console-api:
         condition: service_healthy
     environment:
-      - PG_CONSOLE_AUTHORIZATION_TOKEN=${AUTH_TOKEN}
+      - VITE_AUTH_TOKEN=${AUTH_TOKEN}
       - PG_CONSOLE_API_HOST=autobase-console-api
     networks:
       - autobase


### PR DESCRIPTION
Fix for https://github.com/vitabaks/autobase/issues/1354