### PR TITLE
fix: strip quotes when reading passwords back from patroni.yml

### DIFF
--- a/automation/roles/pre_checks/tasks/passwords.yml
+++ b/automation/roles/pre_checks/tasks/passwords.yml
@@ -29,7 +29,7 @@
       ansible.builtin.shell: |
         set -o pipefail;
         grep -A10 "authentication:" /etc/patroni/patroni.yml | \
-        grep -A3 "superuser" | grep "password:" | awk '{ print $2 }' | tail -n 1
+        grep -A3 "superuser" | grep "password:" | awk '{ gsub(/"/, "", $2); print $2 }' | tail -n 1
       args:
         executable: /bin/bash
       delegate_to: "{{ groups[group_name][0] }}"
@@ -41,7 +41,7 @@
       ansible.builtin.shell: |
         set -o pipefail;
         grep -A10 "authentication:" /etc/patroni/patroni.yml | \
-        grep -A3 "replication" | grep "password:" | awk '{ print $2 }' | tail -n 1
+        grep -A3 "replication" | grep "password:" | awk '{ gsub(/"/, "", $2); print $2 }' | tail -n 1
       args:
         executable: /bin/bash
       delegate_to: "{{ groups[group_name][0] }}"
@@ -53,7 +53,7 @@
       ansible.builtin.shell: |
         set -o pipefail;
         grep -A10 "restapi:" /etc/patroni/patroni.yml | \
-        grep -A3 "authentication" | grep "password:" | awk '{ print $2 }' | tail -n 1
+        grep -A3 "authentication" | grep "password:" | awk '{ gsub(/"/, "", $2); print $2 }' | tail -n 1
       args:
         executable: /bin/bash
       delegate_to: "{{ groups[group_name][0] }}"


### PR DESCRIPTION
## Summary

- Commit add3eaf added double quotes around password values in `patroni.yml.j2` to prevent YAML type coercion
- The password extraction in `pre_checks/tasks/passwords.yml` uses `awk '{ print $2 }'` which now returns the value **with** surrounding quotes (e.g. `"mypassword"` instead of `mypassword`)
- When `config_pgcluster.yml` re-renders the template, the password variable already contains quotes, producing `password: ""value""` — invalid YAML that fails `patroni --validate-config`

## Fix

Add `gsub(/"/, "", $2)` to the three `awk` commands that extract passwords from `/etc/patroni/patroni.yml`, so quotes are stripped before the value is stored in a variable.

## How to reproduce

1. Deploy a cluster with `deploy_pgcluster.yml` (passwords get quoted in `patroni.yml`)
2. Run `config_pgcluster.yml` to reconfigure (triggers password readback from the file)
3. The `patroni.yml` template validation fails with:
   ```
   yaml.parser.ParserError: while parsing a block mapping
   expected <block end>, but found '<scalar>'
   ```

## Test plan

- [ ] Deploy a fresh cluster, then run `config_pgcluster.yml` — should succeed without YAML parse errors
- [ ] Verify passwords in `/etc/patroni/patroni.yml` are correctly quoted (single set of quotes)