### PR TITLE
fix(cloud): encode string secrets without extra quotes

### DIFF
--- a/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
+++ b/console/ui/src/shared/lib/clusterValuesTransformFunctions.ts
@@ -522,19 +522,24 @@ const convertObjectValueToBase64Format = (object: Record<string, unknown>): stri
     return acc;
   }, []);
 
-const getRequestCloudParams = (values, secretsInfo, customExtraVars) => ({
-  envs: convertObjectValueToBase64Format({
-    ...Object.fromEntries(
-      Object.entries({
-        ...secretsInfo,
-      }).filter(([key, value]) => SECRET_MODAL_CONTENT_BODY_FORM_FIELDS?.[key] && value),
-    ),
-  }),
-  extra_vars: customExtraVars ?? {
-    ...getBaseClusterExtraVars(values),
-    ...getCloudProviderExtraVars(values),
-  },
-});
+const getRequestCloudParams = (values, secretsInfo, customExtraVars) => {
+  const secretsObject = Object.fromEntries(
+    Object.entries({
+      ...secretsInfo,
+    }).filter(([key, value]) => SECRET_MODAL_CONTENT_BODY_FORM_FIELDS?.[key] && value),
+  );
+
+  return {
+    envs:
+      values[CLUSTER_FORM_FIELD_NAMES.PROVIDER]?.code === PROVIDERS.GCP
+        ? convertObjectValueToBase64Format(secretsObject)
+        : Object.entries(secretsObject).map(([key, value]) => `${key}=${value}`),
+    extra_vars: customExtraVars ?? {
+      ...getBaseClusterExtraVars(values),
+      ...getCloudProviderExtraVars(values),
+    },
+  };
+};
 
 const getRequestLocalMachineParams = (values, secretId, customExtraVars) => ({
   envs: convertObjectValueToBase64Format(getLocalMachineEnvs(values, secretId)),


### PR DESCRIPTION
1. Refactored `convertObjectValueToBase64Format` to handle string values without extra quotes.
This ensures base64-decoded output is cleaner and more consistent for downstream processing.
2. Use convertObjectValueToBase64Format only for the Google Cloud provider.