### PR TITLE
Set --auth-local for the default pg_hba.conf at bootstrap

### DIFF
--- a/automation/roles/patroni/tasks/main.yml
+++ b/automation/roles/patroni/tasks/main.yml
@@ -442,6 +442,8 @@
         -p {{ postgresql_port }}
         -e {{ postgresql_encoding }}
         --locale {{ postgresql_locale }}
+        --
+        --auth-local {{ postgresql_password_encryption_algorithm }}
       register: pg_createcluster_result
       failed_when: pg_createcluster_result.rc != 0
       when: (ansible_os_family == "Debian" and


### PR DESCRIPTION
This change enables password authentication at the time of bootstrap with initdb. Required for Patroni to log-in, when patroni_superuser_username != postgres.

The pg_hba.conf is only used for the bootstrap, and is replaced as soon as the bootstrap is complete.

Resolves: #1418