### PR TITLE
fix(patroni): use `systemd` privilege escalation instead of sudo for `watchdog` setup

### DIFF
--- a/automation/roles/patroni/templates/patroni.service.j2
+++ b/automation/roles/patroni/templates/patroni.service.j2
@@ -19,13 +19,13 @@ EnvironmentFile=-/etc/patroni_env.conf
 # StandardOutput=syslog
 
 # Pre-commands to start watchdog device
-# Uncomment if watchdog is part of your patroni setup
+# Uses '+' prefix to run as root without sudo (avoids SELinux init_t -> sudo_exec_t denial)
 {% if patroni_watchdog_mode in ['automatic', 'required']  %}
-ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
-ExecStartPre=-/usr/bin/sudo /bin/chown postgres {{ patroni_watchdog_device }}
+ExecStartPre=-+/sbin/modprobe softdog
+ExecStartPre=-+/bin/chown postgres {{ patroni_watchdog_device }}
 {% else %}
-#ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
-#ExecStartPre=-/usr/bin/sudo /bin/chown postgres {{ patroni_watchdog_device }}
+#ExecStartPre=-+/sbin/modprobe softdog
+#ExecStartPre=-+/bin/chown postgres {{ patroni_watchdog_device }}
 {% endif %}
 
 # Start the patroni process


### PR DESCRIPTION
## Problem

On systems running SELinux in enforcing mode with systemd 257+, the Patroni service fails to execute the watchdog setup commands:

```
  patroni.service: Unable to locate executable '/usr/bin/sudo': Permission denied
  ExecStartPre=/usr/bin/sudo /sbin/modprobe softdog (code=exited, status=203/EXEC)
```

This occurs because SELinux denies the `init_t` domain (systemd) from executing binaries with the `sudo_exec_t` context.

## Solution

Replace `sudo` with systemd's native privilege escalation using the + prefix in `ExecStartPre`. This tells `systemd` to run the command with full root privileges, bypassing the `User=postgres` restriction for just that command.

Verified on AlmaLinux 10 with systemd 257 and SELinux enforcing.

- Before: status=203/EXEC (permission denied)
- After: status=0/SUCCESS
