### PR TITLE
Update: Makefile variables from recursive (=) to simple (:=) assignment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,20 +11,20 @@ SHELL:=/bin/bash
 .SHELLFLAGS = -eu -o pipefail -c
 
 # Makefile colors config
-bold=$(shell tput bold)
-normal=$(shell tput sgr0)
-errorTitle=$(shell tput setab 1 && tput bold && echo '\n')
-recommendation=$(shell tput setab 4)
-underline=$(shell tput smul)
-reset=$(shell tput -Txterm sgr0)
-black=$(shell tput setaf 0)
-red=$(shell tput setaf 1)
-green=$(shell tput setaf 2)
-yellow=$(shell tput setaf 3)
-blue=$(shell tput setaf 4)
-magenta=$(shell tput setaf 5)
-cyan=$(shell tput setaf 6)
-white=$(shell tput setaf 7)
+bold:=$(shell tput bold)
+normal:=$(shell tput sgr0)
+errorTitle:=$(shell tput setab 1 && tput bold && echo '\n')
+recommendation:=$(shell tput setab 4)
+underline:=$(shell tput smul)
+reset:=$(shell tput -Txterm sgr0)
+black:=$(shell tput setaf 0)
+red:=$(shell tput setaf 1)
+green:=$(shell tput setaf 2)
+yellow:=$(shell tput setaf 3)
+blue:=$(shell tput setaf 4)
+magenta:=$(shell tput setaf 5)
+cyan:=$(shell tput setaf 6)
+white:=$(shell tput setaf 7)
 
 define HEADER
 How to use me:


### PR DESCRIPTION
## Makefile variables Change

Makefile variables from recursive (`=`) to simple (`:=`) assignment.

Using `:=` evaluates the tput commands once at parse time instead of re-executing them every time the variable is referenced.

This has a few benefits:

- Performance: avoids repeatedly spawning `tput` subprocesses during a build
- Determinism: ensures color values are consistent throughout the Make run
- Clarity of intent: these values are constants, not dynamic expressions
- Fewer side effects: prevents unexpected behavior if terminal state changes mid-build

Overall, this makes the Makefile more efficient, predictable, and easier to reason about.


Additionally, with recursive (`=`) assignment, running commands like `make help` could appear to hang or remain idle, and `make help --debug=verbose` shows repeated “`not recursively expanding … to export to shell function`” messages, indicating Make repeatedly tries (and fails) to expand these variables; switching to `:=` eliminates this behavior.

```bash
Makefile:19: not recursively expanding reset to export to shell function
Makefile:17: not recursively expanding recommendation to export to shell function
Makefile:14: not recursively expanding bold to export to shell function
Makefile:18: not recursively expanding underline to export to shell function
Makefile:26: not recursively expanding cyan to export to shell function
Makefile:26: not recursively expanding cyan to export to shell function
Makefile:19: not recursively expanding reset to export to shell function
Makefile:25: not recursively expanding magenta to export to shell function
Makefile:21: not recursively expanding red to export to shell function
Makefile:15: not recursively expanding normal to export to shell function
Makefile:27: not recursively expanding white to export to shell function
Makefile:22: not recursively expanding green to export to shell function
Makefile:24: not recursively expanding blue to export to shell function
Makefile:15: not recursively expanding normal to export to shell function
Makefile:27: not recursively expanding white to export to shell function
Makefile:22: not recursively expanding green to export to shell function
Makefile:24: not recursively expanding blue to export to shell functi
```
