### PR TITLE
Set default values for pgbackrest repo1-path and repo1-type

### DIFF
--- a/automation/roles/pgbackrest/tasks/stanza_create.yml
+++ b/automation/roles/pgbackrest/tasks/stanza_create.yml
@@ -55,10 +55,18 @@
       delegate_to: "{{ pgbackrest_delegate }}"
       run_once: true
       ansible.builtin.set_fact:
-        repo1_path: "{{ pgbackrest_server_conf['global'] | selectattr('option', 'equalto', 'repo1-path') | map(attribute='value') | list | first }}"
+        repo1_path: >-
+          {{
+            (pgbackrest_server_conf['global']
+              | selectattr('option', 'equalto', 'repo1-path')
+              | map(attribute='value')
+              | list
+              | first
+            ) | default('/var/lib/pgbackrest', true)
+          }}
       when: (pgbackrest_repo_type | default('posix')) | lower == 'posix'
 
-    - name: "Make sure the {{ repo1_path | default('') }} directory exists"
+    - name: "Make sure the {{ repo1_path | default('/var/lib/pgbackrest') }} directory exists"
       delegate_to: "{{ pgbackrest_delegate }}"
       run_once: true
       ansible.builtin.file:


### PR DESCRIPTION
Adds default values for repo1-path ('/var/lib/pgbackrest') and repo1-type ('posix') in stanza_create.yml to ensure proper directory creation and configuration when options are missing.

Fixes https://github.com/vitabaks/autobase/discussions/1412