### PR TITLE
Run pgBackRest cron jobs only on primary to avoid lock contention

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -792,8 +792,7 @@ pgbackrest_cron_jobs:
     day: "*"
     month: "*"
     weekday: "0"
-    job: "pgbackrest --stanza={{ pgbackrest_stanza }} --type=full backup"
-    # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --stanza={{ pgbackrest_stanza }} --type=full backup; fi"
+    job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --stanza={{ pgbackrest_stanza }} --type=full backup; fi"
   - name: "pgBackRest: Diff Backup"
     file: "/etc/cron.d/pgbackrest-{{ patroni_cluster_name }}"
     user: "postgres"
@@ -802,8 +801,7 @@ pgbackrest_cron_jobs:
     day: "*"
     month: "*"
     weekday: "1-6"
-    job: "pgbackrest --stanza={{ pgbackrest_stanza }} --type=diff backup"
-    # job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --stanza={{ pgbackrest_stanza }} --type=diff backup; fi"
+    job: "if [ $(psql -tAXc 'select pg_is_in_recovery()') = 'f' ]; then pgbackrest --stanza={{ pgbackrest_stanza }} --type=diff backup; fi"
 
 # PITR mode (if patroni_cluster_bootstrap_method: "pgbackrest" or "wal-g"):
 # 1) The database cluster directory will be cleaned (for "wal-g") or overwritten (for "pgbackrest" --delta restore).


### PR DESCRIPTION
This PR updates the pgBackRest full/diff cron commands to execute only on the primary node. This prevents concurrent pgBackRest runs on replicas and eliminates occasional lock acquisition errors.

Even though the cron job is triggered on the primary, the backup workload is still performed on a standby (backup-standby=y).

Fixed:

```
-------------------PROCESS START-------------------
2025-12-17 05:00:02.000 P00   INFO: backup command begin 2.57.0: --backup-standby=y --exec-id=1768547-cddd1b79 --log-level-console=info --log-level-file=detail --log-path=/var/log/pgbackrest --pg2-host=10.0.1.1 --pg3-host=10.0.1.2 --pg1-path=/pgdata/18/main --pg2-path=/pgdata/18/main --pg3-path=/pgdata/18/main --pg2-port=5432 --pg3-port=5432 --process-max=8 --repo1-block --repo1-bundle --repo1-path=/pgbackrest --repo1-retention-full=14 --repo1-retention-full-type=time --repo1-s3-bucket=pg-prod-cluster-backup --repo1-s3-endpoint=https://nbg1.your-objectstorage.com --repo1-s3-key=<redacted> --repo1-s3-key-secret=<redacted> --repo1-s3-region=nbg1 --repo1-s3-uri-style=path --repo1-type=s3 --no-resume --stanza=pg-prod-cluster --start-fast --stop-auto --type=diff
2025-12-17 05:00:03.656 P00   WARN: unable to check pg2: [LockAcquireError] raised from remote-0 ssh protocol on '10.0.1.1': unable to acquire lock on file '/tmp/pgbackrest/pg-prod-cluster-backup-1.lock': Resource temporarily unavailable
                                    HINT: is another pgBackRest process running?
2025-12-17 05:00:03.931 P00   WARN: unable to check pg3: [LockAcquireError] raised from remote-0 ssh protocol on '10.0.1.2': unable to acquire lock on file '/tmp/pgbackrest/pg-prod-cluster-backup-1.lock': Resource temporarily unavailable
                                    HINT: is another pgBackRest process running?
2025-12-17 05:00:03.931 P00  ERROR: [056]: unable to find primary cluster - cannot proceed
                                    HINT: are all available clusters in recovery?
2025-12-17 05:00:03.931 P00 DETAIL: statistics: {"http.client":{"total":1},"http.request":{"total":5},"http.session":{"total":1},"socket.client":{"total":1},"socket.retry":{"total":1},"socket.session":{"total":1},"tls.client":{"total":1},"tls.session":{"total":1}}
2025-12-17 05:00:03.931 P00   INFO: backup command end: aborted with exception [056]
2025-12-17 05:00:03.931 P00   WARN: remote-0 process on '10.0.1.1' terminated unexpectedly [0]
```