### PR TITLE
Fix: Add default for item.state in postgresql_db task

### DIFF
--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -30,6 +30,11 @@
         local_postgresql_parameters:
           - { option: "shared_buffers", value: "128MB" }
           - { option: "effective_cache_size", value: "512MB" }
+        postgresql_users:
+          - { name: "{{ pgbouncer_auth_username }}", password: "{{ pgbouncer_auth_password }}" }
+          - { name: "db1_user", password: "db1_user-pass" }
+        postgresql_databases:
+          - { db: "db1", encoding: "UTF8", lc_collate: "en_US.UTF-8", lc_ctype: "en_US.UTF-8", owner: "db1_user" }
         patroni_failsafe_mode: true
         cacheable: true
       delegate_to: localhost

--- a/automation/molecule/default/converge.yml
+++ b/automation/molecule/default/converge.yml
@@ -31,8 +31,8 @@
           - { option: "shared_buffers", value: "128MB" }
           - { option: "effective_cache_size", value: "512MB" }
         postgresql_users:
-          - { name: "{{ pgbouncer_auth_username }}", password: "{{ pgbouncer_auth_password }}" }
-          - { name: "db1_user", password: "db1_user-pass" }
+          - { name: "pgbouncer", password: "pgbouncer-test-pass" }
+          - { name: "db1_user", password: "db1_user-test-pass" }
         postgresql_databases:
           - { db: "db1", encoding: "UTF8", lc_collate: "en_US.UTF-8", lc_ctype: "en_US.UTF-8", owner: "db1_user" }
         patroni_failsafe_mode: true

--- a/automation/roles/postgresql_databases/tasks/main.yml
+++ b/automation/roles/postgresql_databases/tasks/main.yml
@@ -18,7 +18,7 @@
     login_user: "{{ patroni_superuser_username }}"
     login_password: "{{ patroni_superuser_password }}"
     state: "{{ item.state | default('present') }}"
-    force: "{{ 'true' if item.state == 'absent' else 'false' }}"
+    force: "{{ 'true' if item.state | default('present') == 'absent' else 'false' }}"
   ignore_errors: true
   loop: "{{ postgresql_databases | flatten(1) }}"
   when:


### PR DESCRIPTION
Apply item.state | default('present') when computing the 'force' flag in `postgresql_databases` tasks. This prevents undefined-variable issues for database entries that omit state and ensures 'force' is only true for explicit 'absent' items.

Closes: https://github.com/autobase-tech/autobase/issues/1518