### PR TITLE
Fix: Use integer default for max_replication_lag_bytes

### DIFF
--- a/automation/roles/update/tasks/pre_checks.yml
+++ b/automation/roles/update/tasks/pre_checks.yml
@@ -29,7 +29,7 @@
     - pg_replication_state.stdout | int == 0
     - not ansible_check_mode
 
-- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default('') | human_readable }})"
+- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default(0) | int | human_readable }})"
   ansible.builtin.command: >-
     {{ postgresql_bin_dir }}/psql -h 127.0.0.1 -p {{ postgresql_port }} -U {{ patroni_superuser_username }} -d postgres -tAXc
     "select pg_wal_lsn_diff(pg_current_wal_lsn(),replay_lsn) pg_lag_bytes

--- a/automation/roles/upgrade/tasks/pre_checks.yml
+++ b/automation/roles/upgrade/tasks/pre_checks.yml
@@ -318,7 +318,7 @@
     - inventory_hostname in groups['primary']
     - pg_replication_state.stdout | int == 0
 
-- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default('') | human_readable }})"
+- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default(0) | int | human_readable }})"
   ansible.builtin.command: >-
     {{ psql_command }} -tAXc "
       select pg_wal_lsn_diff(pg_current_wal_lsn(),replay_lsn) as pg_lag_bytes
@@ -349,7 +349,7 @@
     - pg_lag_bytes.stdout|int >= max_replication_lag_bytes|int
 
 # for compatibility with Postgres 9.x
-- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default('') | human_readable }})"
+- name: "[Pre-Check] Make sure there is no high replication lag (more than {{ max_replication_lag_bytes | default(0) | int | human_readable }})"
   ansible.builtin.command: >-
     {{ psql_command }} -tAXc "
       select pg_xlog_location_diff(pg_current_xlog_location(),replay_location) as pg_lag_bytes

--- a/automation/roles/upgrade/tasks/replication_slot_lag.yml
+++ b/automation/roles/upgrade/tasks/replication_slot_lag.yml
@@ -1,7 +1,7 @@
 ---
 # Check the maximum lag of the logical replication slots (blue-green deployment method)
 - block:
-    - name: "Ensure logical replication lag is no more than {{ max_replication_lag_bytes | default(0) | human_readable }}"
+    - name: "Ensure logical replication lag is no more than {{ max_replication_lag_bytes | default(0) | int | human_readable }}"
       ansible.builtin.command: >-
         {{ psql_command }} -tAXc "
         select pg_wal_lsn_diff(pg_current_wal_lsn(),confirmed_flush_lsn) as lag_bytes

--- a/automation/roles/upgrade/tasks/stop_services.yml
+++ b/automation/roles/upgrade/tasks/stop_services.yml
@@ -18,7 +18,7 @@
   delay: 10
 
 # Wait for the window to appear without high replication lag before stopping PostgreSQL
-- name: "Wait until replication lag is less than {{ max_replication_lag_bytes | default('') | human_readable }}"
+- name: "Wait until replication lag is less than {{ max_replication_lag_bytes | default(0) | int | human_readable }}"
   ansible.builtin.command: >-
     {{ psql_command }} -tAXc "
       select coalesce(max(pg_wal_lsn_diff(pg_current_wal_lsn(),replay_lsn)),1)
@@ -55,7 +55,7 @@
     - pg_lag_bytes.stdout|int >= max_replication_lag_bytes|int
 
 # for compatibility with Postgres 9.x
-- name: "Wait until replication lag is less than {{ max_replication_lag_bytes | default('') | human_readable }}"
+- name: "Wait until replication lag is less than {{ max_replication_lag_bytes | default(0) | int | human_readable }}"
   ansible.builtin.command: >-
     {{ psql_command }} -tAXc "
       select coalesce(max(pg_xlog_location_diff(pg_current_xlog_location(),replay_location)),1)


### PR DESCRIPTION
Coerce `max_replication_lag_bytes` to an integer and use a numeric default(0) in human-readable messages and checks.

Fixed:

```
FAILED! => {"msg": "Unexpected templating type error occurred on (Ensure logical replication lag is no more than {{ max_replication_lag_bytes | default(0) | human_readable }}): human_readable() failed on bad input: '>=' not supported between instances of 'str' and 'int'. human_readable()
  failed on bad input: '>=' not supported between instances of 'str' and 'int'"}
```