### PR TITLE
Add error ignore option to chronyd restart handler

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -8,9 +8,10 @@
       ansible.builtin.set_fact:
         ansible_become_method: su # Override become_method
         firewall_enabled_at_boot: false
-        firewall_enable_ipv6: false # Added to prevent test failures in CI.
-        swap_file_create: false # Added to prevent test failures in CI.
-        sysctl_set: false # Added to prevent test failures in CI.
+        firewall_enable_ipv6: false # to prevent test failures in CI
+        swap_file_create: false # to prevent test failures in CI
+        sysctl_set: false # to prevent test failures in CI
+        chronyd_ignore_errors: true # to prevent failures in CI
         nameservers: ["8.8.8.8", "9.9.9.9"]
         timezone: "Etc/UTC"
         with_haproxy_load_balancing: "{{ [true, false] | random }}"

--- a/automation/molecule/pg_upgrade/converge.yml
+++ b/automation/molecule/pg_upgrade/converge.yml
@@ -8,9 +8,10 @@
       ansible.builtin.set_fact:
         ansible_become_method: su # Override become_method
         firewall_enabled_at_boot: false
-        firewall_enable_ipv6: false # Added to prevent test failures in CI.
-        swap_file_create: false # Added to prevent test failures in CI.
-        sysctl_set: false # Added to prevent test failures in CI.
+        firewall_enable_ipv6: false # to prevent test failures in CI
+        swap_file_create: false # to prevent test failures in CI
+        sysctl_set: false # to prevent test failures in CI
+        chronyd_ignore_errors: true # to prevent failures in CI
         nameservers: ["8.8.8.8", "9.9.9.9"]
         timezone: "Etc/UTC"
         with_haproxy_load_balancing: true

--- a/automation/roles/ntp/handlers/main.yml
+++ b/automation/roles/ntp/handlers/main.yml
@@ -18,5 +18,5 @@
     name: chronyd
     enabled: true
     state: restarted
-  ignore_errors: "{{ chronyd_ignore_errors | default(true) }}" # to prevent failures in CI
+  ignore_errors: "{{ chronyd_ignore_errors | default(false) }}"
   listen: "restart chronyd"


### PR DESCRIPTION
Introduces the 'ignore_errors' parameter to the chronyd restart handler, defaulting to true. This change helps prevent CI failures when restarting chronyd.

Periodically, an error occurs in CI when running tests on CentOS Stream 10, example: https://github.com/vitabaks/autobase/actions/runs/19912928808/job/57085513062
```
Introduces the 'ignore_errors' parameter to the chronyd restart handler, defaulting to true. This change helps prevent CI failures when restarting chronyd.
```

This fix allows to ignore this error.

We have also tested the deployment on servers with CentOS Stream 10 and it works without errors: https://demo.autobase.tech/operations/187/log