### PR TITLE
Bump etcd version to 3.5.27

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -121,7 +121,7 @@ dcs_exists: false # or 'true' if you do not want Autobase to deploy and manage e
 
 # if dcs_type: "etcd" and dcs_exists: false
 # renovate: datasource=github-releases depName=etcd-io/etcd extractVersion=^v(?<version>.*)$
-etcd_version: 3.5.25
+etcd_version: 3.5.27
 # Note: when etcd_installation_method: "rpm", the etcd package is installed from pgdg-rhel-extras,
 # unless install_postgresql_repo or install_postgresql_repo_extras are set to false.
 etcd_installation_method: "binary" # binary -> install from repo such as https://github.com, "{{ pkg_type }}" -> install from apt or yum repository


### PR DESCRIPTION
Update the default `etcd_version` in automation/roles/common/defaults/main.yml from 3.5.25 to 3.5.27 so new deployments use the newer etcd 3.5.27 release.