### PR TITLE
Add version and state support for postgresql_extensions

### DIFF
--- a/automation/roles/common/defaults/main.yml
+++ b/automation/roles/common/defaults/main.yml
@@ -327,8 +327,8 @@ postgresql_privs: []
 # List of database extensions to be created
 postgresql_extensions: []
 #  - { ext: "pg_stat_statements", db: "postgres" }
-#  - { ext: "pg_stat_statements", db: "mydatabase" }
-#  - { ext: "pg_stat_statements", db: "mydatabase", schema: "myschema" }
+#  - { ext: "pg_stat_statements", db: "mydatabase", schema: "myschema", version: "1.10" }
+#  - { ext: "pg_stat_statements", db: "test", state: "absent" }
 #  - { ext: "pg_stat_statements", db: "" }
 #  - { ext: "pg_stat_statements", db: "" }
 #  - { ext: "pg_repack", db: "" }  # postgresql-<version>-repack package is required

--- a/automation/roles/postgresql_extensions/tasks/main.yml
+++ b/automation/roles/postgresql_extensions/tasks/main.yml
@@ -5,13 +5,14 @@
   community.postgresql.postgresql_ext:
     name: "{{ item.ext | regex_replace('^pgvector', 'vector') }}"
     schema: "{{ item.schema | default(default_schema) }}"
+    version: "{{ item.version | default(omit) }}"
     cascade: "{{ item.cascade | default(true) }}"
     login_db: "{{ item.db }}"
     login_host: "127.0.0.1"
     login_port: "{{ postgresql_port }}"
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
-    state: present
+    state: "{{ item.state | default('present') }}"
   ignore_errors: true
   loop: "{{ postgresql_extensions | flatten(1) }}"
   vars:


### PR DESCRIPTION
Update `postgresql_extensions` tasks to read extension version and state from each item. Add version: "{{ item.version | default(omit) }}" so a version is passed only when specified, and change state to "{{ item.state | default('present') }}" to allow absent/removal or other states per-item.

This adds flexibility to manage extension versions and lifecycle per entry in postgresql_extensions.