### PR TITLE
Fix: Do not add the nofailover tag if failover_priority is set

### DIFF
--- a/automation/roles/patroni/templates/patroni.yml.j2
+++ b/automation/roles/patroni/templates/patroni.yml.j2
@@ -287,7 +287,7 @@ tags:
 {% if 'noloadbalance=' not in normalized_tags %}
   noloadbalance: false
 {% endif %}
-{% if 'nofailover=' not in normalized_tags %}
+{% if 'nofailover=' not in normalized_tags and 'failover_priority=' not in normalized_tags %}
   nofailover: false
 {% endif %}
 {% if 'clonefrom=' not in normalized_tags %}


### PR DESCRIPTION
Modified the condition for setting the `nofailover` tag to also check for the presence of `failover_priority` in normalized_tags. This prevents nofailover from being set when failover_priority is specified.

Fixed:

```
fatal: [10.**.**.**]: FAILED! => {"changed": false, "checksum": "d7b7e00a984639baa3f6481aa00a26b37a6e1c18", "exit_status": 1, "msg": "failed to validate", "stderr": "tags  Multiple of ('nofailover', 'failover_priority') provided\n", "stderr_lines": ["tags  Multiple of ('nofailover', 'failover_priority') provided"], "stdout": "", "stdout_lines": []}
```