### PR TITLE
fix: backup-standby=y fails on single-node clusters with dedicated backup server

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -812,7 +812,7 @@ pgbackrest_server_conf:
     - { option: "repo1-block", value: "y" }
     - { option: "archive-check", value: "y" }
     - { option: "archive-copy", value: "n" }
-    - { option: "backup-standby", value: "y" }
+    - { option: "backup-standby", value: "{{ 'y' if groups['postgres_cluster'] | length > 1 else 'n' }}" }
     - { option: "start-fast", value: "y" }
     - { option: "stop-auto", value: "y" }
     - { option: "link-all", value: "y" }


### PR DESCRIPTION
## Summary

- `pgbackrest_server_conf` hardcodes `backup-standby=y`, which tells pgbackrest to read data from a standby replica during backups
- On single-node clusters there is no standby, so backups fail with: `unable to find standby cluster - cannot proceed`
- Changed to use the same conditional already present in `auto_conf.yml`: `'y' if groups['postgres_cluster'] | length > 1 else 'n'`

## Details

The `auto_conf.yml` (used for cloud providers) already handles this correctly at lines 32, 65, 104, 143, 183. But `pgbackrest_server_conf.global` in `defaults/main.yml` (used for the dedicated backup server config) was hardcoded to `y`.

## Test plan

- [x] Deploy a single-node cluster with a dedicated pgbackrest backup server
- [x] Verify `/etc/pgbackrest/pgbackrest.conf` on the backup server contains `backup-standby=n`
- [x] Trigger a backup and confirm it completes successfully
- [ ] Deploy a multi-node cluster and verify `backup-standby=y` is still set