### PR TITLE
Fix [blue-green]: Use fixed-string grep for target lsn

### DIFF
--- a/automation/roles/upgrade/tasks/recovery_target.yml
+++ b/automation/roles/upgrade/tasks/recovery_target.yml
@@ -73,7 +73,7 @@
 
 - name: "Check the PostgreSQL log file"
   ansible.builtin.shell: >
-    grep -E "recovery stopping after WAL location (LSN)|{{ hostvars[groups['source_primary'][0]]['target_lsn'] }}" \
+    grep -E "recovery stopping after WAL location \(LSN\)|{{ hostvars[groups['source_primary'][0]]['target_lsn'] }}" \
     {{ postgresql_log_dir }}/{{ pg_log_filename.stdout }}
   args:
     executable: /bin/bash

--- a/automation/roles/upgrade/tasks/recovery_target.yml
+++ b/automation/roles/upgrade/tasks/recovery_target.yml
@@ -73,10 +73,11 @@
 
 - name: "Check the PostgreSQL log file"
   ansible.builtin.shell: >
-    grep -E "recovery stopping after WAL location \(LSN\)|{{ hostvars[groups['source_primary'][0]]['target_lsn'] }}" \
-    {{ postgresql_log_dir }}/{{ pg_log_filename.stdout }}
+    grep -F 'recovery stopping after WAL location (LSN) "{{ target_lsn }}"' {{ postgresql_log_dir }}/{{ pg_log_filename.stdout }}
   args:
     executable: /bin/bash
+  vars:
+    target_lsn: "{{ hostvars[groups['source_primary'][0]]['target_lsn'] }}"
   register: pg_log_result
   changed_when: false
   ignore_errors: true


### PR DESCRIPTION
In extended regex, (LSN) is a capture group and does not match the literal string (LSN) in the PostgreSQL log, causing the check to always fail even when recovery completed successfully.

UPD:

Replace the previous regex-based grep with grep -F to match the literal recovery message and the target LSN.