### PR TITLE
fix: remove export from `/etc/environment` entries

### DIFF
--- a/automation/roles/locales/tasks/main.yml
+++ b/automation/roles/locales/tasks/main.yml
@@ -74,8 +74,8 @@
         group: root
         mode: "0644"
       loop:
-        - { regexp: "LANG=", line: "export LANG={{ locale }}" }
-        - { regexp: "LC_ALL=", line: "export LC_ALL={{ locale }}" }
+        - { regexp: "LANG=", line: "LANG={{ locale }}" }
+        - { regexp: "LC_ALL=", line: "LC_ALL={{ locale }}" }
       loop_control:
         label: "{{ item.line }}"
       when: ansible_os_family == "RedHat"


### PR DESCRIPTION
`pam_env` doesn't understand shell syntax. Entries in `/etc/environment` should not have `export` prefixes.