### PR TITLE
Update data-checksums logic for PostgreSQL 18

### DIFF
--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -156,6 +156,8 @@ bootstrap:
     - locale: {{ postgresql_locale }}
   {% if postgresql_data_checksums|bool %}
     - data-checksums
+  {% elif postgresql_version | int >= 18 %}
+    - no-data-checksums
   {% endif %}
 
   pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'

--- a/automation/roles/upgrade/tasks/initdb.yml
+++ b/automation/roles/upgrade/tasks/initdb.yml
@@ -101,6 +101,8 @@
     {% endif %}
     {% if (hostvars[groups['primary'][0]].pg_settings.stdout | from_json).data_checksums == 'on' %}
     --data-checksums
+    {% elif pg_new_version | int >= 18 and (hostvars[groups['primary'][0]].pg_settings.stdout | from_json).data_checksums == 'off' %}
+    --no-data-checksums
     {% endif %}
   when:
     - ansible_os_family == "Debian"
@@ -126,6 +128,8 @@
     {% endif %}
     {% if (pg_settings.stdout | from_json).data_checksums == 'on' %}
     --data-checksums
+    {% elif pg_new_version | int >= 18 and (hostvars[groups['primary'][0]].pg_settings.stdout | from_json).data_checksums == 'off' %}
+    --no-data-checksums
     {% endif %}
   when:
     - inventory_hostname in groups['primary']


### PR DESCRIPTION
With data-checksums are now  enabled by default, it is necessary to update the logic for initdb and upgrade if PostgreSQL >= 18.

Resolves: #1420