### PR TITLE
Allow disabling the softdog

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -585,6 +585,9 @@ patroni_log_loggers_urllib3: warning # or 'debug'
 
 patroni_watchdog_mode: automatic # or 'off', 'required'
 patroni_watchdog_device: /dev/watchdog
+# Whether to automatically configure the softdog
+# If false, ensure that /dev/watchdog is available and can be used by the postgres user.
+patroni_watchdog_configure_softdog: true
 
 patroni_postgresql_use_pg_rewind: true # or 'false'
 # try to use pg_rewind on the former leader when it joins cluster as a replica.

--- a/automation/roles/patroni/templates/patroni.service.j2
+++ b/automation/roles/patroni/templates/patroni.service.j2
@@ -20,7 +20,7 @@ EnvironmentFile=-/etc/patroni_env.conf
 
 # Pre-commands to start watchdog device
 # Uses '+' prefix to run as root without sudo (avoids SELinux init_t -> sudo_exec_t denial)
-{% if patroni_watchdog_mode in ['automatic', 'required']  %}
+{% if patroni_watchdog_configure_softdog | default('true') and patroni_watchdog_mode in ['automatic', 'required'] %}
 ExecStartPre=-+/sbin/modprobe softdog
 ExecStartPre=-+/bin/chown postgres {{ patroni_watchdog_device }}
 {% else %}


### PR DESCRIPTION
When patroni_watchdog_configure_softdog: false, softdog isn't configured. This prevents creation of another watchdog, when hardware watchdog is present.

Resolves: #1464