### PR TITLE
Fix: Handle sequence input for pg_replication_database

### DIFF
--- a/automation/roles/upgrade/tasks/source_databases.yml
+++ b/automation/roles/upgrade/tasks/source_databases.yml
@@ -23,10 +23,13 @@
       ansible.builtin.set_fact:
         source_databases: >-
           {{
-            pg_replication_database is string
-            | ternary(
-                pg_replication_database.split(',') | map('trim') | reject('equalto', '') | list,
-                (pg_replication_database | default([], true))
-              )
+            (
+              pg_replication_database
+              if pg_replication_database is sequence and pg_replication_database is not string
+              else (pg_replication_database | default('', true) | string).split(',')
+            )
+            | map('trim')
+            | reject('equalto', '')
+            | list
           }}
   when: patroni_cluster_leader | default(false) | bool


### PR DESCRIPTION
Replace the previous ternary with an explicit check that uses `pg_replication_database` directly when it's a sequence (and not a string); otherwise cast to string, split on commas, then trim and reject empty entries. 

This normalizes pg_replication_database into a clean list and improves robustness when the variable is provided as either a list or a comma-separated string.

Fixed:

```
TASK [vitabaks.autobase.upgrade : Set variable: source_databases] ************************************************************************************************************************************************************************************************************************************************************
fatal: [172.17.104.21]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'list object' has no attribute 'split'\n\nThe error appears to be in '/Users/faseehullah/.ansible/collections/ansible_collections/vitabaks/autobase/roles/upgrade/tasks/source_databases.yml': line 22, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: \"Set variable: source_databases\"\n      ^ here\nThis one looks easy to fix. It seems that there is a value started\nwith a quote, and the YAML parser is expecting to see the line ended\nwith the same kind of quote. For instance:\n\n    when: \"ok\" in result.stdout\n\nCould be written as:\n\n   when: '\"ok\" in result.stdout'\n\nOr equivalently:\n\n   when: \"'ok' in result.stdout\"\n"}
```