### PR TITLE
Add locale_provider, tablespace to postgresql_databases

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -305,7 +305,7 @@ postgresql_users:
 postgresql_databases: []
 #  - { db: "mydatabase", encoding: "UTF8", lc_collate: "ru_RU.UTF-8", lc_ctype: "ru_RU.UTF-8", owner: "mydb-user" }
 #  - { db: "mydatabase2", encoding: "UTF8", lc_collate: "ru_RU.UTF-8", lc_ctype: "ru_RU.UTF-8", owner: "mydb-user", conn_limit: "50" }
-#  - { db: "", encoding: "UTF8", lc_collate: "en_US.UTF-8", lc_ctype: "en_US.UTF-8", owner: "" }
+#  - { db: "test", encoding: "UTF8", lc_collate: "en_US.UTF-8", lc_ctype: "en_US.UTF-8", tablespace: "my_tablespace" }
 #  - { db: "", encoding: "UTF8", lc_collate: "en_US.UTF-8", lc_ctype: "en_US.UTF-8", owner: "" }
 
 # List of schemas to be created

--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -4,17 +4,21 @@
   become_user: postgres
   community.postgresql.postgresql_db:
     name: "{{ item.db }}"
-    owner: "{{ item.owner }}"
-    encoding: "{{ item.encoding }}"
-    lc_collate: "{{ item.lc_collate }}"
-    lc_ctype: "{{ item.lc_ctype }}"
+    owner: "{{ item.owner | default('') }}"
+    encoding: "{{ item.encoding | default('') }}"
+    lc_collate: "{{ item.lc_collate | default('') }}"
+    lc_ctype: "{{ item.lc_ctype | default('') }}"
+    icu_locale: "{{ item.icu_locale | default('') }}"
+    locale_provider: "{{ item.locale_provider | default('') }}" # icu or libc
+    conn_limit: "{{ item.conn_limit | default(omit) }}"
     template: "{{ item.template | default('template0') }}"
+    tablespace: "{{ item.tablespace | default('') }}"
     login_host: "127.0.0.1"
     login_port: "{{ postgresql_port }}"
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
-    conn_limit: "{{ item.conn_limit | default(omit) }}"
-    state: present
+    state: "{{ item.state | default('present') }}"
+    force: "{{ 'true' if item.state == 'absent' else 'false' }}" 
   ignore_errors: true
   loop: "{{ postgresql_databases | flatten(1) }}"
   when:

--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -18,7 +18,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
-    force: "{{ 'true' if item.state == 'absent' else 'false' }}" 
+    force: "{{ 'true' if item.state == 'absent' else 'false' }}"
   ignore_errors: true
   loop: "{{ postgresql_databases | flatten(1) }}"
   when:


### PR DESCRIPTION
In `postgresql_databases` tasks, make owner/encoding/lc_collate/lc_ctype optional with defaults, add icu_locale and locale_provider parameters, and expose tablespace. \
Make state configurable (default 'present') and set force to true when state == 'absent' to ensure removals are applied.